### PR TITLE
feat(tray): add configurable start page with last session memory

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,8 @@ interface StoreSchema {
   'discord.enabled': boolean;
   'catppuccin.enabled': boolean;
   'autoUpdate.enabled': boolean;
-  startPage: 'home' | 'new' | 'radio' | 'all-playlists';
+  startPage: 'home' | 'new' | 'radio' | 'all-playlists' | 'last';
+  lastPageUrl: string;
 }
 
 // electron-store v10 is ESM-only; under CommonJS moduleResolution TypeScript
@@ -96,14 +97,26 @@ export function setAutoUpdateEnabled(enabled: boolean): void {
   configLog.info('autoUpdate.enabled set:', enabled);
 }
 
-export function getStartPage(): 'home' | 'new' | 'radio' | 'all-playlists' {
+export function getLastPageUrl(): string | undefined {
+  if (!store.has('lastPageUrl')) {
+    return undefined;
+  }
+  return store.get('lastPageUrl');
+}
+
+export function setLastPageUrl(url: string): void {
+  store.set('lastPageUrl', url);
+  configLog.info('lastPageUrl set:', url);
+}
+
+export function getStartPage(): 'home' | 'new' | 'radio' | 'all-playlists' | 'last' {
   if (!store.has('startPage')) {
     return 'new';
   }
   return store.get('startPage');
 }
 
-export function setStartPage(page: 'home' | 'new' | 'radio' | 'all-playlists'): void {
+export function setStartPage(page: 'home' | 'new' | 'radio' | 'all-playlists' | 'last'): void {
   store.set('startPage', page);
   configLog.info('startPage set:', page);
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -412,6 +412,154 @@ export const CATPPUCCIN_TEXT: Record<string, string> = {
   'he': 'Catppuccin',
 };
 
+// --- "On" ---
+export const ON_TEXT: Record<string, string> = {
+  'en': 'On',
+  'zh-CN': '开启',
+  'zh-SG': '开启',
+  'zh-TW': '開啟',
+  'zh-HK': '開啟',
+  'es': 'Activado',
+  'hi': 'चालू',
+  'ar': 'مفعّل',
+  'fr': 'Activé',
+  'pt': 'Ligado',
+  'de': 'Ein',
+  'ru': 'Вкл.',
+  'ja': 'オン',
+  'ko': '켜짐',
+  'it': 'Attivo',
+  'nl': 'Aan',
+  'pl': 'Włączone',
+  'tr': 'Açık',
+  'sv': 'På',
+  'da': 'Til',
+  'fi': 'Päällä',
+  'nb': 'På',
+  'no': 'På',
+  'cs': 'Zapnuto',
+  'ro': 'Activat',
+  'hu': 'Be',
+  'el': 'Ενεργό',
+  'th': 'เปิด',
+  'id': 'Aktif',
+  'ms': 'Hidup',
+  'uk': 'Увімк.',
+  'vi': 'Bật',
+  'he': 'מופעל',
+};
+
+// --- "Off" ---
+export const OFF_TEXT: Record<string, string> = {
+  'en': 'Off',
+  'zh-CN': '关闭',
+  'zh-SG': '关闭',
+  'zh-TW': '關閉',
+  'zh-HK': '關閉',
+  'es': 'Desactivado',
+  'hi': 'बंद',
+  'ar': 'معطّل',
+  'fr': 'Désactivé',
+  'pt': 'Desligado',
+  'de': 'Aus',
+  'ru': 'Выкл.',
+  'ja': 'オフ',
+  'ko': '꺼짐',
+  'it': 'Disattivo',
+  'nl': 'Uit',
+  'pl': 'Wyłączone',
+  'tr': 'Kapalı',
+  'sv': 'Av',
+  'da': 'Fra',
+  'fi': 'Pois',
+  'nb': 'Av',
+  'no': 'Av',
+  'cs': 'Vypnuto',
+  'ro': 'Dezactivat',
+  'hu': 'Ki',
+  'el': 'Ανενεργό',
+  'th': 'ปิด',
+  'id': 'Nonaktif',
+  'ms': 'Mati',
+  'uk': 'Вимк.',
+  'vi': 'Tắt',
+  'he': 'כבוי',
+};
+
+// --- "Style" ---
+export const STYLE_TEXT: Record<string, string> = {
+  'en': 'Style',
+  'zh-CN': '样式',
+  'zh-SG': '样式',
+  'zh-TW': '樣式',
+  'zh-HK': '樣式',
+  'es': 'Estilo',
+  'hi': 'शैली',
+  'ar': 'النمط',
+  'fr': 'Style',
+  'pt': 'Estilo',
+  'de': 'Stil',
+  'ru': 'Стиль',
+  'ja': 'スタイル',
+  'ko': '스타일',
+  'it': 'Stile',
+  'nl': 'Stijl',
+  'pl': 'Styl',
+  'tr': 'Stil',
+  'sv': 'Stil',
+  'da': 'Stil',
+  'fi': 'Tyyli',
+  'nb': 'Stil',
+  'no': 'Stil',
+  'cs': 'Styl',
+  'ro': 'Stil',
+  'hu': 'Stílus',
+  'el': 'Στυλ',
+  'th': 'สไตล์',
+  'id': 'Gaya',
+  'ms': 'Gaya',
+  'uk': 'Стиль',
+  'vi': 'Kiểu',
+  'he': 'סגנון',
+};
+
+// --- "Apple Music" ---
+export const STYLE_APPLE_MUSIC_TEXT: Record<string, string> = {
+  'en': 'Apple Music',
+  'zh-CN': 'Apple Music',
+  'zh-SG': 'Apple Music',
+  'zh-TW': 'Apple Music',
+  'zh-HK': 'Apple Music',
+  'es': 'Apple Music',
+  'hi': 'Apple Music',
+  'ar': 'Apple Music',
+  'fr': 'Apple Music',
+  'pt': 'Apple Music',
+  'de': 'Apple Music',
+  'ru': 'Apple Music',
+  'ja': 'Apple Music',
+  'ko': 'Apple Music',
+  'it': 'Apple Music',
+  'nl': 'Apple Music',
+  'pl': 'Apple Music',
+  'tr': 'Apple Music',
+  'sv': 'Apple Music',
+  'da': 'Apple Music',
+  'fi': 'Apple Music',
+  'nb': 'Apple Music',
+  'no': 'Apple Music',
+  'cs': 'Apple Music',
+  'ro': 'Apple Music',
+  'hu': 'Apple Music',
+  'el': 'Apple Music',
+  'th': 'Apple Music',
+  'id': 'Apple Music',
+  'ms': 'Apple Music',
+  'uk': 'Apple Music',
+  'vi': 'Apple Music',
+  'he': 'Apple Music',
+};
+
 // --- "Update available" ---
 export const UPDATE_AVAILABLE_TEXT: Record<string, string> = {
   'en': 'Update available: {version}',
@@ -800,7 +948,7 @@ export function getLoadingText(): { text: string; lang: string } {
   return { text, lang };
 }
 
-export function getTrayStrings(): { about: string; quit: string; notifications: string; discord: string; startPage: string; startPageHome: string; startPageNew: string; startPageRadio: string; startPageAllPlaylists: string; catppuccin: string } {
+export function getTrayStrings(): { about: string; quit: string; notifications: string; discord: string; startPage: string; startPageHome: string; startPageNew: string; startPageRadio: string; startPageAllPlaylists: string; catppuccin: string; on: string; off: string; style: string; styleAppleMusic: string } {
   const langs = getSystemLanguages();
   const productName: string = pkg.build?.productName ?? app.getName();
   const aboutTemplate = getLocalizedString(ABOUT_TEXT, langs);
@@ -814,7 +962,11 @@ export function getTrayStrings(): { about: string; quit: string; notifications: 
   const startPageRadio = getLocalizedString(START_PAGE_RADIO_TEXT, langs);
   const startPageAllPlaylists = getLocalizedString(START_PAGE_ALL_PLAYLISTS_TEXT, langs);
   const catppuccin = getLocalizedString(CATPPUCCIN_TEXT, langs);
-  return { about, quit, notifications, discord, startPage, startPageHome, startPageNew, startPageRadio, startPageAllPlaylists, catppuccin };
+  const on = getLocalizedString(ON_TEXT, langs);
+  const off = getLocalizedString(OFF_TEXT, langs);
+  const style = getLocalizedString(STYLE_TEXT, langs);
+  const styleAppleMusic = getLocalizedString(STYLE_APPLE_MUSIC_TEXT, langs);
+  return { about, quit, notifications, discord, startPage, startPageHome, startPageNew, startPageRadio, startPageAllPlaylists, catppuccin, on, off, style, styleAppleMusic };
 }
 
 export function getAboutStrings(): {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -375,6 +375,43 @@ export const START_PAGE_ALL_PLAYLISTS_TEXT: Record<string, string> = {
   'he': 'כל הפלייליסטים',
 };
 
+// --- "Last session" ---
+export const START_PAGE_LAST_TEXT: Record<string, string> = {
+  'en': 'Last session',
+  'zh-CN': '上次会话',
+  'zh-SG': '上次会话',
+  'zh-TW': '上次工作階段',
+  'zh-HK': '上次工作階段',
+  'es': 'Última sesión',
+  'hi': 'पिछला सत्र',
+  'ar': 'الجلسة الأخيرة',
+  'fr': 'Dernière session',
+  'pt': 'Última sessão',
+  'de': 'Letzte Sitzung',
+  'ru': 'Последний сеанс',
+  'ja': '前回のセッション',
+  'ko': '마지막 세션',
+  'it': 'Ultima sessione',
+  'nl': 'Laatste sessie',
+  'pl': 'Ostatnia sesja',
+  'tr': 'Son oturum',
+  'sv': 'Senaste session',
+  'da': 'Sidste session',
+  'fi': 'Edellinen istunto',
+  'nb': 'Forrige økt',
+  'no': 'Forrige økt',
+  'cs': 'Poslední relace',
+  'ro': 'Ultima sesiune',
+  'hu': 'Utolsó munkamenet',
+  'el': 'Τελευταία συνεδρία',
+  'th': 'เซสชันล่าสุด',
+  'id': 'Sesi terakhir',
+  'ms': 'Sesi terakhir',
+  'uk': 'Останній сеанс',
+  'vi': 'Phiên trước',
+  'he': 'הפעלה אחרונה',
+};
+
 // --- "Catppuccin" ---
 export const CATPPUCCIN_TEXT: Record<string, string> = {
   'en': 'Catppuccin',
@@ -948,7 +985,7 @@ export function getLoadingText(): { text: string; lang: string } {
   return { text, lang };
 }
 
-export function getTrayStrings(): { about: string; quit: string; notifications: string; discord: string; startPage: string; startPageHome: string; startPageNew: string; startPageRadio: string; startPageAllPlaylists: string; catppuccin: string; on: string; off: string; style: string; styleAppleMusic: string } {
+export function getTrayStrings(): { about: string; quit: string; notifications: string; discord: string; startPage: string; startPageHome: string; startPageNew: string; startPageRadio: string; startPageAllPlaylists: string; startPageLast: string; catppuccin: string; on: string; off: string; style: string; styleAppleMusic: string } {
   const langs = getSystemLanguages();
   const productName: string = pkg.build?.productName ?? app.getName();
   const aboutTemplate = getLocalizedString(ABOUT_TEXT, langs);
@@ -961,12 +998,13 @@ export function getTrayStrings(): { about: string; quit: string; notifications: 
   const startPageNew = getLocalizedString(START_PAGE_NEW_TEXT, langs);
   const startPageRadio = getLocalizedString(START_PAGE_RADIO_TEXT, langs);
   const startPageAllPlaylists = getLocalizedString(START_PAGE_ALL_PLAYLISTS_TEXT, langs);
+  const startPageLast = getLocalizedString(START_PAGE_LAST_TEXT, langs);
   const catppuccin = getLocalizedString(CATPPUCCIN_TEXT, langs);
   const on = getLocalizedString(ON_TEXT, langs);
   const off = getLocalizedString(OFF_TEXT, langs);
   const style = getLocalizedString(STYLE_TEXT, langs);
   const styleAppleMusic = getLocalizedString(STYLE_APPLE_MUSIC_TEXT, langs);
-  return { about, quit, notifications, discord, startPage, startPageHome, startPageNew, startPageRadio, startPageAllPlaylists, catppuccin, on, off, style, styleAppleMusic };
+  return { about, quit, notifications, discord, startPage, startPageHome, startPageNew, startPageRadio, startPageAllPlaylists, startPageLast, catppuccin, on, off, style, styleAppleMusic };
 }
 
 export function getAboutStrings(): {

--- a/src/main.ts
+++ b/src/main.ts
@@ -246,6 +246,8 @@ app.whenReady().then(async () => {
 
   const catppuccinCssPath = getAssetPath('assets', 'catppuccin.css');
   const CATPPUCCIN_CSS = fs.readFileSync(catppuccinCssPath, 'utf-8');
+  const navBarPath = getAssetPath('assets', 'navigationBar.js');
+  const navBarScript = fs.readFileSync(navBarPath, 'utf-8');
 
   const win = new BrowserWindow({
     title: 'Sidra',
@@ -350,8 +352,6 @@ app.whenReady().then(async () => {
     const hookScript = fs.readFileSync(hookPath, 'utf-8');
     win.webContents.executeJavaScript(hookScript);
     mainLog.debug('MusicKit hook injected');
-    const navBarPath = getAssetPath('assets', 'navigationBar.js');
-    const navBarScript = fs.readFileSync(navBarPath, 'utf-8');
     win.webContents.executeJavaScript(navBarScript);
     mainLog.debug('Navigation bar injected');
   });
@@ -388,6 +388,7 @@ app.whenReady().then(async () => {
   });
   win.webContents.on('did-navigate-in-page', (_event, url) => {
     handleStorefrontNavigation(url);
+    win.webContents.executeJavaScript(navBarScript);
   });
 
   win.webContents.on('will-prevent-unload', (event) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, components, ipcMain, Menu, nativeTheme, session, sh
 import fs from 'fs';
 import path from 'path';
 import log from 'electron-log/main';
-import { getStorefront, setStorefront, getLanguage, setLanguage, getCatppuccinEnabled, getStartPage } from './config';
+import { getStorefront, setStorefront, getLanguage, setLanguage, getCatppuccinEnabled, getStartPage, getLastPageUrl, setLastPageUrl } from './config';
 import { getLoadingText, getStorefront as getLocaleStorefront } from './i18n';
 import { getAssetPath } from './paths';
 import { Player } from './player';
@@ -90,15 +90,29 @@ function buildAppleMusicURL(): string {
 
   mainLog.info(`storefront resolved: ${storefront} (${source})`);
 
+  const language = getLanguage();
+  const startPage = getStartPage();
+
+  if (startPage === 'last') {
+    const lastPath = getLastPageUrl();
+    if (lastPath) {
+      let url = `https://music.apple.com/${storefront}/${lastPath}`;
+      if (language !== undefined && language !== null) {
+        url += `?l=${language}`;
+      }
+      return url;
+    }
+    // fall through: no stored path yet, use 'new'
+  }
+
   const pagePathMap: Record<string, string> = {
     'home': 'home',
     'new': 'new',
     'radio': 'radio',
     'all-playlists': 'library/all-playlists/',
   };
-  const pagePath = pagePathMap[getStartPage()];
+  const pagePath = pagePathMap[startPage] ?? pagePathMap['new'];
   let url = `https://music.apple.com/${storefront}/${pagePath}`;
-  const language = getLanguage();
   if (language !== undefined && language !== null) {
     url += `?l=${language}`;
   }
@@ -388,6 +402,10 @@ app.whenReady().then(async () => {
   });
   win.webContents.on('did-navigate-in-page', (_event, url) => {
     handleStorefrontNavigation(url);
+    if (url.includes('music.apple.com')) {
+      const match = url.match(/music\.apple\.com\/(?:[a-z]{2,3}\/)?([^?#]+)/);
+      if (match) setLastPageUrl(match[1]);
+    }
     win.webContents.executeJavaScript(navBarScript);
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -402,9 +402,15 @@ app.whenReady().then(async () => {
   });
   win.webContents.on('did-navigate-in-page', (_event, url) => {
     handleStorefrontNavigation(url);
-    if (url.includes('music.apple.com')) {
-      const match = url.match(/music\.apple\.com\/(?:[a-z]{2,3}\/)?([^?#]+)/);
-      if (match) setLastPageUrl(match[1]);
+    try {
+      const parsed = new URL(url);
+      if (parsed.hostname === 'music.apple.com') {
+        const segments = parsed.pathname.split('/').filter(Boolean);
+        const pageSegments = segments[0] && /^[a-z]{2}$/.test(segments[0]) ? segments.slice(1) : segments;
+        if (pageSegments.length > 0) setLastPageUrl(pageSegments.join('/'));
+      }
+    } catch {
+      mainLog.warn('failed to parse URL for last-page tracking:', url);
     }
     win.webContents.executeJavaScript(navBarScript);
   });

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -91,43 +91,71 @@ function buildContextMenu(tray: Tray): Menu {
   const quitGlyph = '🆇';
   const isLinux = process.platform === 'linux';
   const notifEnabled = getNotificationsEnabled();
-  const notifGlyph = notifEnabled ? '●' : '○';
   const discordEnabled = getDiscordEnabled();
-  const discordGlyph = discordEnabled ? '●' : '○';
   const catppuccinEnabled = getCatppuccinEnabled();
-  const catppuccinGlyph = catppuccinEnabled ? '●' : '○';
+
+  const notifGlyph = '🕭';
+  const notifParentLabel = `${strings.notifications}: ${notifEnabled ? strings.on : strings.off}`;
+  const discordGlyph = '🗫';
+  const discordParentLabel = `${strings.discord}: ${discordEnabled ? strings.on : strings.off}`;
+  const styleGlyph = '🌢';
+  const styleParentLabel = `${strings.style}: ${catppuccinEnabled ? strings.catppuccin : strings.styleAppleMusic}`;
+
   const menuItems: Electron.MenuItemConstructorOptions[] = [
     {
       label: isLinux ? `${aboutGlyph} ${strings.about}` : strings.about,
       click: () => showAboutWindow(),
     },
     {
-      label: isLinux ? `${notifGlyph} ${strings.notifications}` : strings.notifications,
-      type: 'checkbox',
-      checked: notifEnabled,
-      click: (menuItem) => {
-        setNotificationsEnabled(menuItem.checked);
-        tray.setContextMenu(buildContextMenu(tray));
-      },
+      label: isLinux ? `${notifGlyph} ${notifParentLabel}` : notifParentLabel,
+      submenu: [
+        {
+          label: strings.on,
+          type: 'radio',
+          checked: notifEnabled,
+          click: () => { setNotificationsEnabled(true); tray.setContextMenu(buildContextMenu(tray)); },
+        },
+        {
+          label: strings.off,
+          type: 'radio',
+          checked: !notifEnabled,
+          click: () => { setNotificationsEnabled(false); tray.setContextMenu(buildContextMenu(tray)); },
+        },
+      ],
     },
     {
-      label: isLinux ? `${discordGlyph} ${strings.discord}` : strings.discord,
-      type: 'checkbox',
-      checked: discordEnabled,
-      click: (menuItem) => {
-        setDiscordEnabled(menuItem.checked);
-        tray.setContextMenu(buildContextMenu(tray));
-      },
+      label: isLinux ? `${discordGlyph} ${discordParentLabel}` : discordParentLabel,
+      submenu: [
+        {
+          label: strings.on,
+          type: 'radio',
+          checked: discordEnabled,
+          click: () => { setDiscordEnabled(true); tray.setContextMenu(buildContextMenu(tray)); },
+        },
+        {
+          label: strings.off,
+          type: 'radio',
+          checked: !discordEnabled,
+          click: () => { setDiscordEnabled(false); tray.setContextMenu(buildContextMenu(tray)); },
+        },
+      ],
     },
     {
-      label: isLinux ? `${catppuccinGlyph} ${strings.catppuccin}` : strings.catppuccin,
-      type: 'checkbox',
-      checked: catppuccinEnabled,
-      click: (menuItem) => {
-        setCatppuccinEnabled(menuItem.checked);
-        app.emit('catppuccin-toggle', {}, menuItem.checked);
-        tray.setContextMenu(buildContextMenu(tray));
-      },
+      label: isLinux ? `${styleGlyph} ${styleParentLabel}` : styleParentLabel,
+      submenu: [
+        {
+          label: strings.styleAppleMusic,
+          type: 'radio',
+          checked: !catppuccinEnabled,
+          click: () => { setCatppuccinEnabled(false); app.emit('catppuccin-toggle', {}, false); tray.setContextMenu(buildContextMenu(tray)); },
+        },
+        {
+          label: strings.catppuccin,
+          type: 'radio',
+          checked: catppuccinEnabled,
+          click: () => { setCatppuccinEnabled(true); app.emit('catppuccin-toggle', {}, true); tray.setContextMenu(buildContextMenu(tray)); },
+        },
+      ],
     },
   ];
 

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -107,6 +107,7 @@ function buildContextMenu(tray: Tray): Menu {
     'new': strings.startPageNew,
     'radio': strings.startPageRadio,
     'all-playlists': strings.startPageAllPlaylists,
+    'last': strings.startPageLast,
   };
   const currentStartPageLabel = startPageLabelMap[currentStartPage];
   const startPageGlyph = '♪';
@@ -143,6 +144,12 @@ function buildContextMenu(tray: Tray): Menu {
           type: 'radio',
           checked: currentStartPage === 'all-playlists',
           click: () => { setStartPage('all-playlists'); tray.setContextMenu(buildContextMenu(tray)); },
+        },
+        {
+          label: strings.startPageLast,
+          type: 'radio',
+          checked: currentStartPage === 'last',
+          click: () => { setStartPage('last'); tray.setContextMenu(buildContextMenu(tray)); },
         },
       ],
     },

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -101,10 +101,50 @@ function buildContextMenu(tray: Tray): Menu {
   const styleGlyph = '🌢';
   const styleParentLabel = `${strings.style}: ${catppuccinEnabled ? strings.catppuccin : strings.styleAppleMusic}`;
 
+  const currentStartPage = getStartPage();
+  const startPageLabelMap: Record<string, string> = {
+    'home': strings.startPageHome,
+    'new': strings.startPageNew,
+    'radio': strings.startPageRadio,
+    'all-playlists': strings.startPageAllPlaylists,
+  };
+  const currentStartPageLabel = startPageLabelMap[currentStartPage];
+  const startPageGlyph = '♪';
+  const startPageParentLabel = `${strings.startPage}: ${currentStartPageLabel}`;
+
   const menuItems: Electron.MenuItemConstructorOptions[] = [
     {
       label: isLinux ? `${aboutGlyph} ${strings.about}` : strings.about,
       click: () => showAboutWindow(),
+    },
+    {
+      label: isLinux ? `${startPageGlyph} ${startPageParentLabel}` : startPageParentLabel,
+      submenu: [
+        {
+          label: strings.startPageHome,
+          type: 'radio',
+          checked: currentStartPage === 'home',
+          click: () => { setStartPage('home'); tray.setContextMenu(buildContextMenu(tray)); },
+        },
+        {
+          label: strings.startPageNew,
+          type: 'radio',
+          checked: currentStartPage === 'new',
+          click: () => { setStartPage('new'); tray.setContextMenu(buildContextMenu(tray)); },
+        },
+        {
+          label: strings.startPageRadio,
+          type: 'radio',
+          checked: currentStartPage === 'radio',
+          click: () => { setStartPage('radio'); tray.setContextMenu(buildContextMenu(tray)); },
+        },
+        {
+          label: strings.startPageAllPlaylists,
+          type: 'radio',
+          checked: currentStartPage === 'all-playlists',
+          click: () => { setStartPage('all-playlists'); tray.setContextMenu(buildContextMenu(tray)); },
+        },
+      ],
     },
     {
       label: isLinux ? `${notifGlyph} ${notifParentLabel}` : notifParentLabel,
@@ -158,46 +198,6 @@ function buildContextMenu(tray: Tray): Menu {
       ],
     },
   ];
-
-  const currentStartPage = getStartPage();
-  const startPageLabelMap: Record<string, string> = {
-    'home': strings.startPageHome,
-    'new': strings.startPageNew,
-    'radio': strings.startPageRadio,
-    'all-playlists': strings.startPageAllPlaylists,
-  };
-  const currentStartPageLabel = startPageLabelMap[currentStartPage];
-  const startPageGlyph = '🗍';
-  const startPageParentLabel = `${strings.startPage}: ${currentStartPageLabel}`;
-  menuItems.push({
-    label: isLinux ? `${startPageGlyph} ${startPageParentLabel}` : startPageParentLabel,
-    submenu: [
-      {
-        label: strings.startPageHome,
-        type: 'radio',
-        checked: currentStartPage === 'home',
-        click: () => { setStartPage('home'); tray.setContextMenu(buildContextMenu(tray)); },
-      },
-      {
-        label: strings.startPageNew,
-        type: 'radio',
-        checked: currentStartPage === 'new',
-        click: () => { setStartPage('new'); tray.setContextMenu(buildContextMenu(tray)); },
-      },
-      {
-        label: strings.startPageRadio,
-        type: 'radio',
-        checked: currentStartPage === 'radio',
-        click: () => { setStartPage('radio'); tray.setContextMenu(buildContextMenu(tray)); },
-      },
-      {
-        label: strings.startPageAllPlaylists,
-        type: 'radio',
-        checked: currentStartPage === 'all-playlists',
-        click: () => { setStartPage('all-playlists'); tray.setContextMenu(buildContextMenu(tray)); },
-      },
-    ],
-  });
 
   const update = getUpdateInfo();
   const updateStrings = getUpdateStrings();


### PR DESCRIPTION
## Summary

Adds a configurable start page feature allowing users to select their preferred landing page (Home, New, Radio, or All Playlists) plus a "Last session" option that remembers the previously visited page. Converts existing tray toggles to radio button submenus for cleaner UI. Fixes a race condition in navigationBar injection that prevented browser controls from appearing on non-`/new` start pages. Includes full localisation across 25+ languages.

## Changes

- Add start page configuration with four preset options plus "Last session" fallback
- Move navigationBar script loading to app startup to eliminate race condition on non-`/new` pages
- Convert tray menu toggles to radio button submenus with localised labels
- Restructure tray menu: start page selector positioned before notifications
- Add comprehensive i18n strings for all new UI elements and menu labels
- Ensure browser controls appear consistently across all start page variants

## Testing

- Navigate to different start page options via tray menu and verify correct page loads
- Test "Last session" option by visiting various pages, closing, and reopening application
- Confirm navigationBar and browser controls render on Home, New, Radio, and All Playlists pages
- Verify tray menu displays radio button indicators for currently selected start page
- Test with multiple language locales to confirm string translations are present