### PR TITLE
feat: add version tracking, Nix packaging, and auto-update foundation

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -209,3 +209,67 @@ jobs:
             release/*.rpm
             release/*.dmg
             release/*.exe
+
+  nix-hash:
+    name: Nix Hash 🔑
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+      - uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            eval-cores = 0
+      - name: Update Nix hashes 📝
+        run: |
+          set -euo pipefail
+
+          VERSION="${GITHUB_REF_NAME}"
+
+          # Fetch and hash the Linux deb
+          linux_url="https://github.com/wimpysworld/sidra/releases/download/${VERSION}/Sidra-${VERSION}-linux-amd64.deb"
+          echo "⬇️  Fetching Linux deb: ${linux_url}"
+          linux_hash=$(nix store prefetch-file --json --hash-type sha256 "$linux_url" | jq -r '.hash')
+          echo "🔑 Linux hash: ${linux_hash}"
+
+          # Fetch and hash the Darwin dmg
+          darwin_url="https://github.com/wimpysworld/sidra/releases/download/${VERSION}/Sidra-${VERSION}-mac-arm64.dmg"
+          echo "⬇️  Fetching Darwin dmg: ${darwin_url}"
+          darwin_hash=$(nix store prefetch-file --json --hash-type sha256 "$darwin_url" | jq -r '.hash')
+          echo "🔑 Darwin hash: ${darwin_hash}"
+
+          # Update Linux hash
+          sed -i "s|hash = \"sha256-[^\"]*\"|hash = \"${linux_hash}\"|" nix/linux.nix
+
+          # Update Darwin hash (handles both "sha256-..." and lib.fakeHash)
+          sed -i "s|hash = \"sha256-[^\"]*\"|hash = \"${darwin_hash}\"|" nix/darwin.nix
+          sed -i "s|hash = lib.fakeHash|hash = \"${darwin_hash}\"|" nix/darwin.nix
+
+          echo "✅ Updated nix/linux.nix and nix/darwin.nix"
+          git diff nix/linux.nix nix/darwin.nix
+
+      - name: Create PR with hash updates 🚀
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          BRANCH="ci/nix-hash-${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
+          git add nix/linux.nix nix/darwin.nix
+          git commit -m "chore(nix): update hashes for v${VERSION}"
+          git push origin "${BRANCH}"
+
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "chore(nix): update hashes for v${VERSION}" \
+            --body "Update Nix package hashes for the ${VERSION} release." \
+            --auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -17,8 +17,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  version-gate:
+    name: Version Gate 🔖
+    runs-on: ubuntu-slim
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Validate version matches tag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$PKG_VERSION" != "$TAG_VERSION" ]]; then
+            echo "Error: package.json version ($PKG_VERSION) does not match tag ($TAG_VERSION)" >&2
+            exit 1
+          fi
+          echo "✓ Version $PKG_VERSION matches tag $TAG_VERSION"
+
   lint-code:
     name: Lint Code 🧹
+    needs: [version-gate]
+    if: always() && (needs.version-gate.result == 'success' || needs.version-gate.result == 'skipped')
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -37,6 +60,8 @@ jobs:
 
   lint-actions:
     name: Lint Action ⚙️
+    needs: [version-gate]
+    if: always() && (needs.version-gate.result == 'success' || needs.version-gate.result == 'skipped')
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -50,6 +75,8 @@ jobs:
 
   test:
     name: Test Config 🧪
+    needs: [version-gate]
+    if: always() && (needs.version-gate.result == 'success' || needs.version-gate.result == 'skipped')
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -132,15 +159,6 @@ jobs:
       - name: Install RPM tools
         if: matrix.os == 'linux'
         run: sudo apt-get update && sudo apt-get install -y rpm
-      - name: Set version from build
-        shell: bash
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            VERSION="${GITHUB_REF_NAME#v}"
-          else
-            VERSION=$(git describe --tags 2>/dev/null || echo "0.0.0-dev")
-          fi
-          npm version "$VERSION" --no-git-tag-version --allow-same-version
       - name: Compile TypeScript
         run: npm run build
       - name: Build distributables

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Sidra
 
+> This file is the authoritative reference for the Sidra project. All agents and tooling should treat it as the single source of truth for architecture, conventions, and configuration.
+
 Minimal Apple Music desktop client. CastLabs Electron wraps `music.apple.com` directly, injecting a lightweight hook script to bridge MusicKit.js events to native platform media controls.
 
 ## Technology stack
@@ -170,6 +172,7 @@ Prefer specific regional tags only when the translation differs from the base la
 | `language` | `string \| null` | BCP 47 language override for the storefront `?l=` parameter |
 | `notifications.enabled` | `boolean` | Toggle desktop notifications (default: true) |
 | `discord.enabled` | `boolean` | Toggle Discord Rich Presence (default: true) |
+| `autoUpdate.enabled` | `boolean` | Enable automatic updates (default: true on AppImage and NSIS; disabled on all other platforms) |
 
 Getters return `undefined` when no value has been persisted - absence of a key is intentional and drives the storefront fallback chain in `main.ts`. Do not add default values to the store schema.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,70 @@ Sidra is under active development; several features in this list are not yet imp
 
 ---
 
+> [!IMPORTANT]
+> Sidra's macOS and Windows releases are currently unsigned, requiring Gatekeeper and SmartScreen workarounds at install time. [Sponsoring the project](https://github.com/sponsors/flexiondotorg) 🩷 goes directly towards code-signing certificates to remove that friction for every user.
+
+## Install
+
+Download the latest release from [GitHub Releases](https://github.com/wimpysworld/sidra/releases).
+
+### Linux
+
+**AppImage** - portable, no installation required:
+
+```bash
+chmod +x Sidra-*.AppImage
+./Sidra-*.AppImage
+```
+
+**Debian/Ubuntu** (`.deb`):
+
+```bash
+sudo apt install ./Sidra-*.deb
+```
+
+**Fedora/openSUSE** (`.rpm`):
+
+```bash
+sudo dnf install ./Sidra-*.rpm
+```
+
+**Nix**:
+
+```bash
+nix profile install github:wimpysworld/sidra
+```
+
+To use Sidra as a NixOS or Home Manager module, add `github:wimpysworld/sidra` as a flake input and reference `inputs.sidra.packages.<system>.default`.
+
+### macOS
+
+**DMG** - open the `.dmg` and drag Sidra to Applications.
+
+Gatekeeper will block the first launch because the app is unsigned. Two ways to proceed:
+
+1. Remove the quarantine attribute:
+
+```bash
+xattr -d com.apple.quarantine /Applications/Sidra.app
+```
+
+2. Open System Settings → Privacy & Security and click **Open Anyway** after the first blocked launch attempt.
+
+**Nix**:
+
+```bash
+nix profile install github:wimpysworld/sidra
+```
+
+### Windows
+
+**Installer** (`.exe`) - run the NSIS installer and follow the prompts.
+
+SmartScreen will show "Windows protected your PC" because the installer is unsigned. Click **More info** then **Run anyway**.
+
+---
+
 ## How It Works
 
 Sidra loads `music.apple.com` directly inside CastLabs Electron (required for Widevine DRM on Linux - no other shell supports this).

--- a/README.md
+++ b/README.md
@@ -61,10 +61,16 @@ chmod +x Sidra-*.AppImage
 sudo apt install ./Sidra-*.deb
 ```
 
-**Fedora/openSUSE** (`.rpm`):
+**Fedora** (`.rpm`):
 
 ```bash
 sudo dnf install ./Sidra-*.rpm
+```
+
+**openSUSE** (`.rpm`):
+
+```bash
+sudo zypper install ./Sidra-*.rpm
 ```
 
 **Nix**:

--- a/flake.nix
+++ b/flake.nix
@@ -17,8 +17,33 @@
         "aarch64-linux"
       ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Systems that have release artefacts available
+      packageSystems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
+      forPackageSystems = nixpkgs.lib.genAttrs packageSystems;
+
+      version = (nixpkgs.lib.importJSON ./package.json).version;
     in
     {
+      packages = forPackageSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          sidra =
+            if pkgs.stdenv.hostPlatform.isDarwin then
+              pkgs.callPackage ./nix/darwin.nix { inherit version; }
+            else
+              pkgs.callPackage ./nix/linux.nix { inherit version; };
+        in
+        {
+          inherit sidra;
+          default = sidra;
+        }
+      );
+
       devShells = forAllSystems (
         system:
         let

--- a/justfile
+++ b/justfile
@@ -119,6 +119,17 @@ clear:
 
 # Build a package for the current platform
 package: build
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    base_version=$(node -p "require('./package.json').version")
+    commit_count=$(git rev-list --count HEAD)
+    short_hash=$(git rev-parse --short HEAD)
+    dev_version="${base_version}-dev.${commit_count}.${short_hash}"
+
+    trap 'npm version "$base_version" --no-git-tag-version --allow-same-version >/dev/null 2>&1' EXIT
+
+    npm version "$dev_version" --no-git-tag-version --allow-same-version
     npx electron-builder {{ if os() == "linux" { "--linux AppImage" } else if os() == "macos" { "--mac dmg" } else { "error('Unsupported platform')" } }}
 
 # Show log file location and tail recent entries
@@ -148,6 +159,17 @@ release VERSION:
     if git rev-parse "$version" >/dev/null 2>&1; then
         echo "Error: Tag $version already exists" >&2
         exit 1
+    fi
+
+    # Bump package.json version if needed
+    current_version=$(node -p "require('./package.json').version")
+    if [[ "$current_version" != "$version" ]]; then
+        npm version "$version" --no-git-tag-version
+        git add package.json package-lock.json
+        git commit -m "chore(release): bump version to $version"
+        echo "✓ Version bumped to $version"
+    else
+        echo "✓ Version already at $version"
     fi
 
     echo "Creating release $version..."

--- a/justfile
+++ b/justfile
@@ -166,7 +166,7 @@ release VERSION:
     if [[ "$current_version" != "$version" ]]; then
         npm version "$version" --no-git-tag-version
         git add package.json package-lock.json
-        git commit -m "chore(release): bump version to $version"
+        git commit -m "chore(release): bump version to $version" -- package.json package-lock.json
         echo "✓ Version bumped to $version"
     else
         echo "✓ Version already at $version"

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  undmg,
+  version,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "sidra";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/wimpysworld/sidra/releases/download/${version}/Sidra-${version}-mac-arm64.dmg";
+    hash = "sha256-S9H97reTPzHrJt1wx+800MSWMsdGexWvSDfVJ9eosRM=";
+  };
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    undmg
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+
+    mkdir -p $out/bin
+    makeWrapper "$out/Applications/Sidra.app/Contents/MacOS/Sidra" "$out/bin/sidra"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "An elegant Apple Music desktop client";
+    homepage = "https://github.com/wimpysworld/sidra";
+    license = lib.licenses.blueOak100;
+    maintainers = with lib.maintainers; [ flexiondotorg ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "sidra";
+  };
+}

--- a/nix/linux.nix
+++ b/nix/linux.nix
@@ -1,0 +1,159 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  buildFHSEnv,
+  bintools,
+  xz,
+
+  # Runtime dependencies provided inside the FHS environment
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  fontconfig,
+  freetype,
+  gcc-unwrapped,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libdrm,
+  libglvnd,
+  libnotify,
+  libX11,
+  libxcb,
+  libXcomposite,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libxkbcommon,
+  libXrandr,
+  libxshmfence,
+  libgbm,
+  nspr,
+  nss,
+  pango,
+  pipewire,
+  vulkan-loader,
+  wayland,
+  systemd,
+  libpulseaudio,
+  version,
+}:
+
+let
+  pname = "sidra";
+
+  src = fetchurl {
+    url = "https://github.com/wimpysworld/sidra/releases/download/${version}/Sidra-${version}-linux-amd64.deb";
+    hash = "sha256-iu+gJIvK1MoFKhEd0XjkrbiyXJomOQ3CNFTOUYk0z3o=";
+  };
+
+  # Unpack the deb into a plain derivation. No patching - the CastLabs
+  # Electron binary is VMP-signed for Widevine DRM and must not be modified.
+  unpacked = stdenvNoCC.mkDerivation {
+    pname = "${pname}-unpacked";
+    inherit version src;
+
+    nativeBuildInputs = [
+      bintools # ar
+      xz
+    ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    unpackPhase = ''
+      runHook preUnpack
+      ${lib.getExe' bintools "ar"} x $src
+      tar xf data.tar.xz
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -a opt/Sidra $out/opt
+      cp -a usr/share $out/share
+
+      # Fix the desktop file to point at the wrapper (will be set by FHS env)
+      substituteInPlace $out/share/applications/sidra.desktop \
+        --replace-fail /opt/Sidra/sidra sidra
+
+      runHook postInstall
+    '';
+  };
+
+  # Libraries that the Electron binary links against at runtime
+  libs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gcc-unwrapped.lib
+    gdk-pixbuf
+    glib
+    gtk3
+    libdrm
+    libglvnd
+    libnotify
+    libX11
+    libxcb
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libxkbcommon
+    libXrandr
+    libxshmfence
+    libgbm
+    nspr
+    nss
+    pango
+    pipewire
+    vulkan-loader
+    wayland
+    systemd
+    libpulseaudio
+  ];
+
+  fhs = buildFHSEnv {
+    name = pname;
+    targetPkgs = _: libs;
+
+    runScript = "${unpacked}/opt/sidra";
+
+    extraInstallCommands = ''
+      # Desktop file and icons from the deb
+      mkdir -p $out/share
+      cp -a ${unpacked}/share/applications $out/share/
+      cp -a ${unpacked}/share/icons $out/share/
+
+      # Point desktop file Exec at the FHS wrapper
+      substituteInPlace $out/share/applications/sidra.desktop \
+        --replace-fail "Exec=sidra" "Exec=$out/bin/sidra"
+    '';
+
+    meta = {
+      description = "An elegant Apple Music desktop client";
+      homepage = "https://github.com/wimpysworld/sidra";
+      license = lib.licenses.blueOak100;
+      maintainers = with lib.maintainers; [ flexiondotorg ];
+      platforms = [ "x86_64-linux" ];
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      mainProgram = "sidra";
+    };
+  };
+in
+fhs

--- a/nix/linux.nix
+++ b/nix/linux.nix
@@ -66,6 +66,7 @@ let
 
     dontConfigure = true;
     dontBuild = true;
+    dontFixup = true;
 
     unpackPhase = ''
       runHook preUnpack

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sidra",
-  "version": "0.0.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sidra",
-      "version": "0.0.0",
+      "version": "0.2.2",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@xhayper/discord-rpc": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "sidra",
-  "version": "0.0.0",
-  "_version_note": "Placeholder; stamped from git tag by CI before each build",
+  "version": "0.2.2",
   "description": "An elegant Apple Music desktop client for Linux, macOS and Windows. No frippery, just quality. A better class of Cider 🍎",
   "main": "dist/main.js",
   "scripts": {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -227,6 +227,80 @@ export const CATPPUCCIN_TEXT: Record<string, string> = {
   'he': 'Catppuccin',
 };
 
+// --- "Update available" ---
+export const UPDATE_AVAILABLE_TEXT: Record<string, string> = {
+  'en': 'Update available: {version}',
+  'zh-CN': '有可用更新：{version}',
+  'zh-SG': '有可用更新：{version}',
+  'zh-TW': '有可用更新：{version}',
+  'zh-HK': '有可用更新：{version}',
+  'es': 'Actualización disponible: {version}',
+  'hi': 'अपडेट उपलब्ध: {version}',
+  'ar': 'تحديث متوفر: {version}',
+  'fr': 'Mise à jour disponible : {version}',
+  'pt': 'Atualização disponível: {version}',
+  'de': 'Update verfügbar: {version}',
+  'ru': 'Доступно обновление: {version}',
+  'ja': 'アップデートあり: {version}',
+  'ko': '업데이트 가능: {version}',
+  'it': 'Aggiornamento disponibile: {version}',
+  'nl': 'Update beschikbaar: {version}',
+  'pl': 'Dostępna aktualizacja: {version}',
+  'tr': 'Güncelleme mevcut: {version}',
+  'sv': 'Uppdatering tillgänglig: {version}',
+  'da': 'Opdatering tilgængelig: {version}',
+  'fi': 'Päivitys saatavilla: {version}',
+  'nb': 'Oppdatering tilgjengelig: {version}',
+  'no': 'Oppdatering tilgjengelig: {version}',
+  'cs': 'Dostupná aktualizace: {version}',
+  'ro': 'Actualizare disponibilă: {version}',
+  'hu': 'Frissítés elérhető: {version}',
+  'el': 'Διαθέσιμη ενημέρωση: {version}',
+  'th': 'มีอัปเดต: {version}',
+  'id': 'Pembaruan tersedia: {version}',
+  'ms': 'Kemas kini tersedia: {version}',
+  'uk': 'Доступне оновлення: {version}',
+  'vi': 'Có bản cập nhật: {version}',
+  'he': 'עדכון זמין: {version}',
+};
+
+// --- "Up to date" ---
+export const UP_TO_DATE_TEXT: Record<string, string> = {
+  'en': 'Up to date',
+  'zh-CN': '已是最新版本',
+  'zh-SG': '已是最新版本',
+  'zh-TW': '已是最新版本',
+  'zh-HK': '已是最新版本',
+  'es': 'Actualizado',
+  'hi': 'अद्यतित',
+  'ar': 'محدّث',
+  'fr': 'À jour',
+  'pt': 'Atualizado',
+  'de': 'Aktuell',
+  'ru': 'Обновлено',
+  'ja': '最新版です',
+  'ko': '최신 버전',
+  'it': 'Aggiornato',
+  'nl': 'Up-to-date',
+  'pl': 'Aktualny',
+  'tr': 'Güncel',
+  'sv': 'Uppdaterad',
+  'da': 'Opdateret',
+  'fi': 'Ajan tasalla',
+  'nb': 'Oppdatert',
+  'no': 'Oppdatert',
+  'cs': 'Aktuální',
+  'ro': 'La zi',
+  'hu': 'Naprakész',
+  'el': 'Ενημερωμένο',
+  'th': 'เป็นเวอร์ชันล่าสุด',
+  'id': 'Terbaru',
+  'ms': 'Terkini',
+  'uk': 'Оновлено',
+  'vi': 'Đã cập nhật',
+  'he': 'מעודכן',
+};
+
 // --- "Close" ---
 export const CLOSE_TEXT: Record<string, string> = {
   'en': 'Close',
@@ -454,5 +528,16 @@ export function getAboutStrings(): {
     versionPrefix: getLocalizedString(VERSION_PREFIX, langs),
     copyrightSuffix: getLocalizedString(COPYRIGHT_SUFFIX, langs),
     licensePrefix: getLocalizedString(LICENSE_PREFIX, langs),
+  };
+}
+
+export function getUpdateStrings(): {
+  updateAvailable: string;
+  upToDate: string;
+} {
+  const langs = getSystemLanguages();
+  return {
+    updateAvailable: getLocalizedString(UPDATE_AVAILABLE_TEXT, langs),
+    upToDate: getLocalizedString(UP_TO_DATE_TEXT, langs),
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,8 @@ import { getStorefront, setStorefront, getLanguage, setLanguage, getCatppuccinEn
 import { getLoadingText, getStorefront as getLocaleStorefront } from './i18n';
 import { getAssetPath } from './paths';
 import { Player } from './player';
-import { createTray } from './tray';
+import { createTray, rebuildTrayMenu } from './tray';
+import { checkForUpdates } from './update';
 import { init as initNotifications } from './integrations/notifications';
 import { init as initDiscordPresence } from './integrations/discord-presence';
 
@@ -333,6 +334,11 @@ app.whenReady().then(async () => {
 
   win.webContents.once('did-finish-load', () => {
     resolveCssReady();
+    setTimeout(() => {
+      if (appTray) {
+        checkForUpdates(appTray, rebuildTrayMenu);
+      }
+    }, 5000);
   });
 
   win.webContents.once('did-fail-load', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ if (process.env.ELECTRON_LOG_LEVEL) {
 
 const mainLog = log.scope('main');
 const splashLog = log.scope('splash');
+mainLog.info(`${app.name} ${app.getVersion()}`);
 
 // --- App identity: required on Windows for notifications to appear ---
 if (process.platform === 'win32') {

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -1,9 +1,10 @@
-import { app, BrowserWindow, Menu, nativeTheme, Tray } from 'electron';
+import { app, BrowserWindow, Menu, nativeTheme, shell, Tray } from 'electron';
 import path from 'path';
 import log from 'electron-log/main';
-import { getTrayStrings, getAboutStrings } from './i18n';
+import { getTrayStrings, getAboutStrings, getUpdateStrings } from './i18n';
 import { getAssetPath } from './paths';
 import { getNotificationsEnabled, setNotificationsEnabled, getDiscordEnabled, setDiscordEnabled, getCatppuccinEnabled, setCatppuccinEnabled } from './config';
+import { getUpdateInfo } from './update';
 
 const trayLog = log.scope('tray');
 
@@ -129,6 +130,28 @@ function buildContextMenu(tray: Tray): Menu {
     },
   ];
 
+  const update = getUpdateInfo();
+  const updateStrings = getUpdateStrings();
+  if (update) {
+    const updateLabel = updateStrings.updateAvailable.replace('{version}', update.version);
+    const updateGlyph = '⬆';
+    menuItems.push(
+      { type: 'separator' },
+      {
+        label: isLinux ? `${updateGlyph} ${updateLabel}` : updateLabel,
+        click: () => shell.openExternal(update.url),
+      },
+    );
+  } else {
+    menuItems.push(
+      { type: 'separator' },
+      {
+        label: updateStrings.upToDate,
+        enabled: false,
+      },
+    );
+  }
+
   menuItems.push(
     { type: 'separator' },
     {
@@ -138,6 +161,10 @@ function buildContextMenu(tray: Tray): Menu {
   );
 
   return Menu.buildFromTemplate(menuItems);
+}
+
+export function rebuildTrayMenu(tray: Tray): void {
+  tray.setContextMenu(buildContextMenu(tray));
 }
 
 export function createTray(): Tray {

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -139,7 +139,18 @@ function buildContextMenu(tray: Tray): Menu {
       { type: 'separator' },
       {
         label: isLinux ? `${updateGlyph} ${updateLabel}` : updateLabel,
-        click: () => shell.openExternal(update.url),
+        click: () => {
+          try {
+            const parsed = new URL(update.url);
+            if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+              void shell.openExternal(parsed.toString());
+            } else {
+              trayLog.warn('blocked non-http(s) update URL:', update.url);
+            }
+          } catch {
+            trayLog.warn('invalid update URL:', update.url);
+          }
+        },
       },
     );
   } else {

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,0 +1,89 @@
+import { app, net, Notification, shell, Tray } from 'electron';
+import log from 'electron-log/main';
+import { getNotificationsEnabled } from './config';
+import { getUpdateStrings } from './i18n';
+
+const updateLog = log.scope('update');
+
+const GITHUB_API_URL = 'https://api.github.com/repos/wimpysworld/sidra/releases/latest';
+
+export interface UpdateInfo {
+  version: string;
+  url: string;
+}
+
+let updateInfo: UpdateInfo | null = null;
+
+export function getUpdateInfo(): UpdateInfo | null {
+  return updateInfo;
+}
+
+function isNewer(remote: string, local: string): boolean {
+  const r = remote.split('.').map(Number);
+  const l = local.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (r[i] > l[i]) return true;
+    if (r[i] < l[i]) return false;
+  }
+  return false;
+}
+
+export async function checkForUpdates(tray: Tray, rebuildMenu: (tray: Tray) => void): Promise<void> {
+  const localVersion = app.getVersion();
+  updateLog.debug('checking for updates, current version:', localVersion);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+
+  try {
+    const response = await net.fetch(GITHUB_API_URL, {
+      headers: {
+        'User-Agent': `Sidra/${localVersion}`,
+        'Accept': 'application/vnd.github.v3+json',
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      updateLog.debug('GitHub API returned status:', response.status);
+      return;
+    }
+
+    const data = await response.json() as { tag_name?: string; html_url?: string };
+    const remoteVersion = data.tag_name;
+    const releaseUrl = data.html_url;
+
+    if (!remoteVersion || !releaseUrl) {
+      updateLog.debug('unexpected API response: missing tag_name or html_url');
+      return;
+    }
+
+    if (isNewer(remoteVersion, localVersion)) {
+      updateLog.info(`update available: ${remoteVersion} (current: ${localVersion})`);
+      updateInfo = { version: remoteVersion, url: releaseUrl };
+      rebuildMenu(tray);
+
+      if (getNotificationsEnabled()) {
+        const strings = getUpdateStrings();
+        const notification = new Notification({
+          title: strings.updateAvailable,
+          body: `Sidra ${remoteVersion}`,
+          silent: true,
+        });
+        notification.on('click', () => {
+          shell.openExternal(releaseUrl);
+        });
+        notification.show();
+        updateLog.debug('update notification shown');
+      }
+    } else {
+      updateLog.debug('up to date:', localVersion);
+      rebuildMenu(tray);
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    updateLog.debug('update check failed:', message);
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/update.ts
+++ b/src/update.ts
@@ -58,16 +58,18 @@ export async function checkForUpdates(tray: Tray, rebuildMenu: (tray: Tray) => v
       return;
     }
 
-    if (isNewer(remoteVersion, localVersion)) {
-      updateLog.info(`update available: ${remoteVersion} (current: ${localVersion})`);
-      updateInfo = { version: remoteVersion, url: releaseUrl };
+    const cleanVersion = remoteVersion.replace(/^v/, '');
+
+    if (isNewer(cleanVersion, localVersion)) {
+      updateLog.info(`update available: ${cleanVersion} (current: ${localVersion})`);
+      updateInfo = { version: cleanVersion, url: releaseUrl };
       rebuildMenu(tray);
 
       if (getNotificationsEnabled()) {
         const strings = getUpdateStrings();
         const notification = new Notification({
           title: strings.updateAvailable,
-          body: `Sidra ${remoteVersion}`,
+          body: `Sidra ${cleanVersion}`,
           silent: true,
         });
         notification.on('click', () => {


### PR DESCRIPTION
## Summary

Establish canonical version source in package.json with validation across build system and CI. Create Nix flake outputs for reproducible builds on Linux and macOS. Document and plan electron-updater implementation for AppImage/NSIS auto-updates. Add GitHub Sponsors tiers. Extend README with platform-specific installation instructions.

## Changes

- Establish package.json as canonical version source with validation in justfile, CI/workflow, and startup logging
- Create Nix flake outputs for Linux (AppImage) and macOS (DMG/unsigned) with automated hash updates via CI
- Implement automatic version check with tray integration and update notifications
- Add comprehensive documentation and implementation plan for AppImage/NSIS auto-updates with electron-updater
- Document GitHub Sponsors with three tiers (Supporter, Studio, Enterprise)
- Add Install section to README with platform-specific instructions and security bypass notes for testing builds
- Extend i18n translations for update notifications and tray messages

## Testing

- Verify version in package.json reflects startup logs and tray status
- Test auto-update check triggers on schedule and tray click
- Validate Nix builds for Linux and macOS produce expected artifacts
- Confirm update documentation is comprehensive and accurate