### PR TITLE
ci(release): automate version management in GitHub Actions

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -132,6 +132,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y rpm
       - name: Set version from tag
         if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
         run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version
       - name: Compile TypeScript
         run: npm run build

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Install RPM tools
         if: matrix.os == 'linux'
         run: sudo apt-get update && sudo apt-get install -y rpm
+      - name: Set version from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: npm version "${{ github.ref_name }}" --no-git-tag-version
       - name: Compile TypeScript
         run: npm run build
       - name: Build distributables
@@ -157,6 +160,22 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Commit version bump
+        run: |
+          VERSION="${{ github.ref_name }}"
+          npm version "$VERSION" --no-git-tag-version
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "release: v$VERSION"
+          git push origin main
       - name: Download all build artefacts
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -132,7 +132,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y rpm
       - name: Set version from tag
         if: startsWith(github.ref, 'refs/tags/')
-        run: npm version "${{ github.ref_name }}" --no-git-tag-version
+        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version
       - name: Compile TypeScript
         run: npm run build
       - name: Build distributables
@@ -170,12 +170,16 @@ jobs:
       - name: Commit version bump
         run: |
           VERSION="${{ github.ref_name }}"
-          npm version "$VERSION" --no-git-tag-version
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json
-          git commit -m "release: v$VERSION"
-          git push origin main
+          if [ "$(node -p "require('./package.json').version")" != "${VERSION#v}" ]; then
+            npm version "${VERSION#v}" --no-git-tag-version
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add package.json package-lock.json
+            git commit -m "release: v$VERSION"
+            git push origin main
+          else
+            echo "Version already up to date; skipping bump commit."
+          fi
       - name: Download all build artefacts
         uses: actions/download-artifact@v8
         with:

--- a/justfile
+++ b/justfile
@@ -141,17 +141,8 @@ release VERSION:
         echo "Error: must be on main branch (currently on $branch)" >&2
         exit 1
     fi
-    if [[ -n "$(git status --porcelain)" ]]; then
-        echo "Error: working tree is dirty" >&2
-        exit 1
-    fi
-
-    npm version "{{VERSION}}" --no-git-tag-version
-
-    git add package.json package-lock.json
-    git commit -m "release: v{{VERSION}}"
     git tag "{{VERSION}}"
 
-    echo "Release {{VERSION}} prepared. Push with:"
+    echo "Release {{VERSION}} tagged. Push with:"
     echo "  git push origin main {{VERSION}}"
 


### PR DESCRIPTION
# Description

- Add automatic version setting from git tags in builder workflow
- Remove manual version bumping and commit logic from justfile
- Transfer release automation responsibility to CI pipeline

## Additional Context

This automates the release process, eliminating local version management steps and ensuring consistency across all releases.