### PR TITLE
feat(track-log): implement MusicKit event capture and debug logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ sidra/
 │   ├── main.ts              — Bootstrap, Widevine, window, IPC hub
 │   ├── preload.ts           — contextBridge IPC exposure
 │   ├── config.ts            — electron-store wrapper
+│   ├── paths.ts             — Shared `getAssetPath()` utility
 │   ├── player.ts            — EventEmitter for playback state
 │   └── integrations/
 │       ├── integration.ts   — IIntegration interface
@@ -182,3 +183,4 @@ When adding new persistent settings, add typed getter/setter pairs to `config.ts
 - macOS and Windows use Chromium's native mediaSession bridges (no extra libraries)
 - Authentication is handled entirely by Apple's web flow; use `persist:sidra` partition for cookie persistence
 - Volume sync between MPRIS and MusicKit uses a suppression flag to prevent feedback loops
+- `volumeDidChange` on the MusicKit instance does not fire when the music.apple.com volume slider is used - the slider writes directly to `HTMLMediaElement.volume`, bypassing MusicKit's setter; the hook script polls `mk.volume` every 250ms as a fallback alongside the event listener

--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -48,11 +48,11 @@
       window.AMWrapper.ipcRenderer.send('shuffleModeDidChange', mk.shuffleMode);
     });
 
+    let lastVolume = mk.volume;
     mk.addEventListener('volumeDidChange', () => {
+      lastVolume = mk.volume;
       window.AMWrapper.ipcRenderer.send('volumeDidChange', mk.volume);
     });
-
-    let lastVolume = mk.volume;
     setInterval(() => {
       const v = mk.volume;
       if (v !== lastVolume) {

--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -1,0 +1,69 @@
+(function () {
+  if (window.__sidra) return;
+
+  const waitForMK = setInterval(() => {
+    if (!window.MusicKit) return;
+    clearInterval(waitForMK);
+
+    const mk = MusicKit.getInstance();
+
+    mk.addEventListener('playbackStateDidChange', ({ state }) => {
+      window.AMWrapper.ipcRenderer.send('playbackStateDidChange', {
+        status: state === MusicKit.PlaybackStates.playing,
+        state,
+      });
+    });
+
+    mk.addEventListener('nowPlayingItemDidChange', ({ item }) => {
+      if (!item) {
+        window.AMWrapper.ipcRenderer.send('nowPlayingItemDidChange', null);
+        return;
+      }
+      window.AMWrapper.ipcRenderer.send('nowPlayingItemDidChange', {
+        name: item.attributes.name,
+        albumName: item.attributes.albumName,
+        artistName: item.attributes.artistName,
+        durationInMillis: item.attributes.durationInMillis,
+        genreNames: item.attributes.genreNames,
+        artworkUrl: item.attributes.artwork?.url
+          ?.replace('{w}', '512').replace('{h}', '512'),
+        trackId: item.id,
+        audioTraits: item.attributes?.audioTraits,
+        trackNumber: item.attributes.trackNumber,
+        targetBitrate: mk.bitrate,
+      });
+    });
+
+    mk.addEventListener('playbackTimeDidChange', () => {
+      window.AMWrapper.ipcRenderer.send('playbackTimeDidChange',
+        mk.currentPlaybackTime * 1_000_000
+      );
+    });
+
+    mk.addEventListener('repeatModeDidChange', () => {
+      window.AMWrapper.ipcRenderer.send('repeatModeDidChange', mk.repeatMode);
+    });
+
+    mk.addEventListener('shuffleModeDidChange', () => {
+      window.AMWrapper.ipcRenderer.send('shuffleModeDidChange', mk.shuffleMode);
+    });
+
+    mk.addEventListener('volumeDidChange', () => {
+      window.AMWrapper.ipcRenderer.send('volumeDidChange', mk.volume);
+    });
+
+    window.__sidra = {
+      play:       () => mk.play(),
+      pause:      () => mk.pause(),
+      playPause:  () => mk.isPlaying ? mk.pause() : mk.play(),
+      next:       () => mk.skipToNextItem(),
+      previous:   () => mk.skipToPreviousItem(),
+      seek:       (secs) => mk.seekToTime(secs),
+      setVolume:  (v) => { mk.volume = v; },
+      setRepeat:  (m) => { mk.repeatMode = m; },
+      setShuffle: (m) => { mk.shuffleMode = m; },
+    };
+
+    console.log('[Sidra] MusicKit hooked successfully');
+  }, 500);
+})();

--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -52,6 +52,15 @@
       window.AMWrapper.ipcRenderer.send('volumeDidChange', mk.volume);
     });
 
+    let lastVolume = mk.volume;
+    setInterval(() => {
+      const v = mk.volume;
+      if (v !== lastVolume) {
+        lastVolume = v;
+        window.AMWrapper.ipcRenderer.send('volumeDidChange', v);
+      }
+    }, 250);
+
     window.__sidra = {
       play:       () => mk.play(),
       pause:      () => mk.pause(),

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -197,6 +197,40 @@ Events flow from the renderer (MusicKit hook script) to the main process (player
 | `shuffleModeDidChange` | Mode integer | MPRIS |
 | `volumeDidChange` | Volume float (0.0-1.0) | MPRIS |
 
+### MusicKit.js Enum Values
+
+MusicKit.js exposes enums as integer values. These are the concrete mappings observed at runtime:
+
+**`MusicKit.PlaybackStates`:**
+
+| Value | State |
+|---|---|
+| 0 | none |
+| 1 | loading |
+| 2 | playing |
+| 3 | paused |
+| 4 | stopped |
+| 5 | ended |
+| 6 | seeking |
+| 7 | waiting |
+| 8 | stalled |
+| 9 | completed |
+
+**`MusicKit.PlayerRepeatMode`:**
+
+| Value | Mode |
+|---|---|
+| 0 | none |
+| 1 | one |
+| 2 | all |
+
+**`MusicKit.PlayerShuffleMode`:**
+
+| Value | Mode |
+|---|---|
+| 0 | off |
+| 1 | songs |
+
 ### Main → Renderer (via `webContents.executeJavaScript`)
 
 Integrations call back into the renderer through the `window.__sidra` control object:
@@ -285,6 +319,13 @@ Injected into `music.apple.com` after page load via `webContents.executeJavaScri
   }, 500);
 })();
 ```
+
+### Audio Quality Metadata Caveats
+
+MusicKit.js does not expose the actual codec, bitrate, or sample rate of the audio stream. Quality negotiation happens at the HLS/CDN level, invisible to JavaScript. The available properties are misleading if taken at face value:
+
+- `item.attributes.audioTraits` (e.g. `['lossless', 'lossy-stereo']`) indicates what formats the track *supports*, not what is currently playing. Values observed: `atmos`, `lossless`, `lossy-stereo`, `hi-res-lossless`.
+- `mk.bitrate` reflects the *target* bitrate preference (`MusicKit.PlaybackBitrate.HIGH` = 256, `STANDARD` = 64), not actual playback quality. Apple's own documentation states it "does not necessarily represent the actual bit rate of the item being played". Log it as `targetBitrate` to make the semantics explicit.
 
 ---
 
@@ -422,6 +463,10 @@ ipcMain.on('volumeDidChange', (_event, volume: number) => {
 ```
 
 Also update `navigator.mediaSession` volume whenever MusicKit volume changes - `music.apple.com` does not always do this itself.
+
+### Volume Event Workaround
+
+The `music.apple.com` volume slider writes directly to `HTMLMediaElement.volume`, bypassing MusicKit's setter. As a result, `volumeDidChange` never fires on user-initiated slider changes. The workaround is to poll `mk.volume` at 250ms intervals and send IPC only when the value changes. Keep `addEventListener('volumeDidChange', ...)` in place for programmatic volume changes (e.g. from `window.__sidra.setVolume()`).
 
 ---
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,12 @@
-import { app, BrowserWindow, components, Menu, session, shell, Tray } from 'electron';
+import { app, BrowserWindow, components, ipcMain, Menu, session, shell, Tray } from 'electron';
+import fs from 'fs';
 import path from 'path';
 import log from 'electron-log/main';
-import { createTray } from './tray';
-import { getLoadingText, getStorefront as getLocaleStorefront } from './i18n';
 import { getStorefront, setStorefront, getLanguage, setLanguage } from './config';
+import { getLoadingText, getStorefront as getLocaleStorefront } from './i18n';
+import { getAssetPath } from './paths';
+import { Player } from './player';
+import { createTray } from './tray';
 
 // --- Logging: initialise before anything else ---
 log.initialize();
@@ -161,6 +164,14 @@ app.whenReady().then(async () => {
   Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
   mainLog.info('application menu set');
 
+  const player = new Player();
+  ipcMain.on('playbackStateDidChange', (_event, data) => player.handlePlaybackStateDidChange(data));
+  ipcMain.on('nowPlayingItemDidChange', (_event, data) => player.handleNowPlayingItemDidChange(data));
+  ipcMain.on('playbackTimeDidChange', (_event, data) => player.handlePlaybackTimeDidChange(data));
+  ipcMain.on('repeatModeDidChange', (_event, data) => player.handleRepeatModeDidChange(data));
+  ipcMain.on('shuffleModeDidChange', (_event, data) => player.handleShuffleModeDidChange(data));
+  ipcMain.on('volumeDidChange', (_event, data) => player.handleVolumeDidChange(data));
+
   appTray = createTray();
 
   // Show a splash screen while the Widevine CDM downloads/initialises
@@ -245,6 +256,10 @@ app.whenReady().then(async () => {
     mainLog.info('page loaded:', win.webContents.getURL());
     win.webContents.insertCSS(STYLE_FIX_CSS);
     mainLog.debug('CSS fixes injected');
+    const hookPath = getAssetPath('assets', 'musicKitHook.js');
+    const hookScript = fs.readFileSync(hookPath, 'utf-8');
+    win.webContents.executeJavaScript(hookScript);
+    mainLog.debug('MusicKit hook injected');
   });
 
   win.webContents.once('did-finish-load', () => {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,9 @@
+import { app } from 'electron';
+import path from 'path';
+
+export function getAssetPath(...parts: string[]): string {
+  const base = app.isPackaged
+    ? path.join(process.resourcesPath, 'app.asar.unpacked')
+    : path.join(__dirname, '..');
+  return path.join(base, ...parts);
+}

--- a/src/player.ts
+++ b/src/player.ts
@@ -3,6 +3,19 @@ import log from 'electron-log/main';
 
 const playerLog = log.scope('player');
 
+const PLAYBACK_STATES: Record<number, string> = {
+  0: 'none',
+  1: 'loading',
+  2: 'playing',
+  3: 'paused',
+  4: 'stopped',
+  5: 'ended',
+  6: 'seeking',
+  7: 'waiting',
+  8: 'stalled',
+  9: 'completed',
+};
+
 export class Player extends EventEmitter {
   private lastTimeLogAt = 0;
 
@@ -11,7 +24,9 @@ export class Player extends EventEmitter {
   }
 
   handlePlaybackStateDidChange(payload: unknown): void {
-    playerLog.debug('playbackStateDidChange:', payload);
+    const p = payload as { status: boolean; state: number } | null;
+    const stateName = p != null ? (PLAYBACK_STATES[p.state] ?? String(p.state)) : null;
+    playerLog.debug('playbackStateDidChange:', { ...p, state: stateName });
     this.emit('playbackStateDidChange', payload);
   }
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -4,6 +4,8 @@ import log from 'electron-log/main';
 const playerLog = log.scope('player');
 
 export class Player extends EventEmitter {
+  private lastTimeLogAt = 0;
+
   constructor() {
     super();
   }
@@ -19,7 +21,11 @@ export class Player extends EventEmitter {
   }
 
   handlePlaybackTimeDidChange(payload: unknown): void {
-    playerLog.debug('playbackTimeDidChange:', payload);
+    const now = Date.now();
+    if (now - this.lastTimeLogAt >= 10_000) {
+      playerLog.debug('playbackTimeDidChange:', payload);
+      this.lastTimeLogAt = now;
+    }
     this.emit('playbackTimeDidChange', payload);
   }
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -1,0 +1,40 @@
+import { EventEmitter } from 'events';
+import log from 'electron-log/main';
+
+const playerLog = log.scope('player');
+
+export class Player extends EventEmitter {
+  constructor() {
+    super();
+  }
+
+  handlePlaybackStateDidChange(payload: unknown): void {
+    playerLog.debug('playbackStateDidChange:', payload);
+    this.emit('playbackStateDidChange', payload);
+  }
+
+  handleNowPlayingItemDidChange(payload: unknown): void {
+    playerLog.debug('nowPlayingItemDidChange:', payload);
+    this.emit('nowPlayingItemDidChange', payload);
+  }
+
+  handlePlaybackTimeDidChange(payload: unknown): void {
+    playerLog.debug('playbackTimeDidChange:', payload);
+    this.emit('playbackTimeDidChange', payload);
+  }
+
+  handleRepeatModeDidChange(payload: unknown): void {
+    playerLog.debug('repeatModeDidChange:', payload);
+    this.emit('repeatModeDidChange', payload);
+  }
+
+  handleShuffleModeDidChange(payload: unknown): void {
+    playerLog.debug('shuffleModeDidChange:', payload);
+    this.emit('shuffleModeDidChange', payload);
+  }
+
+  handleVolumeDidChange(payload: unknown): void {
+    playerLog.debug('volumeDidChange:', payload);
+    this.emit('volumeDidChange', payload);
+  }
+}

--- a/src/player.ts
+++ b/src/player.ts
@@ -3,6 +3,17 @@ import log from 'electron-log/main';
 
 const playerLog = log.scope('player');
 
+const REPEAT_MODES: Record<number, string> = {
+  0: 'none',
+  1: 'one',
+  2: 'all',
+};
+
+const SHUFFLE_MODES: Record<number, string> = {
+  0: 'off',
+  1: 'songs',
+};
+
 const PLAYBACK_STATES: Record<number, string> = {
   0: 'none',
   1: 'loading',
@@ -45,12 +56,14 @@ export class Player extends EventEmitter {
   }
 
   handleRepeatModeDidChange(payload: unknown): void {
-    playerLog.debug('repeatModeDidChange:', payload);
+    const modeName = typeof payload === 'number' ? (REPEAT_MODES[payload] ?? String(payload)) : payload;
+    playerLog.debug('repeatModeDidChange:', modeName);
     this.emit('repeatModeDidChange', payload);
   }
 
   handleShuffleModeDidChange(payload: unknown): void {
-    playerLog.debug('shuffleModeDidChange:', payload);
+    const modeName = typeof payload === 'number' ? (SHUFFLE_MODES[payload] ?? String(payload)) : payload;
+    playerLog.debug('shuffleModeDidChange:', modeName);
     this.emit('shuffleModeDidChange', payload);
   }
 

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -2,17 +2,11 @@ import { app, BrowserWindow, Menu, nativeTheme, Tray } from 'electron';
 import path from 'path';
 import log from 'electron-log/main';
 import { getTrayStrings, getAboutStrings } from './i18n';
+import { getAssetPath } from './paths';
 
 const trayLog = log.scope('tray');
 
 const pkg = require(path.join(__dirname, '..', 'package.json'));
-
-function getAssetPath(...parts: string[]): string {
-  const base = app.isPackaged
-    ? path.join(process.resourcesPath, 'app.asar.unpacked')
-    : path.join(__dirname, '..');
-  return path.join(base, ...parts);
-}
 
 const iconsDir = getAssetPath('assets', 'icons');
 


### PR DESCRIPTION
## Summary
Wire MusicKit.js event capture through to main process with debug logging. 
The renderer hook injects into music.apple.com, captures track changes and 
playback events, and forwards them via IPC to a Player EventEmitter that 
logs at debug level. Includes event enum decoding and volume polling for 
complete visibility into playback state.

## Changes
- Extract shared `getAssetPath()` to `src/paths.ts`
- Create `Player` EventEmitter class to receive IPC events and log at debug level
- Implement MusicKit hook script in `assets/musicKitHook.js` with all six event listeners
- Wire hook injection in `src/main.ts` `did-finish-load` handler
- Register six IPC listeners in main process forwarding to player
- Throttle `playbackTimeDidChange` logging to 10s intervals (event emits every tick for MPRIS)
- Decode playback state enum values (0→none, 1→loading, 2→playing, etc.) in logs
- Decode repeat mode enum values (0→none, 1→one, 2→all) in logs
- Decode shuffle mode enum values (0→off, 1→songs) in logs
- Add volume polling (250ms) to detect slider-driven changes that bypass MusicKit setter

## Testing
Performed manual testing with `just run` and `just run-debug`:
- Hook injection confirmed via `[Sidra] MusicKit hooked successfully` in console
- Track metadata logged on playback (name, artist, album, duration, artwork, genres, track ID, audioTraits, trackNumber, targetBitrate)
- Null handling verified when queue clears
- All six events produce debug log lines with decoded enum values
- Volume adjustments detected via slider in web UI
- Playback state transitions logged with readable names
- No private API access (only public item.attributes.* and mk.* properties)
- `just build` and `just lint` pass

## Architecture
- **New files:** `src/paths.ts` (shared utility), `src/player.ts` (event hub), `assets/musicKitHook.js` (renderer hook)
- **Modified files:** `src/tray.ts`, `src/main.ts`
- **No dependency changes**, no changes to TypeScript config
- Player is built as a full EventEmitter from the start to support future MPRIS and Discord integration consumers

## Constraints Maintained
- Uses only public, documented MusicKit.js APIs
- No access to `_state` internals or undocumented properties
- Hook injection via standard `webContents.executeJavaScript()` pattern
- IPC via standard Electron preload bridge already in place