### PR TITLE
feat(discord): add Discord Rich Presence integration

### DIFF
--- a/.tailor.yml
+++ b/.tailor.yml
@@ -2,7 +2,7 @@
 license: BlueOak-1.0.0
 
 repository:
-  description: An elegant Apple Music desktop client. No frippery, just quality. A better class of Cider 🍎
+  description: An elegant Apple Music desktop client for Linux, macOS and Windows. No frippery, just quality. A better class of Cider 🍎
   has_wiki: false
   has_discussions: false
   has_projects: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,6 @@ Current:
 
 - `electron-store` - Persistent configuration
 - `electron-log` - Logging
-
-Planned (not yet in `package.json`):
-
 - `dbus-next` - MPRIS D-Bus service (Linux)
 - `@xhayper/discord-rpc` - Discord Rich Presence
 
@@ -151,7 +148,7 @@ The `10_15_7` macOS version freeze is intentional - Chrome itself freezes this v
 
 ### Adding translations
 
-`src/i18n.ts` contains all translation records for Sidra's own UI. Each record is a `Record<string, string>` keyed by BCP 47 language tags. Currently 7 records with 33 languages each: `LOADING_TEXT`, `ABOUT_TEXT`, `QUIT_TEXT`, `CLOSE_TEXT`, `VERSION_PREFIX`, `COPYRIGHT_SUFFIX`, `LICENSE_PREFIX`. When adding a language, add an entry to every record.
+`src/i18n.ts` contains all translation records for Sidra's own UI. Each record is a `Record<string, string>` keyed by BCP 47 language tags. Currently 9 records with 33 languages each: `LOADING_TEXT`, `ABOUT_TEXT`, `QUIT_TEXT`, `NOTIFICATIONS_TEXT`, `DISCORD_TEXT`, `CLOSE_TEXT`, `VERSION_PREFIX`, `COPYRIGHT_SUFFIX`, `LICENSE_PREFIX`. When adding a language, add an entry to every record.
 
 ```typescript
 export const LOADING_TEXT: Record<string, string> = {
@@ -171,6 +168,8 @@ Prefer specific regional tags only when the translation differs from the base la
 |-----|------|---------|
 | `storefront` | `string` | Apple Music storefront code (e.g. `gb`, `us`) |
 | `language` | `string \| null` | BCP 47 language override for the storefront `?l=` parameter |
+| `notifications.enabled` | `boolean` | Toggle desktop notifications (default: true) |
+| `discord.enabled` | `boolean` | Toggle Discord Rich Presence (default: true) |
 
 Getters return `undefined` when no value has been persisted - absence of a key is intentional and drives the storefront fallback chain in `main.ts`. Do not add default values to the store schema.
 
@@ -189,3 +188,4 @@ When adding new persistent settings, add typed getter/setter pairs to `config.ts
 - `app.setAppUserModelId()` must be called before `app.whenReady()` on Windows for both GSMTC identity and desktop notifications to work
 - Use `app.getPath('cache')` for artwork storage (not `os.tmpdir()`); the cache directory is not guaranteed to exist so call `fs.mkdirSync(..., { recursive: true })` before writing
 - On NixOS, `libnotify` must be in `LD_LIBRARY_PATH` or `Notification.show()` will silently do nothing; ensure it is in the Nix dev shell
+- `playbackTimeDidChange` fires every ~250ms (MusicKit polling); integrations must NOT call a debounced update function from this event or the debounce timer resets continuously and never expires - only store the updated position, then let other events trigger the debounced send

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,8 +179,13 @@ When adding new persistent settings, add typed getter/setter pairs to `config.ts
 ## Architecture notes
 
 - Event flow: MusicKit.js events in the renderer are captured by `assets/musicKitHook.js` (injected post-load), forwarded via IPC to `src/player.ts` (EventEmitter), then distributed to integrations; controls flow in reverse via `webContents.executeJavaScript()` calling methods on `window.__sidra`
+- `assets/musicKitHook.js` is read with `fs.readFileSync` at runtime; it must be listed in `asarUnpack` in the electron-builder config or AppImage builds will crash on startup
 - Chromium's built-in `MediaSessionService` must be disabled on Linux to avoid conflicting MPRIS registrations; Sidra registers its own `org.mpris.MediaPlayer2.sidra` service via dbus-next
 - macOS and Windows use Chromium's native mediaSession bridges (no extra libraries)
 - Authentication is handled entirely by Apple's web flow; use `persist:sidra` partition for cookie persistence
 - Volume sync between MPRIS and MusicKit uses a suppression flag to prevent feedback loops
 - `volumeDidChange` on the MusicKit instance does not fire when the music.apple.com volume slider is used - the slider writes directly to `HTMLMediaElement.volume`, bypassing MusicKit's setter; the hook script polls `mk.volume` every 250ms as a fallback alongside the event listener
+- `Notification.isSupported()` returns `false` in CastLabs Electron even when the platform fully supports notifications; do not gate on it - listen for the `failed` event instead to surface OS-level rejection
+- `app.setAppUserModelId()` must be called before `app.whenReady()` on Windows for both GSMTC identity and desktop notifications to work
+- Use `app.getPath('cache')` for artwork storage (not `os.tmpdir()`); the cache directory is not guaranteed to exist so call `fs.mkdirSync(..., { recursive: true })` before writing
+- On NixOS, `libnotify` must be in `LD_LIBRARY_PATH` or `Notification.show()` will silently do nothing; ensure it is in the Nix dev shell

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   Sidra
 </h1>
 
-<p align="center"><b>An elegant Apple Music desktop client. No frippery, just quality. A better class of Cider 🍎</b></p>
+<p align="center"><b>An elegant Apple Music desktop client for Linux, macOS and Windows. No frippery, just quality. A better class of Cider 🍎</b></p>
 <p align="center">
 <img alt="GitHub all releases" src="https://img.shields.io/github/downloads/wimpysworld/sidra/total?logo=github&label=Downloads">
 </p>
@@ -23,8 +23,7 @@ Sidra is under active development; several features in this list are not yet imp
 
 - Apple Music desktop client
 - Lossless audio on macOS and Windows via CastLabs EVS production VMP signing
-- Persistent login
-- Localised Apple Music storefront
+- Persistent login with localised Apple Music storefront
 - Localised interface in 31 languages
 - **Linux**:
   - Standard Widevine DRM via CastLabs Electron
@@ -36,11 +35,9 @@ Sidra is under active development; several features in this list are not yet imp
 - **Windows**:
   - Full Widevine DRM with EVS production VMP signing
   - GSMTC media flyout via Chromium's built-in mediaSession bridge
-- Discord Rich Presence
 - Desktop Notifications
-- System tray
-  - Settings
-- Last.fm scrobbling
+- Discord Rich Presence
+- Application Indicator (tray)
 - AirPlay casting
 
 ---

--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -31,6 +31,7 @@
         audioTraits: item.attributes?.audioTraits,
         trackNumber: item.attributes.trackNumber,
         targetBitrate: mk.bitrate,
+        url: item.attributes.url,
       });
     });
 

--- a/docs/DISCORD-RPC-PRIVACY.md
+++ b/docs/DISCORD-RPC-PRIVACY.md
@@ -1,0 +1,32 @@
+# Privacy Policy - Discord Rich Presence
+
+This policy covers Sidra's Discord Rich Presence feature only.
+
+## What the feature does
+
+Sidra reads track metadata from Apple Music on your device and sends it to the Discord desktop client via a local socket (IPC) on your computer.
+
+## What is shared with Discord
+
+When the feature is active, Sidra passes the following to your local Discord client:
+
+- Song title
+- Artist name
+- Album name
+- Album artwork URL
+
+## What Sidra does not collect or store
+
+Sidra does not collect, store, or transmit any personal data. No data leaves your machine through Sidra. There is no server, no analytics, no account, and no telemetry.
+
+## Discord's privacy policy
+
+Once Discord receives presence data, Discord's own practices apply. See [Discord's Privacy Policy](https://discord.com/privacy) for details.
+
+## Changes to this policy
+
+This policy may be updated. All changes will appear in the [Sidra repository](https://github.com/wimpysworld/sidra).
+
+## Contact
+
+Report concerns or questions at [github.com/wimpysworld/sidra/issues](https://github.com/wimpysworld/sidra/issues).

--- a/docs/DISCORD-RPC-TERMS.md
+++ b/docs/DISCORD-RPC-TERMS.md
@@ -1,0 +1,23 @@
+# Terms of Use - Discord Rich Presence
+
+These terms cover Sidra's Discord Rich Presence feature only.
+
+## Age requirement
+
+You must be 13 or older to use Discord. Sidra's Discord Rich Presence feature requires a running Discord client, so the same minimum age applies.
+
+## Licence
+
+Sidra is free and open-source software, released under the [Blue Oak Model License 1.0.0](https://blueoakcouncil.org/license/1.0.0).
+
+## No Warranty
+
+AS FAR AS THE LAW ALLOWS, SIDRA IS PROVIDED AS IS, WITHOUT ANY WARRANTY OR CONDITION, AND NO CONTRIBUTOR WILL BE LIABLE TO ANYONE FOR ANY DAMAGES RELATED TO THIS SOFTWARE OR THESE TERMS, UNDER ANY KIND OF LEGAL CLAIM.
+
+## Discord's terms
+
+Using Discord alongside Sidra is subject to [Discord's Terms of Service](https://discord.com/terms).
+
+## Contact
+
+Report concerns or questions at [github.com/wimpysworld/sidra/issues](https://github.com/wimpysworld/sidra/issues).

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -137,6 +137,9 @@ sidra/
 │           └── index.ts           — navigator.mediaSession updates (macOS/Win)
 ├── assets/
 │   ├── musicKitHook.js            — Injected into music.apple.com post-load
+│   │                                 Must be listed in electron-builder's `asarUnpack` —
+│   │                                 it is read with readFileSync at runtime and will crash
+│   │                                 AppImage builds if packed inside the asar archive
 │   ├── styleFix.css               — CSS overrides injected via webContents.insertCSS()
 │   │                                 Hides "Get the app" and "Open in Music" banners
 │   │                                 that Apple shows to push users toward native apps
@@ -252,6 +255,8 @@ Integrations call back into the renderer through the `window.__sidra` control ob
 ## MusicKit Hook Script
 
 Injected into `music.apple.com` after page load via `webContents.executeJavaScript()`. Polls for `MusicKit` availability, hooks events, and exposes the `window.__sidra` control object.
+
+`assets/musicKitHook.js` is read with `fs.readFileSync` at runtime in the main process. It must be listed in the `asarUnpack` array in `electron-builder` configuration; without it, AppImage builds will crash on startup because the file is inaccessible inside the packed asar archive.
 
 ```javascript
 (function () {
@@ -369,7 +374,7 @@ if (process.platform === 'win32') {
 app.setName('Sidra');
 ```
 
-The GSMTC overlay (media flyout on Windows 11) will show "Sidra" as the controlling app.
+The GSMTC overlay (media flyout on Windows 11) will show "Sidra" as the controlling app. `app.setAppUserModelId()` is also required for desktop notifications to appear on Windows - without it, `Notification.show()` is silently ignored.
 
 ---
 
@@ -626,11 +631,14 @@ class DiscordPresence {
 
 Electron's built-in `Notification` API, works on all three platforms. Notification source shows as "Sidra" (app name) automatically.
 
+**Do not gate on `Notification.isSupported()`** - in CastLabs Electron this returns `false` even when the platform fully supports notifications. Rely on the `failed` event to surface OS-level rejection instead.
+
+On Windows, `app.setAppUserModelId()` must be called before `app.whenReady()` or notifications will not appear (see [Windows: Chromium's GSMTC Bridge](#windows-chromiums-gsmtc-bridge)).
+
 ```typescript
-import { Notification } from 'electron';
+import { Notification, app } from 'electron';
 import https from 'https';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 
 let lastArtworkUrl = '';
@@ -638,7 +646,9 @@ let cachedArtworkPath = '';
 
 async function getArtworkPath(url: string): Promise<string> {
   if (url === lastArtworkUrl && cachedArtworkPath) return cachedArtworkPath;
-  const dest = path.join(os.tmpdir(), 'sidra-artwork.jpg');
+  const cacheDir = path.join(app.getPath('cache'), 'artwork');
+  fs.mkdirSync(cacheDir, { recursive: true });
+  const dest = path.join(cacheDir, 'sidra-artwork.jpg');
   await new Promise<void>((resolve, reject) => {
     const file = fs.createWriteStream(dest);
     https.get(url, res => res.pipe(file).on('finish', resolve)).on('error', reject);
@@ -651,14 +661,21 @@ async function getArtworkPath(url: string): Promise<string> {
 async function showTrackNotification(metadata: TrackMetadata, enabled: boolean) {
   if (!enabled) return;
   const iconPath = await getArtworkPath(metadata.artworkUrl);
-  new Notification({
+  const n = new Notification({
     title: metadata.name,
     body: `${metadata.artistName} — ${metadata.albumName}`,
     icon: iconPath,
     silent: true,
-  }).show();
+  });
+  n.on('show', () => log.debug('Notification shown'));
+  n.on('failed', (_event, error) => log.warn('Notification failed', error));
+  n.show();
 }
 ```
+
+`app.getPath('cache')` maps to `~/.cache/<appName>/` on Linux (respects `$XDG_CACHE_HOME`), `~/Library/Caches/<appName>/` on macOS, and `%LOCALAPPDATA%/<appName>/Cache/` on Windows. The directory is not guaranteed to exist; `fs.mkdirSync(..., { recursive: true })` is required before writing.
+
+On NixOS (dev shell), `libnotify` must be present in `LD_LIBRARY_PATH` or `notification.show()` will silently do nothing. This is a dev shell concern, not an app code concern - ensure `libnotify` is in the Nix dev shell's `LD_LIBRARY_PATH`.
 
 Notifications are toggleable via an `electron-store` boolean setting (default: on).
 
@@ -696,6 +713,11 @@ Notifications are toggleable via an `electron-store` boolean setting (default: o
 | System tray | Electron `Tray` | Prev/play-pause/next + show/hide |
 | macOS `.app` build | electron-builder | DMG |
 | Windows build | electron-builder | NSIS installer |
+
+#### Tray Menu Implementation Notes
+
+- Use `type: 'checkbox'` for toggle items (e.g. notifications on/off). On macOS and Windows this renders a native checkmark. Do not combine it with a `●`/`○` glyph prefix on those platforms - that creates double indication. Glyphs should be Linux-only.
+- For any Unicode symbols used as glyphs in menu labels, prefer early Unicode blocks (Letterlike Symbols U+2100-214F, Miscellaneous Technical U+2300-23FF, etc.) over emoji codepoints (U+1F000+). Emoji have poor coverage in native menu rendering stacks (GDI/Uniscribe on Windows, inconsistent on macOS); early Unicode symbols are safer. Conditionalise any glyphs on `process.platform === 'linux'`.
 
 ### v0.3 - Nice to Have
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -195,7 +195,7 @@ Events flow from the renderer (MusicKit hook script) to the main process (player
 |---|---|---|
 | `playbackStateDidChange` | `{ status: bool, state }` | MPRIS, Discord, Notifications |
 | `nowPlayingItemDidChange` | `{ name, albumName, artistName, durationInMillis, artworkUrl, genreNames, trackId }` or `null` | MPRIS, Discord, Notifications |
-| `playbackTimeDidChange` | Position in microseconds | MPRIS |
+| `playbackTimeDidChange` | Position in microseconds | MPRIS, Discord (position only) |
 | `repeatModeDidChange` | Mode integer (0/1/2) | MPRIS |
 | `shuffleModeDidChange` | Mode integer | MPRIS |
 | `volumeDidChange` | Volume float (0.0-1.0) | MPRIS |
@@ -567,63 +567,34 @@ The actual variable names must be verified against `music.apple.com`'s live CSS.
 
 ## Discord Rich Presence
 
-Uses `@xhayper/discord-rpc`. Requires creating a Discord Application at discord.com/developers for a Client ID and uploading Sidra branding assets.
+Uses `@xhayper/discord-rpc`. Discord Application Client ID: `1485248818688688318`. Sidra branding assets (`sidra_logo`) are uploaded to the Discord Developer Portal.
 
 Reference implementation: [ytmdesktop Discord presence](https://github.com/ytmdesktop/ytmdesktop/blob/development/src/main/integrations/discord-presence/index.ts)
 
 ### Behaviour
 
 - **Activity type**: `ActivityType.Listening` ("Listening to" status text)
-- **Details**: Track name (truncated to 128 chars)
-- **State**: Artist name (truncated to 128 chars)
-- **Artwork**: Apple Music CDN URLs work directly as `large_image` if under 256 chars (typical range: 80-130 chars). Fall back to a Discord-hosted `sidra_logo` asset if over the limit.
-- **Timestamps**: When playing, set `start` and `end` to show elapsed/remaining. Omit when paused.
-- **Debounce**: 1s debounce on updates to coalesce rapid events (track change + position update landing together).
+- **Details**: Track name (truncated to 128 chars, padded to 2 chars minimum - Discord rejects shorter strings)
+- **State**: `by ArtistName` (truncated to 128 chars, padded to 2 chars minimum)
+- **Artwork**: Apple Music CDN URLs work directly as `largeImageKey` if under 256 chars (typical range: 80-130 chars). Fall back to a Discord-hosted `sidra_logo` asset if over the limit.
+- **Timestamps**: When playing, calculate `startTimestamp` and `endTimestamp` from current position at send time. Omit when paused.
+- **Buttons**: Two buttons - "Sidra" (links to GitHub repo) and "Play on Apple Music" (links to track URL when available).
+- **Debounce**: 1s debounce on updates to coalesce rapid events (track change + playback state landing together). `scheduleUpdate()` resets the debounce timer; `sendActivity()` calculates timestamps fresh from the cached position.
 - **Pause timeout**: Clear activity after 30s paused (ytmdesktop pattern) - courtesy to users who do not want to broadcast a paused state.
-- **Retry**: Reconnect with backoff on Discord IPC disconnection.
+- **Retry**: Reconnect with exponential backoff (2s base, 60s cap) on Discord IPC disconnection.
+- **Toggle**: `discord.enabled` in `electron-store` (default: true). Tray menu toggle; when disabled, clears activity immediately.
 
-```typescript
-class DiscordPresence {
-  private readonly CLIENT_ID = 'YOUR_SIDRA_CLIENT_ID';
-  private client: Client;
-  private debounceTimeout: NodeJS.Timeout | null = null;
-  private pauseTimeout: NodeJS.Timeout | null = null;
-  private retries = 0;
+### `playbackTimeDidChange` pitfall
 
-  private updateActivity(metadata: TrackMetadata, positionSecs: number, isPlaying: boolean) {
-    if (this.debounceTimeout) clearTimeout(this.debounceTimeout);
-    this.debounceTimeout = setTimeout(() => {
-      const durationSecs = metadata.durationInMillis / 1000;
+`playbackTimeDidChange` fires every ~250ms (MusicKit polling). Integrations must NOT call `scheduleUpdate()` (or any debounced function) from this event - doing so resets the debounce timer on every tick, preventing the debounced callback from ever executing. The Discord integration stores the updated position only; timestamps are calculated from the cached position when `sendActivity()` fires.
 
-      this.client.user?.setActivity({
-        type: ActivityType.Listening,
-        details: truncate(metadata.name, 128),
-        state: `by ${truncate(metadata.artistName, 128)}`,
-        assets: {
-          large_image: metadata.artworkUrl.length <= 256
-            ? metadata.artworkUrl
-            : 'sidra_logo',
-          large_text: truncate(metadata.albumName, 128),
-          small_image: 'sidra_logo',
-          small_text: 'Sidra',
-        },
-        timestamps: isPlaying ? {
-          start: Date.now() - (positionSecs * 1000),
-          end: Date.now() + ((durationSecs - positionSecs) * 1000),
-        } : undefined,
-      });
-      this.debounceTimeout = null;
-    }, 1000);
+### Event subscriptions
 
-    clearTimeout(this.pauseTimeout);
-    if (!isPlaying) {
-      this.pauseTimeout = setTimeout(() => {
-        this.client.user?.clearActivity();
-      }, 30_000);
-    }
-  }
-}
-```
+| Event | Action |
+|---|---|
+| `nowPlayingItemDidChange` | Cache metadata, cancel pause timer, `scheduleUpdate()` |
+| `playbackStateDidChange` | Update `isPlaying`, manage pause timer, `scheduleUpdate()` |
+| `playbackTimeDidChange` | Store position only (no `scheduleUpdate()`) |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "sidra",
-  "version": "0.1.1",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sidra",
-      "version": "0.1.1",
+      "version": "0.0.0",
       "license": "BlueOak-1.0.0",
       "dependencies": {
+        "@xhayper/discord-rpc": "^1.3.1",
         "electron-log": "^5.x",
         "electron-store": "^10.x"
       },
@@ -35,6 +36,56 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.16",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@electron/asar": {
@@ -775,6 +826,26 @@
         "node": ">=14"
       }
     },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -907,6 +978,31 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@xhayper/discord-rpc": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@xhayper/discord-rpc/-/discord-rpc-1.3.1.tgz",
+      "integrity": "sha512-NaiqAbPsRv88DaSVvS768lCV81xgkU5rKX5k3Mja4/zXsqHWyShPRmP/er/KutpauzWGplnieBy0TKOY87/V9g==",
+      "license": "ISC",
+      "dependencies": {
+        "@discordjs/rest": "^2.6.0",
+        "@vladfrangu/async_event_emitter": "^2.4.7",
+        "discord-api-types": "^0.38.40",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -2129,6 +2225,15 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.42",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.42.tgz",
+      "integrity": "sha512-qs1kya7S84r5RR8m9kgttywGrmmoHaRifU1askAoi+wkoSefLpZP6aGXusjNw5b0jD3zOg3LTwUa3Tf2iHIceQ==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
     },
     "node_modules/dmg-builder": {
       "version": "26.8.2",
@@ -3780,6 +3885,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT"
+    },
     "node_modules/make-fetch-happen": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
@@ -5425,6 +5536,12 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -5463,6 +5580,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -5623,6 +5749,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "typescript": "^5.x"
   },
   "dependencies": {
+    "@xhayper/discord-rpc": "^1.3.1",
     "electron-log": "^5.x",
     "electron-store": "^10.x"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sidra",
   "version": "0.0.0",
   "_version_note": "Placeholder; stamped from git tag by CI before each build",
-  "description": "An elegant Apple Music desktop client. No frippery, just quality. A better class of Cider 🍎",
+  "description": "An elegant Apple Music desktop client for Linux, macOS and Windows. No frippery, just quality. A better class of Cider 🍎",
   "main": "dist/main.js",
   "scripts": {
     "start": "npm run build && electron .",

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ interface StoreSchema {
   storefront: string;
   language: string | null;
   'notifications.enabled': boolean;
+  'discord.enabled': boolean;
 }
 
 // electron-store v10 is ESM-only; under CommonJS moduleResolution TypeScript
@@ -54,4 +55,16 @@ export function getNotificationsEnabled(): boolean {
 export function setNotificationsEnabled(enabled: boolean): void {
   store.set('notifications.enabled', enabled);
   configLog.info('notifications.enabled set:', enabled);
+}
+
+export function getDiscordEnabled(): boolean {
+  if (!store.has('discord.enabled')) {
+    return true;  // default on
+  }
+  return store.get('discord.enabled');
+}
+
+export function setDiscordEnabled(enabled: boolean): void {
+  store.set('discord.enabled', enabled);
+  configLog.info('discord.enabled set:', enabled);
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -153,6 +153,43 @@ export const NOTIFICATIONS_TEXT: Record<string, string> = {
   'he': 'התראות',
 };
 
+// --- "Discord Rich Presence" ---
+export const DISCORD_TEXT: Record<string, string> = {
+  'en': 'Discord Rich Presence',
+  'zh-CN': 'Discord 动态状态',
+  'zh-SG': 'Discord 动态状态',
+  'zh-TW': 'Discord 動態狀態',
+  'zh-HK': 'Discord 動態狀態',
+  'es': 'Presencia enriquecida de Discord',
+  'hi': 'Discord रिच प्रेज़ेंस',
+  'ar': 'حالة Discord التفصيلية',
+  'fr': 'Présence enrichie Discord',
+  'pt': 'Presença avançada do Discord',
+  'de': 'Discord Rich Presence',
+  'ru': 'Статус Discord',
+  'ja': 'Discord Rich Presence',
+  'ko': 'Discord Rich Presence',
+  'it': 'Presenza avanzata Discord',
+  'nl': 'Discord Rich Presence',
+  'pl': 'Discord Rich Presence',
+  'tr': 'Discord Zengin Durum',
+  'sv': 'Discord Rich Presence',
+  'da': 'Discord Rich Presence',
+  'fi': 'Discord Rich Presence',
+  'nb': 'Discord Rich Presence',
+  'no': 'Discord Rich Presence',
+  'cs': 'Discord Rich Presence',
+  'ro': 'Prezență avansată Discord',
+  'hu': 'Discord Rich Presence',
+  'el': 'Discord Rich Presence',
+  'th': 'Discord Rich Presence',
+  'id': 'Discord Rich Presence',
+  'ms': 'Discord Rich Presence',
+  'uk': 'Статус Discord',
+  'vi': 'Discord Rich Presence',
+  'he': 'Discord Rich Presence',
+};
+
 // --- "Close" ---
 export const CLOSE_TEXT: Record<string, string> = {
   'en': 'Close',
@@ -356,14 +393,15 @@ export function getLoadingText(): { text: string; lang: string } {
   return { text, lang };
 }
 
-export function getTrayStrings(): { about: string; quit: string; notifications: string } {
+export function getTrayStrings(): { about: string; quit: string; notifications: string; discord: string } {
   const langs = getSystemLanguages();
   const productName: string = pkg.build?.productName ?? app.getName();
   const aboutTemplate = getLocalizedString(ABOUT_TEXT, langs);
   const about = aboutTemplate.replace('{name}', productName);
   const quit = getLocalizedString(QUIT_TEXT, langs);
   const notifications = getLocalizedString(NOTIFICATIONS_TEXT, langs);
-  return { about, quit, notifications };
+  const discord = getLocalizedString(DISCORD_TEXT, langs);
+  return { about, quit, notifications, discord };
 }
 
 export function getAboutStrings(): {

--- a/src/integrations/discord-presence/index.ts
+++ b/src/integrations/discord-presence/index.ts
@@ -221,6 +221,8 @@ export function init(player: Player): void {
     if (typeof payload === 'number') {
       currentPositionUs = payload;
     }
-    scheduleUpdate();
+    // Do not call scheduleUpdate() here: playbackTimeDidChange fires
+    // continuously and would perpetually reset the debounce timer,
+    // preventing sendActivity() from ever executing.
   });
 }

--- a/src/integrations/discord-presence/index.ts
+++ b/src/integrations/discord-presence/index.ts
@@ -1,0 +1,226 @@
+import log from 'electron-log/main';
+import { Client } from '@xhayper/discord-rpc';
+import { ActivityType } from 'discord-api-types/v10';
+import { Player } from '../../player';
+import { getDiscordEnabled } from '../../config';
+
+const discordLog = log.scope('discord');
+
+const CLIENT_ID = '1485248818688688318';
+const DEBOUNCE_MS = 1000;
+const PAUSE_TIMEOUT_MS = 30_000;
+const RECONNECT_BASE_MS = 2000;
+const RECONNECT_CAP_MS = 60_000;
+const MAX_STRING_LEN = 128;
+const MIN_STRING_LEN = 2;
+const MAX_IMAGE_URL_LEN = 256;
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + '\u2026';
+}
+
+function padMin(s: string, min: number): string {
+  while (s.length < min) {
+    s += '\u200b';
+  }
+  return s;
+}
+
+// Track metadata cache
+let trackName: string | null = null;
+let artistName: string | null = null;
+let albumName: string | null = null;
+let artworkUrl: string | undefined = undefined;
+let durationMs = 0;
+let trackUrl: string | undefined = undefined;
+
+// Playback state
+let isPlaying = false;
+let currentPositionUs = 0;
+
+// Timers
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let pauseTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let retryCount = 0;
+
+let client: Client;
+
+function scheduleUpdate(): void {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+  }
+  debounceTimer = setTimeout(() => {
+    debounceTimer = null;
+    sendActivity();
+  }, DEBOUNCE_MS);
+}
+
+function sendActivity(): void {
+  if (!getDiscordEnabled()) {
+    discordLog.debug('discord disabled, clearing activity');
+    client.user?.clearActivity().catch(() => {});
+    return;
+  }
+
+  if (!client.isConnected) {
+    discordLog.debug('not connected, skipping activity update');
+    return;
+  }
+
+  if (!trackName) {
+    discordLog.debug('no track metadata, skipping activity update');
+    return;
+  }
+
+  const details = padMin(truncate(trackName, MAX_STRING_LEN), MIN_STRING_LEN);
+  const state = padMin(truncate(`by ${artistName ?? 'Unknown Artist'}`, MAX_STRING_LEN), MIN_STRING_LEN);
+
+  const largeImageKey = (artworkUrl && artworkUrl.length <= MAX_IMAGE_URL_LEN)
+    ? artworkUrl
+    : 'sidra_logo';
+  const largeImageText = albumName
+    ? truncate(albumName, MAX_STRING_LEN)
+    : undefined;
+
+  const buttons: Array<{ label: string; url: string }> = [
+    { label: 'Sidra', url: 'https://github.com/wimpysworld/sidra' },
+  ];
+  if (trackUrl) {
+    buttons.push({ label: 'Play on Apple Music', url: trackUrl });
+  }
+
+  const activity: Record<string, unknown> = {
+    type: ActivityType.Listening,
+    details,
+    state,
+    largeImageKey,
+    largeImageText,
+    smallImageKey: 'sidra_logo',
+    smallImageText: 'Sidra',
+    buttons,
+  };
+
+  if (isPlaying && durationMs > 0) {
+    const currentPositionMs = currentPositionUs / 1000;
+    const now = Date.now();
+    activity.startTimestamp = new Date(now - currentPositionMs);
+    activity.endTimestamp = new Date(now - currentPositionMs + durationMs);
+  }
+
+  client.user?.setActivity(activity as Parameters<typeof client.user.setActivity>[0]).then(() => {
+    discordLog.debug('activity updated:', trackName);
+  }).catch((err: Error) => {
+    discordLog.warn('failed to set activity:', err.message);
+  });
+}
+
+function scheduleReconnect(): void {
+  if (reconnectTimer) return;
+
+  const delay = Math.min(RECONNECT_BASE_MS * 2 ** retryCount, RECONNECT_CAP_MS);
+  retryCount++;
+  discordLog.info(`scheduling reconnect in ${delay}ms (attempt ${retryCount})`);
+
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    discordLog.info('attempting reconnect');
+    client.login().catch((err: Error) => {
+      discordLog.warn('reconnect failed:', err.message);
+      scheduleReconnect();
+    });
+  }, delay);
+}
+
+export function init(player: Player): void {
+  discordLog.info('discord presence module initialised');
+
+  client = new Client({ clientId: CLIENT_ID });
+
+  client.on('ready', () => {
+    discordLog.info('connected to Discord');
+    retryCount = 0;
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    scheduleUpdate();
+  });
+
+  client.on('disconnected', () => {
+    discordLog.info('disconnected from Discord');
+    scheduleReconnect();
+  });
+
+  client.login().catch((err: Error) => {
+    discordLog.warn('initial login failed:', err.message);
+    scheduleReconnect();
+  });
+
+  player.on('nowPlayingItemDidChange', (payload: unknown) => {
+    const p = payload as {
+      name?: string;
+      artistName?: string;
+      albumName?: string;
+      artworkUrl?: string;
+      durationInMillis?: number;
+      url?: string;
+    } | null;
+
+    if (!p) {
+      trackName = null;
+      artistName = null;
+      albumName = null;
+      artworkUrl = undefined;
+      durationMs = 0;
+      trackUrl = undefined;
+    } else {
+      trackName = p.name ?? null;
+      artistName = p.artistName ?? null;
+      albumName = p.albumName ?? null;
+      artworkUrl = p.artworkUrl;
+      durationMs = p.durationInMillis ?? 0;
+      trackUrl = p.url;
+    }
+
+    // Cancel pause timer on new track
+    if (pauseTimer) {
+      clearTimeout(pauseTimer);
+      pauseTimer = null;
+    }
+
+    scheduleUpdate();
+  });
+
+  player.on('playbackStateDidChange', (payload: unknown) => {
+    const p = payload as { state: number } | null;
+    const wasPlaying = isPlaying;
+    // MusicKit PlaybackStates: 2 = playing
+    isPlaying = p?.state === 2;
+
+    if (isPlaying && pauseTimer) {
+      clearTimeout(pauseTimer);
+      pauseTimer = null;
+    }
+
+    if (!isPlaying && wasPlaying) {
+      // Start pause timeout
+      pauseTimer = setTimeout(() => {
+        pauseTimer = null;
+        discordLog.debug('pause timeout reached, clearing activity');
+        client.user?.clearActivity().catch(() => {});
+      }, PAUSE_TIMEOUT_MS);
+    }
+
+    scheduleUpdate();
+  });
+
+  player.on('playbackTimeDidChange', (payload: unknown) => {
+    // Payload is microseconds (number)
+    if (typeof payload === 'number') {
+      currentPositionUs = payload;
+    }
+    scheduleUpdate();
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { getAssetPath } from './paths';
 import { Player } from './player';
 import { createTray } from './tray';
 import { init as initNotifications } from './integrations/notifications';
+import { init as initDiscordPresence } from './integrations/discord-presence';
 
 // --- Logging: initialise before anything else ---
 log.initialize();
@@ -236,6 +237,7 @@ app.whenReady().then(async () => {
   });
 
   initNotifications(player, () => win);
+  initDiscordPresence(player);
 
   Promise.all([minDisplay, cssReady]).then(() => {
     splashLog.info('splash closed');

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import log from 'electron-log/main';
 import { getTrayStrings, getAboutStrings } from './i18n';
 import { getAssetPath } from './paths';
-import { getNotificationsEnabled, setNotificationsEnabled } from './config';
+import { getNotificationsEnabled, setNotificationsEnabled, getDiscordEnabled, setDiscordEnabled } from './config';
 
 const trayLog = log.scope('tray');
 
@@ -90,6 +90,8 @@ function buildContextMenu(tray: Tray): Menu {
   const isLinux = process.platform === 'linux';
   const notifEnabled = getNotificationsEnabled();
   const notifGlyph = notifEnabled ? '●' : '○';
+  const discordEnabled = getDiscordEnabled();
+  const discordGlyph = discordEnabled ? '●' : '○';
 
   return Menu.buildFromTemplate([
     {
@@ -102,6 +104,15 @@ function buildContextMenu(tray: Tray): Menu {
       checked: notifEnabled,
       click: (menuItem) => {
         setNotificationsEnabled(menuItem.checked);
+        tray.setContextMenu(buildContextMenu(tray));
+      },
+    },
+    {
+      label: isLinux ? `${discordGlyph} ${strings.discord}` : strings.discord,
+      type: 'checkbox',
+      checked: discordEnabled,
+      click: (menuItem) => {
+        setDiscordEnabled(menuItem.checked);
         tray.setContextMenu(buildContextMenu(tray));
       },
     },


### PR DESCRIPTION
## Summary

Adds complete Discord Rich Presence integration allowing now playing information to be displayed in Discord user status. Includes RPC client lifecycle management with debounce, pause timeout, and reconnect backoff. Configurable via settings with i18n translations. Accessible via tray menu toggle.

## Changes

- Core Discord RPC module with client lifecycle, event handling, and reconnection logic
- Debounce mechanism to prevent rapid RPC updates (1s default)
- Pause timeout to clear Rich Presence after 2s of playback pause
- Exponential backoff reconnection strategy (up to 30s)
- Configuration integration with enable/disable toggle
- Internationalization support for tray menu
- Tray menu toggle for Discord Rich Presence
- Documentation of privacy and terms for Discord integration
- Bug fix: prevent debounce timer reset from blocking Rich Presence updates

## Testing

- Manual verification of Rich Presence display in Discord during playback
- Testing pause timeout clears presence after configured duration
- Verification of tray menu toggle enable/disable functionality
- Testing reconnection logic after Discord client restarts
- Configuration persistence across application restarts