### PR TITLE
feat(nav): add browser controls to sidebar header

### DIFF
--- a/assets/catppuccin.css
+++ b/assets/catppuccin.css
@@ -98,9 +98,20 @@
     box-shadow: none !important;
   }
 
-  /* Force --playerBGFill into shadow-DOM-scoped elements */
+  /* Force variables into shadow-DOM-scoped elements */
   * {
     --playerBGFill: rgba(24, 24, 37, 0.88) !important;
+    --keyColor: #f38ba8 !important;
+    --keyColor-rgb: 243,139,168 !important;
+    --keyColor-rollover: #eba0ac !important;
+    --keyColor-pressed: #eba0ac !important;
+    --keyColor-deepPressed: #eba0ac !important;
+    --keyColor-disabled: rgba(243,139,168,0.35) !important;
+    --musicKeyColor: #f38ba8 !important;
+    --systemAccentBG: #f38ba8 !important;
+    --musicBrandBG: #f38ba8 !important;
+    --selectionColor: #f38ba8 !important;
+    --lovedBGColor: #f38ba8 !important;
   }
 
   /* Side panels (Lyrics + Up Next): not covered by :root variables */
@@ -220,6 +231,17 @@
 
   * {
     --playerBGFill: rgba(230, 233, 239, 0.88) !important;
+    --keyColor: #d20f39 !important;
+    --keyColor-rgb: 210,15,57 !important;
+    --keyColor-rollover: #e64553 !important;
+    --keyColor-pressed: #e64553 !important;
+    --keyColor-deepPressed: #e64553 !important;
+    --keyColor-disabled: rgba(210,15,57,0.35) !important;
+    --musicKeyColor: #d20f39 !important;
+    --systemAccentBG: #d20f39 !important;
+    --musicBrandBG: #d20f39 !important;
+    --selectionColor: #d20f39 !important;
+    --lovedBGColor: #d20f39 !important;
   }
 
   /* Side panels (Lyrics + Up Next): not covered by :root variables */
@@ -242,4 +264,9 @@
   .scrollable-page > footer {
     background-color: #dce0e8 !important;
   }
+}
+
+/* Override hardcoded primary button background to use Catppuccin accent */
+.button.primary button.click-action {
+  background-color: var(--keyColor) !important;
 }

--- a/assets/navigationBar.js
+++ b/assets/navigationBar.js
@@ -1,0 +1,78 @@
+(function () {
+  if (document.getElementById('sidra-nav-buttons')) return;
+
+  const logoEl = document.querySelector('.navigation__header .logo');
+  if (!logoEl) {
+    console.warn('Sidra: .navigation__header .logo not found');
+    return;
+  }
+
+  logoEl.setAttribute('style', [
+    'display: flex !important',
+    'align-items: center !important',
+    'justify-content: space-between !important',
+  ].join('; '));
+
+  const container = document.createElement('div');
+  container.id = 'sidra-nav-buttons';
+  container.setAttribute('style', [
+    'display: flex !important',
+    'align-items: center !important',
+    'gap: 4px !important',
+    'margin-left: auto !important',
+    'pointer-events: auto !important',
+  ].join('; '));
+
+  function createButton(label, svgContent, channel) {
+    const btn = document.createElement('button');
+    btn.setAttribute('aria-label', label);
+    btn.setAttribute('style', [
+      'background: none !important',
+      'border: none !important',
+      'cursor: pointer !important',
+      'padding: 6px !important',
+      'border-radius: 6px !important',
+      'display: flex !important',
+      'align-items: center !important',
+      'justify-content: center !important',
+      'color: var(--systemPrimary, #ffffff) !important',
+      'opacity: 0.7 !important',
+      'transition: opacity 0.15s ease, color 0.15s ease !important',
+    ].join('; '));
+
+    btn.innerHTML = svgContent;
+
+    btn.addEventListener('mouseenter', function () {
+      this.style.setProperty('opacity', '1', 'important');
+      this.style.setProperty('color', 'var(--keyColor, #fa586a)', 'important');
+      var svg = this.querySelector('svg');
+      if (svg) svg.style.setProperty('stroke', 'var(--keyColor, #fa586a)', 'important');
+    });
+    btn.addEventListener('mouseleave', function () {
+      this.style.setProperty('opacity', '0.7', 'important');
+      this.style.setProperty('color', 'var(--systemPrimary, #ffffff)', 'important');
+      var svg = this.querySelector('svg');
+      if (svg) svg.style.setProperty('stroke', 'var(--systemPrimary, #ffffff)', 'important');
+    });
+
+    btn.addEventListener('click', function () {
+      window.AMWrapper.ipcRenderer.send(channel);
+    });
+
+    return btn;
+  }
+
+  var svgAttrs = 'xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--systemPrimary, #ffffff)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"';
+
+  var backSvg = '<svg ' + svgAttrs + '><polyline points="15 18 9 12 15 6"></polyline></svg>';
+  var forwardSvg = '<svg ' + svgAttrs + '><polyline points="9 6 15 12 9 18"></polyline></svg>';
+  var reloadSvg = '<svg ' + svgAttrs + '><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>';
+
+  container.appendChild(createButton('Back', backSvg, 'nav:back'));
+  container.appendChild(createButton('Forward', forwardSvg, 'nav:forward'));
+  container.appendChild(createButton('Reload', reloadSvg, 'nav:reload'));
+
+  logoEl.appendChild(container);
+
+  console.log('[Sidra] Navigation bar injected');
+})();

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
       "assets/icons/**",
       "assets/catppuccin.css",
       "assets/musicKitHook.js",
+      "assets/navigationBar.js",
       "assets/sidra-logo.png"
     ],
     "icon": "build/icon.png",

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import { checkForUpdates } from './update';
 import { isAutoUpdateSupported, initAutoUpdate } from './autoUpdate';
 import { init as initNotifications } from './integrations/notifications';
 import { init as initDiscordPresence } from './integrations/discord-presence';
-import { init as initWedgeDetector } from './wedgeDetector';
+import { init as initWedgeDetector, reset as resetWedgeDetector } from './wedgeDetector';
 
 // --- Logging: initialise before anything else ---
 log.initialize();
@@ -261,7 +261,10 @@ app.whenReady().then(async () => {
 
   ipcMain.on('nav:back', () => win.webContents.navigationHistory.goBack());
   ipcMain.on('nav:forward', () => win.webContents.navigationHistory.goForward());
-  ipcMain.on('nav:reload', () => win.webContents.reload());
+  ipcMain.on('nav:reload', () => {
+    resetWedgeDetector();
+    win.webContents.reload();
+  });
 
   // MPRIS D-Bus service (Linux only) - uses require() to avoid loading dbus-next on other platforms
   if (process.platform === 'linux') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -259,6 +259,10 @@ app.whenReady().then(async () => {
   initNotifications(player, () => win);
   initDiscordPresence(player);
 
+  ipcMain.on('nav:back', () => win.webContents.navigationHistory.goBack());
+  ipcMain.on('nav:forward', () => win.webContents.navigationHistory.goForward());
+  ipcMain.on('nav:reload', () => win.webContents.reload());
+
   // MPRIS D-Bus service (Linux only) - uses require() to avoid loading dbus-next on other platforms
   if (process.platform === 'linux') {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -336,6 +340,10 @@ app.whenReady().then(async () => {
     const hookScript = fs.readFileSync(hookPath, 'utf-8');
     win.webContents.executeJavaScript(hookScript);
     mainLog.debug('MusicKit hook injected');
+    const navBarPath = getAssetPath('assets', 'navigationBar.js');
+    const navBarScript = fs.readFileSync(navBarPath, 'utf-8');
+    win.webContents.executeJavaScript(navBarScript);
+    mainLog.debug('Navigation bar injected');
   });
 
   win.webContents.once('did-finish-load', () => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -9,6 +9,9 @@ const SEND_CHANNELS = new Set<string>([
   'repeatModeDidChange',
   'shuffleModeDidChange',
   'volumeDidChange',
+  'nav:back',
+  'nav:forward',
+  'nav:reload',
 ]);
 
 /**

--- a/src/wedgeDetector.ts
+++ b/src/wedgeDetector.ts
@@ -43,6 +43,12 @@ function checkForWedge(getWin: () => BrowserWindow | null): void {
   });
 }
 
+export function reset(): void {
+  isPlaying = false;
+  skipAttempts = 0;
+  stopTimer();
+}
+
 export function init(player: Player, getWin: () => BrowserWindow | null): void {
   player.on('playbackStateDidChange', (payload: unknown) => {
     const p = payload as { state: number } | null;


### PR DESCRIPTION
- Inject Back, Forward, Reload buttons in navigation header logo row
- Wire buttons to Electron navigationHistory API via IPC
- Buttons positioned right of Apple Music wordmark, adapt to light/dark themes