### PR TITLE
chore(nix): update hashes for v0.3.0

### DIFF
--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
 
   src = fetchurl {
     url = "https://github.com/wimpysworld/sidra/releases/download/${version}/Sidra-${version}-mac-arm64.dmg";
-    hash = "sha256-S9H97reTPzHrJt1wx+800MSWMsdGexWvSDfVJ9eosRM=";
+    hash = "sha256-i9ZUGMyqQNIA+w+eO06CPEs1l9BERCSNNmipU5JtIic=";
   };
 
   dontPatch = true;

--- a/nix/linux.nix
+++ b/nix/linux.nix
@@ -50,7 +50,7 @@ let
 
   src = fetchurl {
     url = "https://github.com/wimpysworld/sidra/releases/download/${version}/Sidra-${version}-linux-amd64.deb";
-    hash = "sha256-iu+gJIvK1MoFKhEd0XjkrbiyXJomOQ3CNFTOUYk0z3o=";
+    hash = "sha256-juQ4xqH9hHdFQ6JFZLpsa8eHHTtigihVNcKLyWHKzYw=";
   };
 
   # Unpack the deb into a plain derivation. No patching - the CastLabs


### PR DESCRIPTION
Update Nix package hashes for the 0.3.0 release.