### PR TITLE
fix(ua): use platform-accurate User-Agent strings with EVS production VMP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,15 @@ For `just run` (dev mode), `just install` and `just build` both invoke `_sign-ev
 
 ### User-Agent
 
-All platforms send a Linux Chrome UA (`X11; Linux x86_64`) to Apple Music. This bypasses Apple's stricter server-side DRM enforcement applied to macOS clients. Linux works without this but the consistent UA avoids platform-detection divergence.
+All platforms send a platform-accurate Chrome UA (`chromeUA()` in `src/main.ts`), stripping Electron identifiers that Apple Music detects and blocks. The `Sec-CH-UA-Platform` Client Hint is sent on every request and must match the UA platform token — a Linux UA on macOS creates a detectable inconsistency. Chrome version is pinned to `144.0.0.0` to match the CastLabs ECS Chromium build.
+
+| Platform | UA platform token |
+|----------|------------------|
+| macOS | `Macintosh; Intel Mac OS X 10_15_7` |
+| Windows | `Windows NT 10.0; Win64; x64` |
+| Linux | `X11; Linux x86_64` |
+
+The `10_15_7` macOS version freeze is intentional - Chrome itself freezes this value to reduce fingerprinting surface.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,18 @@ Apple maintains the UI, audio just works, and authentication is a non-issue.
 
 ## Features
 
-- Apple Music desktop client with Widevine DRM
+- Apple Music desktop client
+- Lossless audio on macOS and Windows via CastLabs EVS production VMP signing
 - Persistent login
 - **Linux**:
+  - Standard Widevine DRM via CastLabs Electron
   - Wayland and X11 support
   - Full bi-directional MPRIS (`org.mpris.MediaPlayer2.sidra`) via D-Bus (*planned*)
 - **macOS**:
+  - Full Widevine DRM with EVS production VMP signing
   - Now Playing widget via Chromium's built-in mediaSession bridge (*planned*)
 - **Windows**:
+  - Full Widevine DRM with EVS production VMP signing
   - GSMTC media flyout via Chromium's built-in mediaSession bridge (*planned*)
 - Discord Rich Presence (*planned*)
 - Desktop Notifications (*planned*)

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,15 +25,25 @@ if (process.platform === 'linux') {
   mainLog.info('Linux platform switches applied');
 }
 
-// Always send a Linux Chrome UA regardless of platform.
-// Apple Music does not enforce production Widevine on Linux clients;
-// spoofing a Linux UA bypasses DRM enforcement that blocks playback on macOS.
-// Chromium 144 matches CastLabs Electron v40.7.0+wvcus.
-const CHROME_UA =
-  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36';
+// Use a platform-accurate Chrome UA, stripping Electron identifiers that
+// Apple Music detects and blocks. The platform component must be truthful
+// to match Sec-CH-UA-Platform Client Hints sent on every request.
+// Chrome version 144.0.0.0 matches the Chromium build in CastLabs ECS v40.7.0+wvcus.
+function chromeUA(): string {
+  const version = '144.0.0.0';
+  const webkit = 'AppleWebKit/537.36 (KHTML, like Gecko)';
+  const safari = 'Safari/537.36';
+  if (process.platform === 'darwin') {
+    return `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ${webkit} Chrome/${version} ${safari}`;
+  }
+  if (process.platform === 'win32') {
+    return `Mozilla/5.0 (Windows NT 10.0; Win64; x64) ${webkit} Chrome/${version} ${safari}`;
+  }
+  return `Mozilla/5.0 (X11; Linux x86_64) ${webkit} Chrome/${version} ${safari}`;
+}
 
 // Set fallback UA before app.whenReady() so any early requests use it
-app.userAgentFallback = CHROME_UA;
+app.userAgentFallback = chromeUA();
 
 const APPLE_MUSIC_URL = 'https://music.apple.com';
 
@@ -70,7 +80,7 @@ app.whenReady().then(async () => {
   mainLog.info('Widevine CDM ready, status:', components.status());
 
   // Set UA on the default session (updates navigator.userAgentData Client Hints)
-  session.defaultSession.setUserAgent(CHROME_UA);
+  session.defaultSession.setUserAgent(chromeUA());
 
   const win = new BrowserWindow({
     width: 1280,
@@ -96,13 +106,13 @@ app.whenReady().then(async () => {
   });
 
   // Set UA on the persist:sidra session used by the window
-  ses.setUserAgent(CHROME_UA);
+  ses.setUserAgent(chromeUA());
 
   // Strip Electron and app name tokens from outgoing request headers
   ses.webRequest.onBeforeSendHeaders((details, callback) => {
     const ua = details.requestHeaders['User-Agent'];
-    if (ua && ua !== CHROME_UA) {
-      details.requestHeaders['User-Agent'] = CHROME_UA;
+    if (ua && ua !== chromeUA()) {
+      details.requestHeaders['User-Agent'] = chromeUA();
     }
     callback({ requestHeaders: details.requestHeaders });
   });
@@ -140,7 +150,7 @@ app.whenReady().then(async () => {
   }
 
   mainLog.info('loading Apple Music...');
-  win.loadURL(APPLE_MUSIC_URL, { userAgent: CHROME_UA });
+  win.loadURL(APPLE_MUSIC_URL, { userAgent: chromeUA() });
 });
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
Replace hardcoded Linux UA spoof with platform-accurate User-Agent strings via chromeUA() function. Now that production EVS VMP signing is in place on macOS and Windows, platform-accurate UAs are both correct and safer: the Sec-CH-UA-Platform Client Hint is sent on every request and must match the UA platform token.

- Add chromeUA() function returning platform-specific UA strings
- Set app.userAgentFallback and session userAgent via chromeUA()
- Strip Electron identifiers in outgoing request headers
- Pin Chrome version to 144.0.0.0 matching CastLabs ECS v40.7.0+wvcus
- Document platform-accurate UA approach in AGENTS.md
- Update README.md to accurately state lossless audio support for macOS and Windows only