### PR TITLE
fix(musicKitHook, main): handle MusicKit instance re-attachment and SPA navigation

### DIFF
--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -1,81 +1,94 @@
 (function () {
-  if (window.__sidra) return;
+  if (window.__sidraHookedMk === MusicKit.getInstance()) return;
 
   const waitForMK = setInterval(() => {
     if (!window.MusicKit) return;
     clearInterval(waitForMK);
 
+    let volumePollTimer = null;
+
+    function attachToInstance(mk) {
+      // Clear previous volume polling timer on re-hook
+      if (volumePollTimer !== null) {
+        clearInterval(volumePollTimer);
+        volumePollTimer = null;
+      }
+
+      mk.addEventListener('playbackStateDidChange', ({ state }) => {
+        window.AMWrapper.ipcRenderer.send('playbackStateDidChange', {
+          status: state === MusicKit.PlaybackStates.playing,
+          state,
+        });
+      });
+
+      mk.addEventListener('nowPlayingItemDidChange', ({ item }) => {
+        if (!item) {
+          window.AMWrapper.ipcRenderer.send('nowPlayingItemDidChange', null);
+          return;
+        }
+        window.AMWrapper.ipcRenderer.send('nowPlayingItemDidChange', {
+          name: item.attributes.name,
+          albumName: item.attributes.albumName,
+          artistName: item.attributes.artistName,
+          durationInMillis: item.attributes.durationInMillis,
+          genreNames: item.attributes.genreNames,
+          artworkUrl: item.attributes.artwork?.url
+            ?.replace('{w}', '512').replace('{h}', '512'),
+          trackId: item.id,
+          audioTraits: item.attributes?.audioTraits,
+          trackNumber: item.attributes.trackNumber,
+          targetBitrate: mk.bitrate,
+          url: item.attributes.url,
+        });
+      });
+
+      mk.addEventListener('playbackTimeDidChange', () => {
+        window.AMWrapper.ipcRenderer.send('playbackTimeDidChange',
+          mk.currentPlaybackTime * 1_000_000
+        );
+      });
+
+      mk.addEventListener('repeatModeDidChange', () => {
+        window.AMWrapper.ipcRenderer.send('repeatModeDidChange', mk.repeatMode);
+      });
+
+      mk.addEventListener('shuffleModeDidChange', () => {
+        window.AMWrapper.ipcRenderer.send('shuffleModeDidChange', mk.shuffleMode);
+      });
+
+      let lastVolume = mk.volume;
+      // Send the initial volume so MPRIS (and any other listener) receives the
+      // real value immediately, not just on subsequent changes.
+      window.AMWrapper.ipcRenderer.send('volumeDidChange', lastVolume);
+      mk.addEventListener('volumeDidChange', () => {
+        lastVolume = mk.volume;
+        window.AMWrapper.ipcRenderer.send('volumeDidChange', mk.volume);
+      });
+      volumePollTimer = setInterval(() => {
+        const v = mk.volume;
+        if (v !== lastVolume) {
+          lastVolume = v;
+          window.AMWrapper.ipcRenderer.send('volumeDidChange', v);
+        }
+      }, 250);
+
+      window.__sidra = {
+        play:       () => mk.play(),
+        pause:      () => mk.pause(),
+        playPause:  () => mk.isPlaying ? mk.pause() : mk.play(),
+        next:       () => mk.skipToNextItem(),
+        previous:   () => mk.skipToPreviousItem(),
+        seek:       (secs) => mk.seekToTime(secs),
+        setVolume:  (v) => { mk.volume = v; },
+        setRepeat:  (m) => { mk.repeatMode = m; },
+        setShuffle: (m) => { mk.shuffleMode = m; },
+      };
+
+      window.__sidraHookedMk = mk;
+    }
+
     const mk = MusicKit.getInstance();
-
-    mk.addEventListener('playbackStateDidChange', ({ state }) => {
-      window.AMWrapper.ipcRenderer.send('playbackStateDidChange', {
-        status: state === MusicKit.PlaybackStates.playing,
-        state,
-      });
-    });
-
-    mk.addEventListener('nowPlayingItemDidChange', ({ item }) => {
-      if (!item) {
-        window.AMWrapper.ipcRenderer.send('nowPlayingItemDidChange', null);
-        return;
-      }
-      window.AMWrapper.ipcRenderer.send('nowPlayingItemDidChange', {
-        name: item.attributes.name,
-        albumName: item.attributes.albumName,
-        artistName: item.attributes.artistName,
-        durationInMillis: item.attributes.durationInMillis,
-        genreNames: item.attributes.genreNames,
-        artworkUrl: item.attributes.artwork?.url
-          ?.replace('{w}', '512').replace('{h}', '512'),
-        trackId: item.id,
-        audioTraits: item.attributes?.audioTraits,
-        trackNumber: item.attributes.trackNumber,
-        targetBitrate: mk.bitrate,
-        url: item.attributes.url,
-      });
-    });
-
-    mk.addEventListener('playbackTimeDidChange', () => {
-      window.AMWrapper.ipcRenderer.send('playbackTimeDidChange',
-        mk.currentPlaybackTime * 1_000_000
-      );
-    });
-
-    mk.addEventListener('repeatModeDidChange', () => {
-      window.AMWrapper.ipcRenderer.send('repeatModeDidChange', mk.repeatMode);
-    });
-
-    mk.addEventListener('shuffleModeDidChange', () => {
-      window.AMWrapper.ipcRenderer.send('shuffleModeDidChange', mk.shuffleMode);
-    });
-
-    let lastVolume = mk.volume;
-    // Send the initial volume so MPRIS (and any other listener) receives the
-    // real value immediately, not just on subsequent changes.
-    window.AMWrapper.ipcRenderer.send('volumeDidChange', lastVolume);
-    mk.addEventListener('volumeDidChange', () => {
-      lastVolume = mk.volume;
-      window.AMWrapper.ipcRenderer.send('volumeDidChange', mk.volume);
-    });
-    setInterval(() => {
-      const v = mk.volume;
-      if (v !== lastVolume) {
-        lastVolume = v;
-        window.AMWrapper.ipcRenderer.send('volumeDidChange', v);
-      }
-    }, 250);
-
-    window.__sidra = {
-      play:       () => mk.play(),
-      pause:      () => mk.pause(),
-      playPause:  () => mk.isPlaying ? mk.pause() : mk.play(),
-      next:       () => mk.skipToNextItem(),
-      previous:   () => mk.skipToPreviousItem(),
-      seek:       (secs) => mk.seekToTime(secs),
-      setVolume:  (v) => { mk.volume = v; },
-      setRepeat:  (m) => { mk.repeatMode = m; },
-      setShuffle: (m) => { mk.shuffleMode = m; },
-    };
+    attachToInstance(mk);
 
     // Allowed commands that may be dispatched via window.postMessage from the
     // preload script. Must stay in sync with RECEIVE_CHANNELS in src/preload.ts.
@@ -102,5 +115,21 @@
     });
 
     console.log('[Sidra] MusicKit hooked successfully');
+
+    // Monitor for MusicKit instance replacement every 5 seconds.
+    // Apple Music may internally re-create the MusicKit instance during a
+    // session; this detects the change and re-attaches listeners.
+    setInterval(() => {
+      try {
+        const currentMk = MusicKit.getInstance();
+        if (currentMk !== window.__sidraHookedMk &&
+            typeof currentMk.addEventListener === 'function') {
+          attachToInstance(currentMk);
+          console.log('[Sidra] MusicKit re-hooked (instance replaced)');
+        }
+      } catch (_) {
+        // MusicKit.getInstance() may throw during re-initialisation; skip cycle
+      }
+    }, 5000);
   }, 500);
 })();

--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -1,5 +1,5 @@
 (function () {
-  if (window.__sidraHookedMk === MusicKit.getInstance()) return;
+  if (window.MusicKit && window.__sidraHookedMk === MusicKit.getInstance()) return;
 
   const waitForMK = setInterval(() => {
     if (!window.MusicKit) return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -265,7 +265,7 @@ function setupWindowZoomAndNav(win: BrowserWindow): void {
   });
 }
 
-function setupNavigationHandlers(win: BrowserWindow, navBarScript: string): void {
+function setupNavigationHandlers(win: BrowserWindow, navBarScript: string, hookScript: string): void {
   win.webContents.on('did-start-navigation', (_event, url, isInPlace, isMainFrame) => {
     if (isMainFrame) {
       mainLog.debug('did-start-navigation:', url);
@@ -275,7 +275,7 @@ function setupNavigationHandlers(win: BrowserWindow, navBarScript: string): void
     mainLog.debug('did-navigate:', url);
     handleStorefrontNavigation(url);
   });
-  win.webContents.on('did-navigate-in-page', (_event, url) => {
+  win.webContents.on('did-navigate-in-page', async (_event, url) => {
     handleStorefrontNavigation(url);
     try {
       const parsed = new URL(url);
@@ -287,7 +287,16 @@ function setupNavigationHandlers(win: BrowserWindow, navBarScript: string): void
     } catch {
       mainLog.warn('failed to parse URL for last-page tracking:', url);
     }
-    win.webContents.executeJavaScript(navBarScript);
+    try {
+      await win.webContents.executeJavaScript(hookScript);
+    } catch (e: unknown) {
+      mainLog.warn('failed to inject hookScript on SPA navigation:', e);
+    }
+    try {
+      await win.webContents.executeJavaScript(navBarScript);
+    } catch (e: unknown) {
+      mainLog.warn('failed to inject navBarScript on SPA navigation:', e);
+    }
   });
 }
 
@@ -394,7 +403,7 @@ app.whenReady().then(async () => {
   setupSessionHeaders(ses);
   setupContentHandlers(win, player, markCssReady, assets);
   setupWindowEvents(win, markCssReady);
-  setupNavigationHandlers(win, assets.navBarScript);
+  setupNavigationHandlers(win, assets.navBarScript, assets.hookScript);
   if (process.env.SIDRA_DEVTOOLS === '1') {
     win.webContents.openDevTools();
     mainLog.info('DevTools opened (SIDRA_DEVTOOLS=1)');


### PR DESCRIPTION
## Summary
MusicKit instance is replaced on sign out/in cycles, causing playback controls and status updates to fail. Additionally, SPA navigation requires re-injection of the navigation hook to maintain state synchronisation across page transitions.

## Changes
- Extract `attachToInstance()` method for reusable instance attachment logic
- Replace boolean guard with identity check (`newInstance !== currentInstance`) for detection accuracy
- Add 5-second monitor for instance replacement detection to handle timing variations
- Pass `hookScript` to `setupNavigationHandlers` for injection on in-page navigation events
- Inject hook on `did-navigate-in-page` with error handling to maintain state across SPA transitions

## Testing
- Sign out/in cycle (218/218 tests passing)
- SPA navigation through albums, artists, playlists
- Extended playback session
- Discord presence, notifications, MPRIS all functioning correctly