### PR TITLE
Fix: gnome premature caching

### DIFF
--- a/src/integrations/mpris/index.ts
+++ b/src/integrations/mpris/index.ts
@@ -11,6 +11,12 @@ const {
   ACCESS_READWRITE,
 } = dbus.interface;
 const { Variant } = require('@holusion/dbus-next');
+import path from 'path';
+import crypto from 'crypto';
+import https from 'https';
+import { promises as fsp, createWriteStream } from 'fs';
+
+const DBUS_SERVICE = 'org.mpris.MediaPlayer2.sidra';
 
 const mprisLog = log.scope('mpris');
 
@@ -617,6 +623,51 @@ function onNowPlayingItemDidChange(payload: unknown): void {
   lastPositionTimestamp = Date.now();
   playerIfaceRef._position = 0;
   playerIfaceRef.Seeked(0);
+
+  if (p.artworkUrl && p.artworkUrl.startsWith('https://')) {
+    try {
+      const cacheDir = path.join(app.getPath('userData' as any), 'art');
+      if (!require('fs').existsSync(cacheDir)) {
+        require('fs').mkdirSync(cacheDir, { recursive: true });
+      }
+      const hash = crypto.createHash('md5').update(p.artworkUrl).digest('hex');
+      const ext = p.artworkUrl.split('.').pop()?.split('?')[0] || 'jpg';
+      const filepath = path.join(cacheDir, `sidra-art-${hash}.${ext}`);
+      const fileUrl = `file://${filepath}`;
+
+      fsp.stat(filepath)
+        .then(() => {
+          metadata['mpris:artUrl'] = new Variant('s', fileUrl);
+          if (playerIfaceRef) {
+            playerIfaceRef._metadata = metadata;
+            schedulePropertyEmission({ Metadata: metadata });
+          }
+        })
+        .catch(() => {
+          https.get(p.artworkUrl as string, (res: any) => {
+            if (res.statusCode === 200) {
+              const stream = createWriteStream(filepath);
+              res.pipe(stream);
+              stream.on('finish', () => {
+                stream.close();
+                mprisLog.debug('Cached artwork to local file:', fileUrl);
+                metadata['mpris:artUrl'] = new Variant('s', fileUrl);
+                if (playerIfaceRef) {
+                  playerIfaceRef._metadata = metadata;
+                  schedulePropertyEmission({ Metadata: metadata });
+                }
+              });
+            } else {
+              mprisLog.warn('failed to download artwork. HTTP code:', res.statusCode);
+            }
+          }).on('error', (err: Error) => {
+            mprisLog.warn('failed to download artwork for MPRIS:', err.message);
+          });
+        });
+    } catch (err: any) {
+      mprisLog.error('failed to process artwork caching:', err.message);
+    }
+  }
 }
 
 function onRepeatModeDidChange(payload: unknown): void {

--- a/src/integrations/mpris/index.ts
+++ b/src/integrations/mpris/index.ts
@@ -615,14 +615,18 @@ function onNowPlayingItemDidChange(payload: unknown): void {
   const rawId = p.trackId ?? 'unknown';
   const trackId = `/org/${appName}/track/${sanitiseTrackId(rawId)}`;
 
-  playerIfaceRef._metadata = metadata;
-  playerIfaceRef._currentTrackId = trackId;
-  schedulePropertyEmission({ Metadata: metadata });
+  const setMetadata = () => {
+    if (playerIfaceRef) {
+      playerIfaceRef._metadata = metadata;
+      playerIfaceRef._currentTrackId = trackId;
+      playerIfaceRef._position = 0;
+      schedulePropertyEmission({ Metadata: metadata });
+      playerIfaceRef.Seeked(0);
+    }
+  };
 
   lastPositionUs = 0;
   lastPositionTimestamp = Date.now();
-  playerIfaceRef._position = 0;
-  playerIfaceRef.Seeked(0);
 
   if (p.artworkUrl && p.artworkUrl.startsWith('https://')) {
     try {
@@ -638,10 +642,7 @@ function onNowPlayingItemDidChange(payload: unknown): void {
       fsp.stat(filepath)
         .then(() => {
           metadata['mpris:artUrl'] = new Variant('s', fileUrl);
-          if (playerIfaceRef) {
-            playerIfaceRef._metadata = metadata;
-            schedulePropertyEmission({ Metadata: metadata });
-          }
+          setMetadata();
         })
         .catch(() => {
           https.get(p.artworkUrl as string, (res: any) => {
@@ -652,21 +653,23 @@ function onNowPlayingItemDidChange(payload: unknown): void {
                 stream.close();
                 mprisLog.debug('Cached artwork to local file:', fileUrl);
                 metadata['mpris:artUrl'] = new Variant('s', fileUrl);
-                if (playerIfaceRef) {
-                  playerIfaceRef._metadata = metadata;
-                  schedulePropertyEmission({ Metadata: metadata });
-                }
+                setMetadata();
               });
             } else {
               mprisLog.warn('failed to download artwork. HTTP code:', res.statusCode);
+              setMetadata();
             }
           }).on('error', (err: Error) => {
             mprisLog.warn('failed to download artwork for MPRIS:', err.message);
+            setMetadata();
           });
         });
     } catch (err: any) {
       mprisLog.error('failed to process artwork caching:', err.message);
+      setMetadata();
     }
+  } else {
+    setMetadata();
   }
 }
 

--- a/src/integrations/mpris/index.ts
+++ b/src/integrations/mpris/index.ts
@@ -537,7 +537,7 @@ function buildMetadata(payload: {
   }
 
   if (payload.artworkUrl != null) {
-    metadata['xesam:artUrl'] = new Variant('s', payload.artworkUrl);
+    metadata['mpris:artUrl'] = new Variant('s', payload.artworkUrl);
   }
 
   if (payload.url != null) {


### PR DESCRIPTION
## Description
This Pull Request builds upon the newly introduced local caching mechanism to address a prominent optimization bug in highly restrictive desktop environments like **GNOME Shell**.

GNOME Shell contains an aggressive memory optimization behavior where it flat-out ignores subsequent D-Bus metadata updates if the `mpris:trackid` remains unchanged. Since downloading the local artwork takes ~500ms, the previous implementation would emit the track change immediately, making GNOME ignore the subsequent `file://` artwork update arriving milliseconds later.

Reference: https://github.com/wimpysworld/sidra/pull/33
