### PR TITLE
feat(window): add application menu and preserve window title

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, components, session, shell } from 'electron';
+import { app, BrowserWindow, components, Menu, session, shell } from 'electron';
 import path from 'path';
 import log from 'electron-log/main';
 
@@ -133,6 +133,20 @@ const STYLE_FIX_CSS = `
 
 app.whenReady().then(async () => {
   mainLog.info('app ready, waiting for Widevine CDM...');
+
+  const menuTemplate: Electron.MenuItemConstructorOptions[] = [];
+  if (process.platform === 'darwin') {
+    menuTemplate.push({ role: 'appMenu' });
+  }
+  menuTemplate.push({ role: 'editMenu' });
+  if (process.env.SIDRA_DEVTOOLS === '1') {
+    menuTemplate.push({
+      label: 'View',
+      submenu: [{ role: 'toggleDevTools' }],
+    });
+  }
+  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
+  mainLog.info('application menu set');
 
   // Show a splash screen while the Widevine CDM downloads/initialises
   const splash = new BrowserWindow({

--- a/src/main.ts
+++ b/src/main.ts
@@ -165,6 +165,7 @@ app.whenReady().then(async () => {
   session.defaultSession.setUserAgent(chromeUA());
 
   const win = new BrowserWindow({
+    title: 'Sidra',
     width: 1280,
     height: 800,
     show: false,
@@ -204,6 +205,11 @@ app.whenReady().then(async () => {
       details.requestHeaders['User-Agent'] = chromeUA();
     }
     callback({ requestHeaders: details.requestHeaders });
+  });
+
+  // Prevent the web page title from overriding the window title
+  win.on('page-title-updated', (event) => {
+    event.preventDefault();
   });
 
   win.webContents.on('did-finish-load', () => {


### PR DESCRIPTION
## Summary

Improves the application window UI by adding an application menu system and preventing web content from overriding the application title. These changes enhance the desktop experience by establishing proper window control mechanisms and providing developers with accessible development tools.

## Changes

- Add persistent application title ('Sidra') to BrowserWindow configuration
- Prevent web page title updates from overriding the window title via page-title-updated event handler
- Import Menu from Electron and create platform-specific menu template
- Add standard Edit menu and platform-specific App menu on macOS
- Implement View menu with toggleDevTools when SIDRA_DEVTOOLS environment variable is set
- Set application menu on window creation with informative log output

## Testing

- Verified window maintains 'Sidra' title when loading web content
- Confirmed application menu appears on application launch
- Tested dev tools toggle functionality in development environment
- Validated platform-specific menu rendering (App menu on macOS only)