### PR TITLE
ci(release): simplify workflow and use dynamic version from git tags

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -130,10 +130,15 @@ jobs:
       - name: Install RPM tools
         if: matrix.os == 'linux'
         run: sudo apt-get update && sudo apt-get install -y rpm
-      - name: Set version from tag
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Set version from build
         shell: bash
-        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "0.0.0-dev")
+          fi
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
       - name: Compile TypeScript
         run: npm run build
       - name: Build distributables

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -161,26 +161,14 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-      - name: Commit version bump
+      - name: Check release does not already exist
         run: |
-          VERSION="${{ github.ref_name }}"
-          if [ "$(node -p "require('./package.json').version")" != "${VERSION#v}" ]; then
-            npm version "${VERSION#v}" --no-git-tag-version
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add package.json package-lock.json
-            git commit -m "release: v$VERSION"
-            git push origin main
-          else
-            echo "Version already up to date; skipping bump commit."
+          if gh release view "${{ github.ref_name }}" > /dev/null 2>&1; then
+            echo "Error: release ${{ github.ref_name }} already exists" >&2
+            exit 1
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Download all build artefacts
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -136,7 +136,12 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
           else
-            VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "0.0.0-dev")
+            VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true)
+            if [[ -z "${VERSION}" ]]; then
+              VERSION="0.0.0-dev"
+            else
+              VERSION="${VERSION#v}"
+            fi
           fi
           npm version "$VERSION" --no-git-tag-version --allow-same-version
       - name: Compile TypeScript

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -107,6 +107,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -136,12 +138,7 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
           else
-            VERSION=$(git describe --tags --abbrev=0 2>/dev/null || true)
-            if [[ -z "${VERSION}" ]]; then
-              VERSION="0.0.0-dev"
-            else
-              VERSION="${VERSION#v}"
-            fi
+            VERSION=$(git describe --tags 2>/dev/null || echo "0.0.0-dev")
           fi
           npm version "$VERSION" --no-git-tag-version --allow-same-version
       - name: Compile TypeScript

--- a/build/afterPack.cjs
+++ b/build/afterPack.cjs
@@ -17,6 +17,11 @@ exports.default = async function afterPack(context) {
     return;
   }
 
+  if (!process.env.EVS_ACCOUNT_NAME || !process.env.EVS_PASSWD) {
+    console.log('EVS: Skipping VMP signing (credentials not available).');
+    return;
+  }
+
   const { execSync } = require('child_process');
 
   console.log('EVS: Signing package with production VMP keys...');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sidra",
-  "version": "0.1.1",
+  "version": "0.0.0",
+  "_version_note": "Placeholder; stamped from git tag by CI before each build",
   "description": "An elegant Apple Music desktop client. No frippery, just quality. A better class of Cider 🍎",
   "main": "dist/main.js",
   "scripts": {


### PR DESCRIPTION
- Replace manual version commit step with release existence validation
- Set package.json version to placeholder (0.0.0) since CI stamps version from git tag
- Reduces friction in release automation by removing unnecessary local commits