### PR TITLE
fix(mpris): Rename xesam:artUrl to compliant mpris:artUrl

### DIFF
--- a/src/integrations/mpris/index.ts
+++ b/src/integrations/mpris/index.ts
@@ -537,7 +537,7 @@ function buildMetadata(payload: {
   }
 
   if (payload.artworkUrl != null) {
-    metadata['xesam:artUrl'] = new Variant('s', payload.artworkUrl);
+    metadata['mpris:artUrl'] = new Variant('s', payload.artworkUrl);
   }
 
   if (payload.url != null) {


### PR DESCRIPTION
## Description
This Pull Request fixes a fundamental metadata property mismatch in the MPRIS integration. According to the official [MPRIS v2 D-Bus Interface Specification](https://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html), the album art URL must be populated under the `mpris:artUrl` key, rather than the Xesam ontology (`xesam:title`, `xesam:artist`).

The previous code was incorrectly assigning the artwork URL to `xesam:artUrl`, causing strict MPRIS clients (like GNOME Shell and many extensions) to discard the property entirely as invalid. This change ensures proper specification compliance.

Reference: https://github.com/wimpysworld/sidra/pull/33