### PR TITLE
feat(widevine): add CastLabs EVS VMP signing and auto-generated release notes

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -165,6 +165,7 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          generate_release_notes: true
           files: |
             release/*.AppImage
             release/*.deb

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -124,6 +124,9 @@ jobs:
           key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install dependencies
         run: npm ci
+      - name: Install uv
+        if: matrix.os == 'macos'
+        uses: astral-sh/setup-uv@v5
       - name: Install RPM tools
         if: matrix.os == 'linux'
         run: sudo apt-get update && sudo apt-get install -y rpm
@@ -131,6 +134,9 @@ jobs:
         run: npm run build
       - name: Build distributables
         run: npx electron-builder --publish never ${{ matrix.targets }}
+        env:
+          EVS_ACCOUNT_NAME: ${{ secrets.EVS_ACCOUNT_NAME }}
+          EVS_PASSWD: ${{ secrets.EVS_PASSWD }}
       - name: Upload artefacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install uv
-        if: matrix.os == 'macos'
+        if: matrix.os == 'macos' || matrix.os == 'windows'
         uses: astral-sh/setup-uv@v5
       - name: Install RPM tools
         if: matrix.os == 'linux'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,6 @@
 
 Minimal Apple Music desktop client. CastLabs Electron wraps `music.apple.com` directly, injecting a lightweight hook script to bridge MusicKit.js events to native platform media controls.
 
-No code has been written yet. This document describes the target architecture.
-
 ## Technology stack
 
 | Component | Technology | Purpose |
@@ -69,6 +67,37 @@ Run `direnv allow` in the project root to activate the Nix dev shell automatical
 | Lint | `just lint` | Run actionlint against GitHub Actions workflows |
 | Measure | `just measure` | Dry-run tailor and report style metrics |
 | Alter | `just alter` | Apply tailor style changes |
+
+## Widevine VMP signing
+
+Widevine enforces VMP (Verified Media Path) production signing on macOS and Windows. Linux does not support VMP and development keys are accepted there. Without production signing, Apple Music returns "Something went wrong" after login on macOS and Windows.
+
+CastLabs ECS ships with development VMP keys. Production signing requires a free [CastLabs EVS](https://github.com/castlabs/electron-releases/wiki/EVS) account.
+
+### One-time setup
+
+```bash
+uvx --from castlabs-evs evs-account signup
+```
+
+Credentials are stored at `~/.config/evs/config.json`. The account is portable - use `evs-account reauth` on any new machine.
+
+### Build pipeline
+
+`build/afterPack.cjs` runs `evs-vmp sign-pkg` via `uvx` as an electron-builder `afterPack` hook on `darwin` and `win32`. This must execute before macOS code-signing (i.e. `afterPack`, not `afterSign`).
+
+For `just run` (dev mode), `just install` and `just build` both invoke `_sign-evs`, which signs `node_modules/electron/dist` directly so the local Electron binary has production VMP keys.
+
+### Credentials
+
+| Context | Method |
+|---------|--------|
+| Local machine | `~/.config/evs/config.json` populated by `evs-account signup` or `reauth`; or set `EVS_ACCOUNT_NAME` + `EVS_PASSWD` env vars (e.g. via sops-nix) |
+| GitHub Actions | `EVS_ACCOUNT_NAME` and `EVS_PASSWD` repository secrets; passed to the "Build distributables" step in `builder.yml` |
+
+### User-Agent
+
+All platforms send a Linux Chrome UA (`X11; Linux x86_64`) to Apple Music. This bypasses Apple's stricter server-side DRM enforcement applied to macOS clients. Linux works without this but the consistent UA avoids platform-detection divergence.
 
 ## Conventions
 

--- a/build/afterPack.cjs
+++ b/build/afterPack.cjs
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * afterPack hook: signs the packaged app with CastLabs EVS production VMP keys.
+ *
+ * VMP signing must happen BEFORE macOS code-signing (afterPack, not afterSign).
+ * Without production VMP keys, Widevine refuses DRM licences on macOS.
+ * Linux does not enforce VMP so this hook is a no-op there.
+ *
+ * Setup: uvx --from castlabs-evs evs-account signup
+ * Docs:  https://github.com/castlabs/electron-releases/wiki/EVS
+ */
+exports.default = async function afterPack(context) {
+  const { appOutDir, electronPlatformName } = context;
+
+  if (electronPlatformName !== 'darwin' && electronPlatformName !== 'win32') {
+    return;
+  }
+
+  const { execSync } = require('child_process');
+
+  console.log('EVS: Signing package with production VMP keys...');
+  try {
+    execSync(`uvx --from castlabs-evs evs-vmp sign-pkg "${appOutDir}"`, {
+      stdio: 'inherit',
+    });
+    console.log('EVS: VMP signing complete.');
+  } catch (err) {
+    console.error('EVS: VMP signing failed. Ensure castlabs_evs is installed:');
+    console.error('  uvx --from castlabs-evs evs-account signup');
+    throw err;
+  }
+};

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+  </dict>
+</plist>

--- a/flake.nix
+++ b/flake.nix
@@ -39,36 +39,38 @@
             # CastLabs Electron (installed via npm) is a prebuilt binary that
             # expects libraries in standard FHS paths. On NixOS we must set
             # LD_LIBRARY_PATH explicitly for the libraries it links against.
-            LD_LIBRARY_PATH = with pkgs; lib.makeLibraryPath [
-              alsa-lib
-              at-spi2-atk
-              cairo
-              cups
-              dbus
-              expat
-              glib
-              gtk3
-              libdrm
-              libgbm
-              libGL
-              mesa
-              nspr
-              nss
-              pango
-              libx11
-              libxcb
-              libxcomposite
-              libxdamage
-              libxext
-              libxfixes
-              libxkbcommon
-              libxrandr
-            ];
+            LD_LIBRARY_PATH = pkgs.lib.optionalString pkgs.stdenv.isLinux (
+              with pkgs; lib.makeLibraryPath [
+                alsa-lib
+                at-spi2-atk
+                cairo
+                cups
+                dbus
+                expat
+                glib
+                gtk3
+                libdrm
+                libgbm
+                libGL
+                mesa
+                nspr
+                nss
+                pango
+                libx11
+                libxcb
+                libxcomposite
+                libxdamage
+                libxext
+                libxfixes
+                libxkbcommon
+                libxrandr
+              ]
+            );
 
             # GPU drivers: use NixOS system drivers from /run/opengl-driver/lib
             # This works across GPU vendors (Intel, AMD, NVIDIA) without listing
             # individual driver packages. Same pattern as jivefire.
-            shellHook = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+            shellHook = (pkgs.lib.optionalString pkgs.stdenv.isLinux ''
               if [ -d "/run/opengl-driver/lib" ]; then
                 if [ -z "$LD_LIBRARY_PATH" ]; then
                   export LD_LIBRARY_PATH="/run/opengl-driver/lib"
@@ -76,7 +78,7 @@
                   export LD_LIBRARY_PATH="/run/opengl-driver/lib:$LD_LIBRARY_PATH"
                 fi
               fi
-
+            '') + ''
               echo "Sidra development shell"
               echo "  node: $(node --version)"
               echo "  npm:  $(npm --version)"

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,9 @@
                 gh
                 just
                 nodejs # 24.x Active LTS, matches Electron 40's bundled Node
+              ]
+              ++ lib.optionals stdenv.isDarwin [
+                uv # required for EVS VMP signing via uvx
               ];
 
             # CastLabs Electron (installed via npm) is a prebuilt binary that

--- a/justfile
+++ b/justfile
@@ -6,6 +6,7 @@ default:
 install:
     npm install
     @just _fix-frameworks
+    @just _sign-evs
 
 # Restore macOS framework symlinks broken by extract-zip during npm install
 [macos]
@@ -44,8 +45,23 @@ _fix-frameworks:
 [private]
 _fix-frameworks:
 
+# Apply CastLabs EVS VMP signing to local Electron binary
+[macos]
+[private]
+_sign-evs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -d "node_modules/electron/dist/Electron.app" ]; then
+        exit 0
+    fi
+    uvx --from castlabs-evs evs-vmp sign-pkg node_modules/electron/dist
+
+[linux]
+[private]
+_sign-evs:
+
 # Build TypeScript to dist/
-build: _fix-frameworks
+build: _fix-frameworks _sign-evs
     npx tsc
 
 # Run the app (builds first)
@@ -84,6 +100,21 @@ test:
 # Clean build artefacts
 clean:
     rm -rf dist/
+
+# Clear all Sidra user data and caches
+[macos]
+clear:
+    rm -rf ~/Library/Application\ Support/Sidra
+    rm -rf ~/Library/Caches/Sidra
+    rm -rf ~/Library/Logs/Sidra
+    @echo "Sidra data cleared"
+
+# Clear all Sidra user data and caches
+[linux]
+clear:
+    rm -rf ~/.config/sidra
+    rm -rf ~/.cache/sidra
+    @echo "Sidra data cleared"
 
 # Build a package for the current platform
 package: build

--- a/justfile
+++ b/justfile
@@ -5,9 +5,47 @@ default:
 # Install project dependencies
 install:
     npm install
+    @just _fix-frameworks
+
+# Restore macOS framework symlinks broken by extract-zip during npm install
+[macos]
+[private]
+_fix-frameworks:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    frameworks_dir="node_modules/electron/dist/Electron.app/Contents/Frameworks"
+    if [ ! -d "$frameworks_dir" ]; then
+        exit 0
+    fi
+    for fw in "$frameworks_dir"/*.framework; do
+        if [ -d "$fw/Versions/A" ] && [ ! -L "$fw/Versions/Current" ]; then
+            ln -sf A "$fw/Versions/Current"
+            name=$(basename "$fw" .framework)
+            # Symlink the main binary
+            if [ -e "$fw/Versions/A/$name" ] && [ ! -L "$fw/$name" ]; then
+                ln -sf "Versions/Current/$name" "$fw/$name"
+            fi
+            # Symlink Resources if present
+            if [ -d "$fw/Versions/A/Resources" ] && [ ! -L "$fw/Resources" ]; then
+                ln -sf "Versions/Current/Resources" "$fw/Resources"
+            fi
+            # Symlink Libraries if present
+            if [ -d "$fw/Versions/A/Libraries" ] && [ ! -L "$fw/Libraries" ]; then
+                ln -sf "Versions/Current/Libraries" "$fw/Libraries"
+            fi
+            # Symlink Helpers if present
+            if [ -d "$fw/Versions/A/Helpers" ] && [ ! -L "$fw/Helpers" ]; then
+                ln -sf "Versions/Current/Helpers" "$fw/Helpers"
+            fi
+        fi
+    done
+
+[linux]
+[private]
+_fix-frameworks:
 
 # Build TypeScript to dist/
-build:
+build: _fix-frameworks
     npx tsc
 
 # Run the app (builds first)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1950,6 +1950,7 @@
       "integrity": "sha512-DaWI+p4DOqiFVZFMovdGYammBOyJAiHHFWUTQ0Z7gNc0twfdIN0LvyJ+vFsgZEDR1fjgbpCj690IVtbYIsZObQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.2",
         "builder-util": "26.8.1",

--- a/package.json
+++ b/package.json
@@ -47,11 +47,16 @@
     "rpm": {
       "vendor": "Martin Wimpress"
     },
+    "afterPack": "build/afterPack.cjs",
     "mac": {
       "target": ["dmg"],
       "icon": "build/icon.icns",
       "category": "public.app-category.music",
-      "darkModeSupport": true
+      "darkModeSupport": true,
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist"
     },
     "dmg": {
       "background": "build/background.png",

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,10 +25,15 @@ if (process.platform === 'linux') {
   mainLog.info('Linux platform switches applied');
 }
 
-// Chrome UA to avoid Apple blocking Electron's default UA
-// Version should match the Chromium version bundled with CastLabs Electron
+// Always send a Linux Chrome UA regardless of platform.
+// Apple Music does not enforce production Widevine on Linux clients;
+// spoofing a Linux UA bypasses DRM enforcement that blocks playback on macOS.
+// Chromium 144 matches CastLabs Electron v40.7.0+wvcus.
 const CHROME_UA =
-  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36';
+
+// Set fallback UA before app.whenReady() so any early requests use it
+app.userAgentFallback = CHROME_UA;
 
 const APPLE_MUSIC_URL = 'https://music.apple.com';
 
@@ -64,6 +69,9 @@ app.whenReady().then(async () => {
   await components.whenReady();
   mainLog.info('Widevine CDM ready, status:', components.status());
 
+  // Set UA on the default session (updates navigator.userAgentData Client Hints)
+  session.defaultSession.setUserAgent(CHROME_UA);
+
   const win = new BrowserWindow({
     width: 1280,
     height: 800,
@@ -78,16 +86,24 @@ app.whenReady().then(async () => {
     },
   });
 
-  // Spoof user-agent on all requests
-  session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
-    details.requestHeaders['User-Agent'] = CHROME_UA;
-    callback({ requestHeaders: details.requestHeaders });
+  // Stale service workers from music.apple.com persist between launches in the
+  // persist: partition and intercept requests, serving invalid cached responses.
+  // Clear service workers and HTTP cache before loading, preserving auth cookies.
+  const ses = session.fromPartition('persist:sidra');
+  await ses.clearData({
+    dataTypes: ['serviceWorkers', 'cache'],
+    origins: ['https://music.apple.com'],
   });
 
-  // Also set it on the window's session (persistent partition)
-  const ses = win.webContents.session;
+  // Set UA on the persist:sidra session used by the window
+  ses.setUserAgent(CHROME_UA);
+
+  // Strip Electron and app name tokens from outgoing request headers
   ses.webRequest.onBeforeSendHeaders((details, callback) => {
-    details.requestHeaders['User-Agent'] = CHROME_UA;
+    const ua = details.requestHeaders['User-Agent'];
+    if (ua && ua !== CHROME_UA) {
+      details.requestHeaders['User-Agent'] = CHROME_UA;
+    }
     callback({ requestHeaders: details.requestHeaders });
   });
 
@@ -124,7 +140,7 @@ app.whenReady().then(async () => {
   }
 
   mainLog.info('loading Apple Music...');
-  win.loadURL(APPLE_MUSIC_URL);
+  win.loadURL(APPLE_MUSIC_URL, { userAgent: CHROME_UA });
 });
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
## Summary
Add CastLabs EVS VMP signing for macOS and Windows Widevine DRM support. Enable auto-generated release notes in GitHub Actions to automatically populate release descriptions from commits and pull requests.

## Changes
- Add CastLabs EVS VMP signing integration for Widevine DRM content protection on macOS and Windows
- Implement `afterPack.cjs` hook for code signing during build process
- Add macOS entitlements configuration (`entitlements.mac.plist`)
- Enable auto-generated release notes in GitHub Actions workflow
- Fix macOS support in devShell and build recipes
- Update AGENTS.md with CastLabs and Widevine implementation details
- Add required dependencies and build configuration

## Testing
- Verify Electron build succeeds with new code signing configuration
- Confirm macOS and Windows builds complete without errors
- Test that GitHub releases include auto-generated notes from commits

## Related Issues
Closes #widevine-support