### PR TITLE
feat(theme): add Catppuccin colour scheme support with live toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,33 @@ Getters return `undefined` when no value has been persisted - absence of a key i
 
 When adding new persistent settings, add typed getter/setter pairs to `config.ts` following the existing pattern. Do not use `electron-store` directly elsewhere in the codebase.
 
+## CSS injection
+
+`webContents.insertCSS()` injects at author-level cascade origin. Apple's own stylesheets compete at the same specificity, so all overrides require `!important` or they lose on specificity ties after navigation.
+
+`@media (prefers-color-scheme: dark/light)` resolves correctly against `nativeTheme.shouldUseDarkColors`. A single CSS file with both media blocks covers both variants.
+
+### Elements outside the `:root` cascade
+
+Most Apple Music styling responds to `:root` custom property overrides. These elements do not:
+
+| Element | Selector | Reason |
+|---------|----------|--------|
+| Player bar background | `.wrapper amp-chrome-player::before` | `::before` pseudo paints the bar |
+| Side panels (Lyrics/Up Next) | `.side-panel`, `.side-panel-header-wrapper` | Direct `background-color` |
+| Page footer | `.scrollable-page > footer` | Direct `background-color` |
+| LCD now-playing widget | `amp-lcd { --lcd-bg-color }` | Shadow DOM scoped variable |
+
+**Pattern:** when a `:root` variable override has no visible effect, the element either (a) uses a shadow-DOM-scoped custom property (set the variable on the host element), or (b) paints its own background via `::before` or a direct property (use a direct selector with `!important`).
+
+### CSS variable audit
+
+Active Apple Music userstyle repositories provide reliable cross-referenced variable lists: PitchBlack (`sprince0031/PitchBlack-UserStyle-themes`), Native AM (`dantelin2009`), AppleMusic-Tui. Search with `mcp__exa__get_code_context_exa` using `"apple music userstyle css variables site:github.com"`.
+
+### Asset packaging
+
+CSS files read via `fs.readFileSync` at runtime must be listed individually in `asarUnpack` in `package.json`. `asarUnpack` does not support globs - each file must be named explicitly or packaged builds will fail to read them.
+
 ## Architecture notes
 
 - Event flow: MusicKit.js events in the renderer are captured by `assets/musicKitHook.js` (injected post-load), forwarded via IPC to `src/player.ts` (EventEmitter), then distributed to integrations; controls flow in reverse via `webContents.executeJavaScript()` calling methods on `window.__sidra`

--- a/assets/catppuccin.css
+++ b/assets/catppuccin.css
@@ -1,0 +1,245 @@
+/*
+ * Catppuccin theme for Apple Music
+ * Mocha (dark) and Latte (light) variants via prefers-color-scheme
+ */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Background & Structure */
+    --pageBG: #1e1e2e !important;
+    --pageBG-rgb: 30,30,46 !important;
+    --opaqueShelfBG: #181825 !important;
+    --opaquePageBGColor: #181825 !important;
+    --fallbackMaterialBG: rgba(24,24,37,0.97) !important;
+    --shelfBG: rgba(49,50,68,0.15) !important;
+    --modalBGColor: #1e1e2e !important;
+    --modalBGColor-rgb: 30,30,46 !important;
+    --modalBGHeaderColor: rgba(24,24,37,0.97) !important;
+    --footerBG: #11111b !important;
+    --sidebar: rgba(49,50,68,0.05) !important;
+    --webNavigationMobileBg: #181825 !important;
+    --genericJoeColor: #45475a !important;
+
+    /* Accent */
+    --keyColor: #f38ba8 !important;
+    --keyColor-rgb: 243,139,168 !important;
+    --keyColor-rollover: #eba0ac !important;
+    --keyColor-pressed: #eba0ac !important;
+    --keyColor-deepPressed: #eba0ac !important;
+    --keyColor-disabled: rgba(243,139,168,0.35) !important;
+    --musicKeyColor: #f38ba8 !important;
+    --systemAccentBG: #f38ba8 !important;
+    --musicBrandBG: #f38ba8 !important;
+    --selectionColor: #f38ba8 !important;
+    --lovedBGColor: #f38ba8 !important;
+
+    /* Text */
+    --systemPrimary: rgba(205,214,244,0.85) !important;
+    --systemPrimary-vibrant: #cdd6f4 !important;
+    --systemPrimary-vibrant-rgb: 205,214,244 !important;
+    --systemSecondary: rgba(186,194,222,0.55) !important;
+    --systemSecondary-vibrant: #a6adc8 !important;
+    --systemTertiary: rgba(108,112,134,0.25) !important;
+    --systemTertiary-vibrant: #585b70 !important;
+    --systemQuaternary: rgba(69,71,90,0.15) !important;
+    --systemQuinary: rgba(49,50,68,0.08) !important;
+    --contextMenuTextColor: rgba(205,214,244,0.85) !important;
+
+    /* Borders & Dividers */
+    --labelDivider: rgba(88,91,112,0.2) !important;
+    --vibrantDivider: rgba(88,91,112,0.25) !important;
+    --sidebarBorderRule: rgba(88,91,112,0.15) !important;
+    --contextMenuBorderColor: rgba(88,91,112,0.2) !important;
+    --searchBorder: rgba(88,91,112,0.2) !important;
+
+    /* Player */
+    --playerBackground: rgba(24,24,37,0.88) !important;
+    --playerBackgroundFallback: rgba(24,24,37,0.97) !important;
+    --playerLCDBGFill: #313244 !important;
+    --playerLCDBGFill-rgb: 49,50,68 !important;
+    --playerLCDLogo: rgba(166,173,200,0.55) !important;
+    --playerScrubberFill: #f38ba8 !important;
+    --playerScrubberTrack: rgba(69,71,90,0.2) !important;
+    --playerScrubberPlayhead: #a6adc8 !important;
+    --playerVolumeFill: #f38ba8 !important;
+    --playerVolumeTrack: rgba(69,71,90,0.2) !important;
+    --playerVolumeIconFill: rgba(186,194,222,0.5) !important;
+    --playerPlatterButtonBGFill: #f38ba8 !important;
+    --playerPlatterButtonIconFill: #1e1e2e !important;
+    --playerDropShadow2: rgba(17,17,27,0.1) !important;
+    --playerArtworkKeyline: rgba(49,50,68,0.15) !important;
+
+    /* Navigation */
+    --sidebarSelectedState: rgba(49,50,68,0.15) !important;
+    --segmentedControlBG: rgba(49,50,68,0.2) !important;
+    --segmentedControlSelectedBG: #45475a !important;
+
+    /* Tracklist */
+    --tracklistHoverColor: rgba(49,50,68,0.08) !important;
+    --tracklistAltRowColor: rgba(49,50,68,0.03) !important;
+    --trackBackgroundEven: rgba(49,50,68,0.05) !important;
+
+    /* Materials */
+    --systemStandardThickMaterialSover: rgba(24,24,37,0.72) !important;
+    --systemHeaderMaterialSover: rgba(24,24,37,0.8) !important;
+    --systemToolbarTitlebarMaterialSover: rgba(24,24,37,0.8) !important;
+  }
+
+  /* Top player bar: amp-chrome-player::before paints the bar background
+     independently of :root variables - must be overridden directly */
+  .wrapper amp-chrome-player::before {
+    background-color: rgba(24, 24, 37, 0.88) !important;
+  }
+
+  /* Prevent .player-bar from painting its own light background over the top */
+  .player-bar,
+  .chrome-player.chrome-player__music {
+    background: none !important;
+    box-shadow: none !important;
+  }
+
+  /* Force --playerBGFill into shadow-DOM-scoped elements */
+  * {
+    --playerBGFill: rgba(24, 24, 37, 0.88) !important;
+  }
+
+  /* Side panels (Lyrics + Up Next): not covered by :root variables */
+  .side-panel {
+    background-color: rgba(24, 24, 37, 0.97) !important;
+    backdrop-filter: blur(50px) saturate(100%) !important;
+  }
+  .side-panel.side-panel-header-wrapper,
+  .side-panel .side-panel-header-wrapper,
+  .side-panel-header-wrapper {
+    background-color: rgba(24, 24, 37, 0.97) !important;
+  }
+
+  /* LCD now-playing text/info area background */
+  amp-lcd {
+    --lcd-bg-color: #313244 !important;
+  }
+
+  /* Footer */
+  .scrollable-page > footer {
+    background-color: #11111b !important;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    /* Background & Structure */
+    --pageBG: #eff1f5 !important;
+    --pageBG-rgb: 239,241,245 !important;
+    --opaqueShelfBG: #e6e9ef !important;
+    --opaquePageBGColor: #e6e9ef !important;
+    --fallbackMaterialBG: rgba(230,233,239,0.97) !important;
+    --shelfBG: rgba(204,208,218,0.15) !important;
+    --modalBGColor: #eff1f5 !important;
+    --modalBGColor-rgb: 239,241,245 !important;
+    --modalBGHeaderColor: rgba(230,233,239,0.97) !important;
+    --footerBG: #dce0e8 !important;
+    --sidebar: rgba(204,208,218,0.05) !important;
+    --webNavigationMobileBg: #e6e9ef !important;
+    --genericJoeColor: #bcc0cc !important;
+
+    /* Accent */
+    --keyColor: #d20f39 !important;
+    --keyColor-rgb: 210,15,57 !important;
+    --keyColor-rollover: #e64553 !important;
+    --keyColor-pressed: #e64553 !important;
+    --keyColor-deepPressed: #e64553 !important;
+    --keyColor-disabled: rgba(210,15,57,0.35) !important;
+    --musicKeyColor: #d20f39 !important;
+    --systemAccentBG: #d20f39 !important;
+    --musicBrandBG: #d20f39 !important;
+    --selectionColor: #d20f39 !important;
+    --lovedBGColor: #d20f39 !important;
+
+    /* Text */
+    --systemPrimary: rgba(76,79,105,0.85) !important;
+    --systemPrimary-vibrant: #4c4f69 !important;
+    --systemPrimary-vibrant-rgb: 76,79,105 !important;
+    --systemSecondary: rgba(92,95,119,0.55) !important;
+    --systemSecondary-vibrant: #6c6f85 !important;
+    --systemTertiary: rgba(156,160,176,0.25) !important;
+    --systemTertiary-vibrant: #acb0be !important;
+    --systemQuaternary: rgba(188,192,204,0.15) !important;
+    --systemQuinary: rgba(204,208,218,0.08) !important;
+    --contextMenuTextColor: rgba(76,79,105,0.85) !important;
+
+    /* Borders & Dividers */
+    --labelDivider: rgba(172,176,190,0.2) !important;
+    --vibrantDivider: rgba(172,176,190,0.25) !important;
+    --sidebarBorderRule: rgba(172,176,190,0.15) !important;
+    --contextMenuBorderColor: rgba(172,176,190,0.2) !important;
+    --searchBorder: rgba(172,176,190,0.2) !important;
+
+    /* Player */
+    --playerBackground: rgba(230,233,239,0.88) !important;
+    --playerBackgroundFallback: rgba(230,233,239,0.97) !important;
+    --playerLCDBGFill: #ccd0da !important;
+    --playerLCDBGFill-rgb: 204,208,218 !important;
+    --playerLCDLogo: rgba(108,111,133,0.55) !important;
+    --playerScrubberFill: #d20f39 !important;
+    --playerScrubberTrack: rgba(188,192,204,0.2) !important;
+    --playerScrubberPlayhead: #6c6f85 !important;
+    --playerVolumeFill: #d20f39 !important;
+    --playerVolumeTrack: rgba(188,192,204,0.2) !important;
+    --playerVolumeIconFill: rgba(92,95,119,0.5) !important;
+    --playerPlatterButtonBGFill: #d20f39 !important;
+    --playerPlatterButtonIconFill: #eff1f5 !important;
+    --playerDropShadow2: rgba(220,224,232,0.1) !important;
+    --playerArtworkKeyline: rgba(204,208,218,0.15) !important;
+
+    /* Navigation */
+    --sidebarSelectedState: rgba(204,208,218,0.15) !important;
+    --segmentedControlBG: rgba(204,208,218,0.2) !important;
+    --segmentedControlSelectedBG: #bcc0cc !important;
+
+    /* Tracklist */
+    --tracklistHoverColor: rgba(204,208,218,0.08) !important;
+    --tracklistAltRowColor: rgba(204,208,218,0.03) !important;
+    --trackBackgroundEven: rgba(204,208,218,0.05) !important;
+
+    /* Materials */
+    --systemStandardThickMaterialSover: rgba(230,233,239,0.72) !important;
+    --systemHeaderMaterialSover: rgba(230,233,239,0.8) !important;
+    --systemToolbarTitlebarMaterialSover: rgba(230,233,239,0.8) !important;
+  }
+
+  /* Top player bar */
+  .wrapper amp-chrome-player::before {
+    background-color: rgba(230, 233, 239, 0.88) !important;
+  }
+
+  .player-bar,
+  .chrome-player.chrome-player__music {
+    background: none !important;
+    box-shadow: none !important;
+  }
+
+  * {
+    --playerBGFill: rgba(230, 233, 239, 0.88) !important;
+  }
+
+  /* Side panels (Lyrics + Up Next): not covered by :root variables */
+  .side-panel {
+    background-color: rgba(230, 233, 239, 0.97) !important;
+    backdrop-filter: blur(50px) saturate(100%) !important;
+  }
+  .side-panel.side-panel-header-wrapper,
+  .side-panel .side-panel-header-wrapper,
+  .side-panel-header-wrapper {
+    background-color: rgba(230, 233, 239, 0.97) !important;
+  }
+
+  /* LCD now-playing text/info area background */
+  amp-lcd {
+    --lcd-bg-color: #ccd0da !important;
+  }
+
+  /* Footer */
+  .scrollable-page > footer {
+    background-color: #dce0e8 !important;
+  }
+}

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -541,27 +541,34 @@ Theme preference is stored in `electron-store` as `theme` (`'default'` | `'catpp
 
 ### Implementation
 
-`catppuccin.css` overrides CSS custom properties on `:root`. Apple Music's own web app uses CSS variables throughout its UI, so a targeted variable replacement is sufficient. No element-level selectors.
+`catppuccin.css` overrides CSS custom properties on `:root` and targets specific elements that fall outside the normal cascade. `webContents.insertCSS()` injects at author-level cascade origin, so all overrides use `!important` to win specificity ties against Apple's own stylesheets after navigation.
 
-```css
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-background: #1e1e2e;
-    --color-text-primary: #cdd6f4;
-    --color-accent: #f38ba8;
-  }
-}
+`@media (prefers-color-scheme: dark)` and `@media (prefers-color-scheme: light)` resolve correctly in Electron's Chromium renderer against `nativeTheme.shouldUseDarkColors`. A single CSS file with both blocks covers both variants.
 
-@media (prefers-color-scheme: light) {
-  :root {
-    --color-background: #eff1f5;
-    --color-text-primary: #4c4f69;
-    --color-accent: #d20f39;
-  }
-}
-```
+#### `:root` variable overrides
 
-The actual variable names must be verified against `music.apple.com`'s live CSS. The above is illustrative.
+Most Apple Music styling responds to `:root` custom property overrides. The CSS file sets colour tokens on `:root` within each `@media (prefers-color-scheme)` block.
+
+#### Elements requiring direct selectors
+
+Several elements render outside the normal `:root` cascade and require direct element selectors:
+
+| Element | Selector | Notes |
+|---------|----------|-------|
+| Player bar background | `.wrapper amp-chrome-player::before` | `::before` pseudo-element paints the bar, ignores `:root` |
+| Side panels (Lyrics + Up Next) | `.side-panel`, `.side-panel-header-wrapper` | Both panels share one container element |
+| Page footer | `.scrollable-page > footer` | Paints its own `background-color` directly |
+| LCD now-playing widget | `amp-lcd { --lcd-bg-color }` | Shadow DOM scoped variable; must be set on the host element, not `:root` |
+
+When a `:root` variable override has no visible effect, the element is either (a) using a shadow-DOM-scoped custom property - set the variable on the host element directly, or (b) painting its own `background-color` via a `::before` pseudo or direct property - use a direct element selector with `!important`.
+
+#### CSS variable audit
+
+A live DevTools audit (`just run-devtools`) is the primary tool for discovering variable names. Active Apple Music userstyle repositories provide reliable cross-referenced variable lists: PitchBlack (`sprince0031/PitchBlack-UserStyle-themes`), Native AM (`dantelin2009`), AppleMusic-Tui.
+
+#### Asset packaging
+
+`asarUnpack` in `package.json` lists files individually (not via glob). Any new CSS asset files read via `fs.readFileSync` at runtime must be added explicitly to `asarUnpack` or they will be inaccessible in packaged builds.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "asar": true,
     "asarUnpack": [
       "assets/icons/**",
+      "assets/catppuccin.css",
       "assets/musicKitHook.js",
       "assets/sidra-logo.png"
     ],

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ interface StoreSchema {
   language: string | null;
   'notifications.enabled': boolean;
   'discord.enabled': boolean;
+  'catppuccin.enabled': boolean;
 }
 
 // electron-store v10 is ESM-only; under CommonJS moduleResolution TypeScript
@@ -67,4 +68,16 @@ export function getDiscordEnabled(): boolean {
 export function setDiscordEnabled(enabled: boolean): void {
   store.set('discord.enabled', enabled);
   configLog.info('discord.enabled set:', enabled);
+}
+
+export function getCatppuccinEnabled(): boolean {
+  if (!store.has('catppuccin.enabled')) {
+    return false;  // default off
+  }
+  return store.get('catppuccin.enabled');
+}
+
+export function setCatppuccinEnabled(enabled: boolean): void {
+  store.set('catppuccin.enabled', enabled);
+  configLog.info('catppuccin.enabled set:', enabled);
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -190,6 +190,43 @@ export const DISCORD_TEXT: Record<string, string> = {
   'he': 'Discord Rich Presence',
 };
 
+// --- "Catppuccin" ---
+export const CATPPUCCIN_TEXT: Record<string, string> = {
+  'en': 'Catppuccin',
+  'zh-CN': 'Catppuccin',
+  'zh-SG': 'Catppuccin',
+  'zh-TW': 'Catppuccin',
+  'zh-HK': 'Catppuccin',
+  'es': 'Catppuccin',
+  'hi': 'Catppuccin',
+  'ar': 'Catppuccin',
+  'fr': 'Catppuccin',
+  'pt': 'Catppuccin',
+  'de': 'Catppuccin',
+  'ru': 'Catppuccin',
+  'ja': 'Catppuccin',
+  'ko': 'Catppuccin',
+  'it': 'Catppuccin',
+  'nl': 'Catppuccin',
+  'pl': 'Catppuccin',
+  'tr': 'Catppuccin',
+  'sv': 'Catppuccin',
+  'da': 'Catppuccin',
+  'fi': 'Catppuccin',
+  'nb': 'Catppuccin',
+  'no': 'Catppuccin',
+  'cs': 'Catppuccin',
+  'ro': 'Catppuccin',
+  'hu': 'Catppuccin',
+  'el': 'Catppuccin',
+  'th': 'Catppuccin',
+  'id': 'Catppuccin',
+  'ms': 'Catppuccin',
+  'uk': 'Catppuccin',
+  'vi': 'Catppuccin',
+  'he': 'Catppuccin',
+};
+
 // --- "Close" ---
 export const CLOSE_TEXT: Record<string, string> = {
   'en': 'Close',
@@ -393,7 +430,7 @@ export function getLoadingText(): { text: string; lang: string } {
   return { text, lang };
 }
 
-export function getTrayStrings(): { about: string; quit: string; notifications: string; discord: string } {
+export function getTrayStrings(): { about: string; quit: string; notifications: string; discord: string; catppuccin: string } {
   const langs = getSystemLanguages();
   const productName: string = pkg.build?.productName ?? app.getName();
   const aboutTemplate = getLocalizedString(ABOUT_TEXT, langs);
@@ -401,7 +438,8 @@ export function getTrayStrings(): { about: string; quit: string; notifications: 
   const quit = getLocalizedString(QUIT_TEXT, langs);
   const notifications = getLocalizedString(NOTIFICATIONS_TEXT, langs);
   const discord = getLocalizedString(DISCORD_TEXT, langs);
-  return { about, quit, notifications, discord };
+  const catppuccin = getLocalizedString(CATPPUCCIN_TEXT, langs);
+  return { about, quit, notifications, discord, catppuccin };
 }
 
 export function getAboutStrings(): {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
-import { app, BrowserWindow, components, ipcMain, Menu, session, shell, Tray } from 'electron';
+import { app, BrowserWindow, components, ipcMain, Menu, nativeTheme, session, shell, Tray } from 'electron';
 import fs from 'fs';
 import path from 'path';
 import log from 'electron-log/main';
-import { getStorefront, setStorefront, getLanguage, setLanguage } from './config';
+import { getStorefront, setStorefront, getLanguage, setLanguage, getCatppuccinEnabled } from './config';
 import { getLoadingText, getStorefront as getLocaleStorefront } from './i18n';
 import { getAssetPath } from './paths';
 import { Player } from './player';
@@ -62,6 +62,9 @@ app.userAgentFallback = UA;
 
 // Prevent garbage collection of tray icon
 let appTray: Tray | null = null;
+
+// Track injected Catppuccin CSS for live toggle
+let catppuccinCssKey: string | null = null;
 
 function buildAppleMusicURL(): string {
   let storefront = getStorefront();
@@ -154,6 +157,10 @@ const STYLE_FIX_CSS = `
   }
 `;
 
+// Apply or remove Catppuccin CSS on the main window.
+// Handles enable, disable, and re-injection (variant change) cases.
+let applyCatppuccinCSS: (enabled: boolean) => Promise<void>;
+
 app.whenReady().then(async () => {
   mainLog.info('app ready, waiting for Widevine CDM...');
 
@@ -220,6 +227,9 @@ app.whenReady().then(async () => {
   // Set UA on the default session (updates navigator.userAgentData Client Hints)
   session.defaultSession.setUserAgent(UA);
 
+  const catppuccinCssPath = getAssetPath('assets', 'catppuccin.css');
+  const CATPPUCCIN_CSS = fs.readFileSync(catppuccinCssPath, 'utf-8');
+
   const win = new BrowserWindow({
     title: 'Sidra',
     width: 1280,
@@ -238,6 +248,31 @@ app.whenReady().then(async () => {
 
   initNotifications(player, () => win);
   initDiscordPresence(player);
+
+  applyCatppuccinCSS = async (enabled: boolean) => {
+    if (enabled && catppuccinCssKey !== null) {
+      await win.webContents.removeInsertedCSS(catppuccinCssKey);
+      catppuccinCssKey = await win.webContents.insertCSS(CATPPUCCIN_CSS);
+      mainLog.debug('Catppuccin CSS re-injected');
+    } else if (enabled) {
+      catppuccinCssKey = await win.webContents.insertCSS(CATPPUCCIN_CSS);
+      mainLog.debug('Catppuccin CSS injected');
+    } else if (catppuccinCssKey !== null) {
+      await win.webContents.removeInsertedCSS(catppuccinCssKey);
+      catppuccinCssKey = null;
+      mainLog.debug('Catppuccin CSS removed');
+    }
+  };
+
+  (app as NodeJS.EventEmitter).on('catppuccin-toggle', (_event: unknown, enabled: boolean) => {
+    void applyCatppuccinCSS(enabled);
+  });
+
+  nativeTheme.on('updated', () => {
+    if (getCatppuccinEnabled()) {
+      void applyCatppuccinCSS(true);
+    }
+  });
 
   Promise.all([minDisplay, cssReady]).then(() => {
     splashLog.info('splash closed');
@@ -262,10 +297,14 @@ app.whenReady().then(async () => {
     event.preventDefault();
   });
 
-  win.webContents.on('did-finish-load', () => {
+  win.webContents.on('did-finish-load', async () => {
     mainLog.info('page loaded:', win.webContents.getURL());
     win.webContents.insertCSS(STYLE_FIX_CSS);
     mainLog.debug('CSS fixes injected');
+    if (getCatppuccinEnabled()) {
+      catppuccinCssKey = await win.webContents.insertCSS(CATPPUCCIN_CSS);
+      mainLog.debug('Catppuccin CSS injected');
+    }
     const hookPath = getAssetPath('assets', 'musicKitHook.js');
     const hookScript = fs.readFileSync(hookPath, 'utf-8');
     win.webContents.executeJavaScript(hookScript);

--- a/src/main.ts
+++ b/src/main.ts
@@ -251,7 +251,11 @@ app.whenReady().then(async () => {
 
   let catppuccinCssOp = Promise.resolve();
   applyCatppuccinCSS = (enabled: boolean) => {
-    catppuccinCssOp = catppuccinCssOp.then(async () => {
+    catppuccinCssOp = catppuccinCssOp
+      .catch((error) => {
+        mainLog.warn('Catppuccin CSS operation failed', error);
+      })
+      .then(async () => {
       if (enabled && catppuccinCssKey !== null) {
         await win.webContents.removeInsertedCSS(catppuccinCssKey);
         catppuccinCssKey = await win.webContents.insertCSS(CATPPUCCIN_CSS);

--- a/src/main.ts
+++ b/src/main.ts
@@ -249,19 +249,23 @@ app.whenReady().then(async () => {
   initNotifications(player, () => win);
   initDiscordPresence(player);
 
-  applyCatppuccinCSS = async (enabled: boolean) => {
-    if (enabled && catppuccinCssKey !== null) {
-      await win.webContents.removeInsertedCSS(catppuccinCssKey);
-      catppuccinCssKey = await win.webContents.insertCSS(CATPPUCCIN_CSS);
-      mainLog.debug('Catppuccin CSS re-injected');
-    } else if (enabled) {
-      catppuccinCssKey = await win.webContents.insertCSS(CATPPUCCIN_CSS);
-      mainLog.debug('Catppuccin CSS injected');
-    } else if (catppuccinCssKey !== null) {
-      await win.webContents.removeInsertedCSS(catppuccinCssKey);
-      catppuccinCssKey = null;
-      mainLog.debug('Catppuccin CSS removed');
-    }
+  let catppuccinCssOp = Promise.resolve();
+  applyCatppuccinCSS = (enabled: boolean) => {
+    catppuccinCssOp = catppuccinCssOp.then(async () => {
+      if (enabled && catppuccinCssKey !== null) {
+        await win.webContents.removeInsertedCSS(catppuccinCssKey);
+        catppuccinCssKey = await win.webContents.insertCSS(CATPPUCCIN_CSS);
+        mainLog.debug('Catppuccin CSS re-injected');
+      } else if (enabled) {
+        catppuccinCssKey = await win.webContents.insertCSS(CATPPUCCIN_CSS);
+        mainLog.debug('Catppuccin CSS injected');
+      } else if (catppuccinCssKey !== null) {
+        await win.webContents.removeInsertedCSS(catppuccinCssKey);
+        catppuccinCssKey = null;
+        mainLog.debug('Catppuccin CSS removed');
+      }
+    });
+    return catppuccinCssOp;
   };
 
   (app as NodeJS.EventEmitter).on('catppuccin-toggle', (_event: unknown, enabled: boolean) => {

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import log from 'electron-log/main';
 import { getTrayStrings, getAboutStrings } from './i18n';
 import { getAssetPath } from './paths';
-import { getNotificationsEnabled, setNotificationsEnabled, getDiscordEnabled, setDiscordEnabled } from './config';
+import { getNotificationsEnabled, setNotificationsEnabled, getDiscordEnabled, setDiscordEnabled, getCatppuccinEnabled, setCatppuccinEnabled } from './config';
 
 const trayLog = log.scope('tray');
 
@@ -92,6 +92,8 @@ function buildContextMenu(tray: Tray): Menu {
   const notifGlyph = notifEnabled ? '●' : '○';
   const discordEnabled = getDiscordEnabled();
   const discordGlyph = discordEnabled ? '●' : '○';
+  const catppuccinEnabled = getCatppuccinEnabled();
+  const catppuccinGlyph = catppuccinEnabled ? '●' : '○';
 
   return Menu.buildFromTemplate([
     {
@@ -113,6 +115,16 @@ function buildContextMenu(tray: Tray): Menu {
       checked: discordEnabled,
       click: (menuItem) => {
         setDiscordEnabled(menuItem.checked);
+        tray.setContextMenu(buildContextMenu(tray));
+      },
+    },
+    {
+      label: isLinux ? `${catppuccinGlyph} ${strings.catppuccin}` : strings.catppuccin,
+      type: 'checkbox',
+      checked: catppuccinEnabled,
+      click: (menuItem) => {
+        setCatppuccinEnabled(menuItem.checked);
+        app.emit('catppuccin-toggle', {}, menuItem.checked);
         tray.setContextMenu(buildContextMenu(tray));
       },
     },


### PR DESCRIPTION
- Add Catppuccin CSS stylesheet with complete colour palette
- Implement getCatppuccinEnabled() and setCatppuccinEnabled() config functions
- Wire Catppuccin CSS injection on window load
- Create applyCatppuccinCSS function for live enable/disable/variant changes
- Add nativeTheme import for potential dark mode integration
- Add i18n strings for Catppuccin theme labels
- Update package.json with theme dependencies

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions