### PR TITLE
fix(mpris): prevent event loop hang on app quit

### DIFF
--- a/src/integrations/mpris/index.ts
+++ b/src/integrations/mpris/index.ts
@@ -696,7 +696,14 @@ function cleanupState(): void {
 function disconnectBus(): void {
   if (bus) {
     mprisLog.info('disconnecting from D-Bus');
+    // bus.disconnect() calls stream.end() which only half-closes the socket.
+    // Force-destroy the underlying stream to release the event loop handle.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stream = (bus as any)._connection?.stream;
     bus.disconnect();
+    if (stream && typeof stream.destroy === 'function') {
+      stream.destroy();
+    }
     bus = null;
   }
   playerIfaceRef = null;


### PR DESCRIPTION
The D-Bus bus.disconnect() method calls stream.end(), which only half-closes the underlying socket. This leaves the socket open with the event loop still holding a reference, blocking Node.js process exit.

Capture the stream via bus._connection.stream before disconnecting, then explicitly call stream.destroy() to force-close the socket and release the event loop handle, allowing clean process shutdown.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
