### PR TITLE
feat(playback): improve reliability with wedge detector and macOS launch fixes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { checkForUpdates } from './update';
 import { isAutoUpdateSupported, initAutoUpdate } from './autoUpdate';
 import { init as initNotifications } from './integrations/notifications';
 import { init as initDiscordPresence } from './integrations/discord-presence';
+import { init as initWedgeDetector } from './wedgeDetector';
 
 // --- Logging: initialise before anything else ---
 log.initialize();
@@ -262,6 +263,8 @@ app.whenReady().then(async () => {
     const mpris = require('./integrations/mpris');
     mpris.init(player, () => win);
   }
+
+  initWedgeDetector(player, () => win);
 
   let catppuccinCssOp = Promise.resolve();
   applyCatppuccinCSS = (enabled: boolean) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,9 @@ if (process.platform === 'linux') {
   mainLog.info('Linux platform switches applied');
 }
 
+// Ensure Discord IPC socket path resolves correctly on macOS GUI launch
+if (process.platform === 'darwin') process.env.TMPDIR = app.getPath('temp');
+
 // Use a platform-accurate Chrome UA, stripping Electron identifiers that
 // Apple Music detects and blocks. The platform component must be truthful
 // to match Sec-CH-UA-Platform Client Hints sent on every request.

--- a/src/main.ts
+++ b/src/main.ts
@@ -175,18 +175,17 @@ let applyCatppuccinCSS: (enabled: boolean) => Promise<void>;
 app.whenReady().then(async () => {
   mainLog.info('app ready, waiting for Widevine CDM...');
 
-  const menuTemplate: Electron.MenuItemConstructorOptions[] = [];
-  if (process.platform === 'darwin') {
-    menuTemplate.push({ role: 'appMenu' });
-  }
-  menuTemplate.push({ role: 'editMenu' });
   if (process.env.SIDRA_DEVTOOLS === '1') {
-    menuTemplate.push({
-      label: 'View',
-      submenu: [{ role: 'toggleDevTools' }],
-    });
+    const menuTemplate: Electron.MenuItemConstructorOptions[] = [
+      {
+        label: 'View',
+        submenu: [{ role: 'toggleDevTools' }],
+      },
+    ];
+    Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
+  } else {
+    Menu.setApplicationMenu(null);
   }
-  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
   mainLog.info('application menu set');
 
   const player = new Player();

--- a/src/wedgeDetector.ts
+++ b/src/wedgeDetector.ts
@@ -1,0 +1,78 @@
+import { app, BrowserWindow } from 'electron';
+import log from 'electron-log/main';
+import { Player } from './player';
+
+const wedgeLog = log.scope('wedge');
+
+const STALL_THRESHOLD_MS = 5000;
+const END_SAFETY_MARGIN_MS = 10000;
+const CHECK_INTERVAL_MS = 1000;
+const MAX_SKIP_ATTEMPTS = 3;
+
+let isPlaying = false;
+let lastPositionUs = 0;
+let lastAdvanceTime = 0;
+let durationMs = 0;
+let checkTimer: ReturnType<typeof setInterval> | null = null;
+let skipAttempts = 0;
+
+function startTimer(getWin: () => BrowserWindow | null): void {
+  if (checkTimer) return;
+  checkTimer = setInterval(() => checkForWedge(getWin), CHECK_INTERVAL_MS);
+}
+
+function stopTimer(): void {
+  if (checkTimer) {
+    clearInterval(checkTimer);
+    checkTimer = null;
+  }
+}
+
+function checkForWedge(getWin: () => BrowserWindow | null): void {
+  if (!isPlaying) return;
+  if (Date.now() - lastAdvanceTime < STALL_THRESHOLD_MS) return;
+  if (durationMs > 0 && (durationMs - lastPositionUs / 1000) < END_SAFETY_MARGIN_MS) return;
+  if (skipAttempts >= MAX_SKIP_ATTEMPTS) return;
+
+  skipAttempts++;
+  lastAdvanceTime = Date.now();
+  wedgeLog.warn(`playback stalled, skipping forward (attempt ${skipAttempts}/${MAX_SKIP_ATTEMPTS})`);
+
+  getWin()?.webContents.executeJavaScript('window.__sidra.next()').catch((err: unknown) => {
+    wedgeLog.warn('skip forward failed:', err);
+  });
+}
+
+export function init(player: Player, getWin: () => BrowserWindow | null): void {
+  player.on('playbackStateDidChange', (payload: unknown) => {
+    const p = payload as { state: number } | null;
+    isPlaying = p?.state === 2;
+    lastAdvanceTime = Date.now();
+    skipAttempts = 0;
+
+    if (isPlaying) {
+      startTimer(getWin);
+    } else {
+      stopTimer();
+    }
+  });
+
+  player.on('nowPlayingItemDidChange', (payload: unknown) => {
+    const p = payload as { durationInMillis?: number } | null;
+    durationMs = p?.durationInMillis ?? 0;
+    lastPositionUs = 0;
+    lastAdvanceTime = Date.now();
+    skipAttempts = 0;
+  });
+
+  player.on('playbackTimeDidChange', (payload: unknown) => {
+    if (typeof payload === 'number' && payload !== lastPositionUs) {
+      lastPositionUs = payload;
+      lastAdvanceTime = Date.now();
+    }
+  });
+
+  app.on('will-quit', () => stopTimer());
+
+  wedgeLog.info('wedge detector initialised');
+}


### PR DESCRIPTION
## Summary
Improves playback reliability and macOS launch stability. Adds a wedge detector mechanism to recover from music playback stalls, fixes Discord IPC socket path issues on macOS, and simplifies menu initialization logic based on devtools environment.

## Changes
- Add wedge detector to recover from music playback stalls
- Set TMPDIR on macOS to resolve Discord IPC socket path issues
- Simplify menu initialization based on devtools environment

## Testing
- Verify playback stall recovery triggers appropriately
- Confirm Discord IPC socket connectivity on macOS
- Test menu initialization with and without devtools enabled