### PR TITLE
feat(config): add region and storefront persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ The `10_15_7` macOS version freeze is intentional - Chrome itself freezes this v
 
 ### Adding translations
 
-`src/i18n.ts` contains all translation records for Sidra's own UI. Each record is a `Record<string, string>` keyed by BCP 47 language tags. Currently 7 records with 31 languages each: `LOADING_TEXT`, `ABOUT_TEXT`, `QUIT_TEXT`, `CLOSE_TEXT`, `VERSION_PREFIX`, `COPYRIGHT_SUFFIX`, `LICENSE_PREFIX`. When adding a language, add an entry to every record.
+`src/i18n.ts` contains all translation records for Sidra's own UI. Each record is a `Record<string, string>` keyed by BCP 47 language tags. Currently 7 records with 33 languages each: `LOADING_TEXT`, `ABOUT_TEXT`, `QUIT_TEXT`, `CLOSE_TEXT`, `VERSION_PREFIX`, `COPYRIGHT_SUFFIX`, `LICENSE_PREFIX`. When adding a language, add an entry to every record.
 
 ```typescript
 export const LOADING_TEXT: Record<string, string> = {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ The `10_15_7` macOS version freeze is intentional - Chrome itself freezes this v
 
 ### Adding translations
 
-`LOADING_TEXT` in `src/i18n.ts` is the only translation surface in Sidra's own code. Keys are BCP 47 language tags. Add an entry to the record - no other change is required. Currently 31 languages are supported.
+`src/i18n.ts` contains all translation records for Sidra's own UI. Each record is a `Record<string, string>` keyed by BCP 47 language tags. Currently 7 records with 31 languages each: `LOADING_TEXT`, `ABOUT_TEXT`, `QUIT_TEXT`, `CLOSE_TEXT`, `VERSION_PREFIX`, `COPYRIGHT_SUFFIX`, `LICENSE_PREFIX`. When adding a language, add an entry to every record.
 
 ```typescript
 export const LOADING_TEXT: Record<string, string> = {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,43 @@ The `10_15_7` macOS version freeze is intentional - Chrome itself freezes this v
 - British English spelling
 - The codebase is tightly focused and as lean as possible
 
+## Internationalisation (i18n)
+
+`src/i18n.ts` handles all locale detection and translated strings for Sidra's own UI. Apple Music's web UI localises itself independently.
+
+### Locale detection
+
+- `app.getPreferredSystemLanguages()` returns a BCP 47 ordered list (e.g. `['en-GB', 'en']`)
+- `getLoadingText()` walks the list and matches against the `LOADING_TEXT` record - exact tag first, then base language (e.g. `en-GB` → `en`)
+- `getStorefront()` uses `app.getLocaleCountryCode()` to extract the region code independently of language (e.g. returns `GB` regardless of whether the language is `en`, `cy`, or `gd`), then lowercases it for use as an Apple Music storefront path segment
+
+### Adding translations
+
+`LOADING_TEXT` in `src/i18n.ts` is the only translation surface in Sidra's own code. Keys are BCP 47 language tags. Add an entry to the record - no other change is required. Currently 31 languages are supported.
+
+```typescript
+export const LOADING_TEXT: Record<string, string> = {
+  'en': 'Loading...',
+  'fr': 'Chargement...',
+  // add new entries here
+};
+```
+
+Prefer specific regional tags only when the translation differs from the base language variant (e.g. `zh-CN` vs `zh-TW`). Use the base tag (e.g. `fr`) for languages where one translation covers all regions.
+
+## Configuration
+
+`src/config.ts` is a typed wrapper around `electron-store`. It exposes typed getter/setter pairs and is the single location for all persistent application state.
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `storefront` | `string` | Apple Music storefront code (e.g. `gb`, `us`) |
+| `language` | `string \| null` | BCP 47 language override for the storefront `?l=` parameter |
+
+Getters return `undefined` when no value has been persisted - absence of a key is intentional and drives the storefront fallback chain in `main.ts`. Do not add default values to the store schema.
+
+When adding new persistent settings, add typed getter/setter pairs to `config.ts` following the existing pattern. Do not use `electron-store` directly elsewhere in the codebase.
+
 ## Architecture notes
 
 - Chromium's built-in `MediaSessionService` must be disabled on Linux to avoid conflicting MPRIS registrations; Sidra registers its own `org.mpris.MediaPlayer2.sidra` service via dbus-next

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Apple maintains the UI, audio just works, and authentication is a non-issue.
 - Apple Music desktop client
 - Lossless audio on macOS and Windows via CastLabs EVS production VMP signing
 - Persistent login
+- Localised Apple Music storefront on launch, detected from OS region with user preference persisted across restarts
+- Localised desktop app interface in 31 languages
 - **Linux**:
   - Standard Widevine DRM via CastLabs Electron
   - Wayland and X11 support

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -18,6 +18,7 @@ The codebase is tightly focused and as lean as possible. Four runtime dependenci
 - [Platform Media Controls](#platform-media-controls)
 - [MPRIS Specification](#mpris-specification)
 - [Volume Sync](#volume-sync)
+- [Region and Storefront](#region-and-storefront)
 - [Authentication](#authentication)
 - [Discord Rich Presence](#discord-rich-presence)
 - [Track Change Notifications](#track-change-notifications)
@@ -421,6 +422,34 @@ Also update `navigator.mediaSession` volume whenever MusicKit volume changes - `
 
 ---
 
+## Region and Storefront
+
+Loading bare `https://music.apple.com` causes Apple's server to 301-redirect all clients to `/us/new`, regardless of location. Users outside the US see the wrong catalogue on every launch.
+
+### Storefront detection
+
+`app.getLocaleCountryCode()` returns the OS region as an uppercase ISO 3166-1 alpha-2 code (e.g. `GB`, `CH`). Lowercasing this value produces the Apple Music storefront path segment directly. No validation against Apple's API is required - Apple's server redirects any unrecognised storefront code to `/us/new` with a clean 301, so the failure mode is identical to the current bare-URL behaviour.
+
+Fallback chain at startup:
+
+```
+1. Read persisted storefront from electron-store
+2. If found → use it
+3. If not found → app.getLocaleCountryCode().toLowerCase()
+4. If empty string (LC_ALL=C, unset locale) → 'us'
+5. Build URL: https://music.apple.com/{storefront}/new[?l={language}]
+```
+
+### Persistence
+
+`electron-store` holds two keys: `storefront` (e.g. `gb`) and `language` (BCP 47 tag from the `?l=` parameter, e.g. `fr`, or `null`). A `did-navigate` and `did-navigate-in-page` listener on `win.webContents` parses the URL after each navigation. When the storefront or language changes, the new values are written to the store. Same-storefront navigation does not trigger a write.
+
+### Storefront codes
+
+Apple Music storefront codes are ISO 3166-1 alpha-2 codes lowercased (e.g. `gb`, `us`, `ch`). Apple supports 167+ storefronts. The `?l=` parameter accepts BCP 47 language tags from each storefront's `supportedLanguageTags` list and controls UI localisation only - the storefront determines catalogue availability.
+
+---
+
 ## Authentication
 
 Non-issue by design. Cider's auth breaks because it uses MusicKit.js with a developer token it controls and the OAuth user-token flow. Sidra loads `music.apple.com` - Apple handles authentication entirely. Identical to opening Chrome and navigating to `music.apple.com`.
@@ -559,6 +588,8 @@ Notifications are toggleable via an `electron-store` boolean setting (default: o
 | MPRIS repeat/shuffle | Two-way | `repeatModeDidChange` + `shuffleModeDidChange` |
 | Discord Rich Presence | `@xhayper/discord-rpc` | With debounce + pause timeout + retry |
 | Track change notifications | Electron `Notification` | With artwork, suppressable in settings |
+| Regional storefront detection | `app.getLocaleCountryCode()` → `/gb/new`, `/ch/new` etc. | Fallback chain: persisted → detected → `us` |
+| Storefront preference persistence | `electron-store` + `did-navigate` listener | Survives restarts; language parameter preserved |
 | User-agent spoofing | `webRequest.onBeforeSendHeaders` | Standard Chrome UA |
 | Window state persistence | `electron-store` | Bounds, maximised state |
 | Wayland support | `--enable-features=UseOzonePlatform` | Auto-detected via platform check |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.1",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "electron-log": "^5.x"
+        "electron-log": "^5.x",
+        "electron-store": "^10.x"
       },
       "devDependencies": {
         "electron": "github:castlabs/electron-releases#v40.7.0+wvcus",
@@ -963,6 +964,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -1233,6 +1273,16 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
       }
     },
     "node_modules/balanced-match": {
@@ -1753,6 +1803,75 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/conf": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-14.0.0.tgz",
+      "integrity": "sha512-L6BuueHTRuJHQvQVc6YXYZRtN5vJUtOdCTLn0tRYYV5azfbAFcPghB5zEE40mVrV6w7slMTqUfkDomutIK14fw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "atomically": "^2.0.3",
+        "debounce-fn": "^6.0.0",
+        "dot-prop": "^9.0.0",
+        "env-paths": "^3.0.0",
+        "json-schema-typed": "^8.0.1",
+        "semver": "^7.7.2",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/conf/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/conf/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1816,6 +1935,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/debounce-fn": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
+      "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/debug": {
@@ -2079,6 +2213,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -2303,6 +2464,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-store": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-10.1.0.tgz",
+      "integrity": "sha512-oL8bRy7pVCLpwhmXy05Rh/L6O93+k9t6dqSw0+MckIc3OmCTZm6Mp04Q4f/J0rtu84Ky6ywkR8ivtGOmrq+16w==",
+      "license": "MIT",
+      "dependencies": {
+        "conf": "^14.0.0",
+        "type-fest": "^4.41.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron-store/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/electron-winstaller": {
@@ -2622,7 +2811,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -2648,6 +2836,22 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -3475,6 +3679,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3698,6 +3908,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -4457,6 +4679,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resedit": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
@@ -4970,6 +5201,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "license": "MIT"
+    },
     "node_modules/sumchecker": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -5207,6 +5453,18 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -5299,6 +5557,12 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "typescript": "^5.x"
   },
   "dependencies": {
-    "electron-log": "^5.x"
+    "electron-log": "^5.x",
+    "electron-store": "^10.x"
   },
   "build": {
     "appId": "world.wimpys.sidra",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,44 @@
+import log from 'electron-log/main';
+
+const configLog = log.scope('config');
+
+interface StoreSchema {
+  storefront: string;
+  language: string | null;
+}
+
+// electron-store v10 is ESM-only; under CommonJS moduleResolution TypeScript
+// cannot follow the Conf inheritance chain.  Use require() and type the
+// instance manually so the rest of the codebase stays on module:"commonjs".
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Store = require('electron-store').default;
+
+const store: {
+  has(key: keyof StoreSchema): boolean;
+  get<K extends keyof StoreSchema>(key: K): StoreSchema[K];
+  set<K extends keyof StoreSchema>(key: K, value: StoreSchema[K]): void;
+} = new Store();
+
+export function getStorefront(): string | undefined {
+  if (!store.has('storefront')) {
+    return undefined;
+  }
+  return store.get('storefront');
+}
+
+export function setStorefront(code: string): void {
+  store.set('storefront', code);
+  configLog.info('storefront set:', code);
+}
+
+export function getLanguage(): string | null | undefined {
+  if (!store.has('language')) {
+    return undefined;
+  }
+  return store.get('language');
+}
+
+export function setLanguage(lang: string | null): void {
+  store.set('language', lang);
+  configLog.info('language set:', lang);
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -282,6 +282,16 @@ export function getLocalizedString(
 
 // --- Public API (uses Electron app internally) ---
 
+export function getStorefront(): string {
+  const code = app.getLocaleCountryCode().toLowerCase();
+  if (code) {
+    i18nLog.debug(`storefront detected from locale: ${code}`);
+    return code;
+  }
+  i18nLog.debug('storefront fallback: us');
+  return 'us';
+}
+
 export function getLoadingText(): { text: string; lang: string } {
   const langs = app.getPreferredSystemLanguages();
   for (const lang of langs) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,6 +85,9 @@ function extractStorefrontFromURL(url: string): { storefront: string; language: 
       return null;
     }
     const storefront = segments[0];
+    if (!/^[a-z]{2}$/.test(storefront)) {
+      return null;
+    }
     const language = parsed.searchParams.get('l');
     return { storefront, language };
   } catch {

--- a/src/main.ts
+++ b/src/main.ts
@@ -103,11 +103,16 @@ function handleStorefrontNavigation(url: string): void {
 
   const currentStorefront = getStorefront();
   const currentLanguage = getLanguage();
+  const nextLanguage = result.language ?? currentLanguage ?? null;
 
-  if (result.storefront !== currentStorefront || result.language !== currentLanguage) {
-    setStorefront(result.storefront);
-    setLanguage(result.language);
-    mainLog.info(`storefront changed: ${result.storefront} (language: ${result.language})`);
+  if (result.storefront !== currentStorefront || nextLanguage !== currentLanguage) {
+    if (result.storefront !== currentStorefront) {
+      setStorefront(result.storefront);
+    }
+    if (nextLanguage !== currentLanguage) {
+      setLanguage(nextLanguage);
+    }
+    mainLog.info(`storefront changed: ${result.storefront} (language: ${nextLanguage})`);
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,8 @@ import { app, BrowserWindow, components, Menu, session, shell, Tray } from 'elec
 import path from 'path';
 import log from 'electron-log/main';
 import { createTray } from './tray';
-import { getLoadingText } from './i18n';
+import { getLoadingText, getStorefront as getLocaleStorefront } from './i18n';
+import { getStorefront, setStorefront, getLanguage, setLanguage } from './config';
 
 // --- Logging: initialise before anything else ---
 log.initialize();
@@ -51,7 +52,61 @@ app.userAgentFallback = chromeUA();
 // Prevent garbage collection of tray icon
 let appTray: Tray | null = null;
 
-const APPLE_MUSIC_URL = 'https://music.apple.com';
+function buildAppleMusicURL(): string {
+  let storefront = getStorefront();
+  let source: string;
+
+  if (storefront !== undefined) {
+    source = 'persisted';
+  } else {
+    storefront = getLocaleStorefront();
+    source = storefront === 'us' ? 'fallback' : 'detected';
+  }
+
+  mainLog.info(`storefront resolved: ${storefront} (${source})`);
+
+  let url = `https://music.apple.com/${storefront}/new`;
+  const language = getLanguage();
+  if (language !== undefined && language !== null) {
+    url += `?l=${language}`;
+  }
+
+  return url;
+}
+
+function extractStorefrontFromURL(url: string): { storefront: string; language: string | null } | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== 'music.apple.com') {
+      return null;
+    }
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    if (segments.length === 0) {
+      return null;
+    }
+    const storefront = segments[0];
+    const language = parsed.searchParams.get('l');
+    return { storefront, language };
+  } catch {
+    return null;
+  }
+}
+
+function handleStorefrontNavigation(url: string): void {
+  const result = extractStorefrontFromURL(url);
+  if (!result) {
+    return;
+  }
+
+  const currentStorefront = getStorefront();
+  const currentLanguage = getLanguage();
+
+  if (result.storefront !== currentStorefront || result.language !== currentLanguage) {
+    setStorefront(result.storefront);
+    setLanguage(result.language);
+    mainLog.info(`storefront changed: ${result.storefront} (language: ${result.language})`);
+  }
+}
 
 // CSS to hide "Get the app" and "Open in Music" banners.
 // Selectors confirmed across three independent Electron wrappers
@@ -195,6 +250,9 @@ app.whenReady().then(async () => {
     mainLog.error('page load failed:', errorCode, errorDescription);
   });
 
+  win.webContents.on('did-navigate', (_event, url) => handleStorefrontNavigation(url));
+  win.webContents.on('did-navigate-in-page', (_event, url) => handleStorefrontNavigation(url));
+
   // Open external links in the system browser (only http/https)
   win.webContents.setWindowOpenHandler(({ url }) => {
     try {
@@ -218,7 +276,7 @@ app.whenReady().then(async () => {
   }
 
   mainLog.info('loading Apple Music...');
-  win.loadURL(APPLE_MUSIC_URL, { userAgent: chromeUA() });
+  win.loadURL(buildAppleMusicURL(), { userAgent: chromeUA() });
 });
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
# Description

- Add electron-store dependency for persistent storage
- Create config.ts with typed store wrapper for storefront and language
- Detect region from OS locale with fallback to 'us'
- Build Apple Music URL with three-tier fallback: persisted storefront, OS region, default
- Append language parameter to URL when persisted
- Listen for navigation events and update store on storefront changes
- Avoid disk I/O churn by only writing when values change
- Update documentation with region/storefront features

Closes #7

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
