### PR TITLE
feat(nowplaying): enrich metadata with container, queue, and MPRIS fields

### DIFF
--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -26,19 +26,37 @@
           window.AMWrapper.ipcRenderer.send('nowPlayingItemDidChange', null);
           return;
         }
+        const pp = item.attributes?.playParams;
         window.AMWrapper.ipcRenderer.send('nowPlayingItemDidChange', {
-          name: item.attributes.name,
-          albumName: item.attributes.albumName,
-          artistName: item.attributes.artistName,
-          durationInMillis: item.attributes.durationInMillis,
-          genreNames: item.attributes.genreNames,
-          artworkUrl: item.attributes.artwork?.url
+          name: item.attributes?.name,
+          albumName: item.attributes?.albumName,
+          artistName: item.attributes?.artistName,
+          durationInMillis: item.attributes?.durationInMillis,
+          genreNames: item.attributes?.genreNames,
+          artworkUrl: item.attributes?.artwork?.url
             ?.replace('{w}', '512').replace('{h}', '512'),
           trackId: item.id,
           audioTraits: item.attributes?.audioTraits,
-          trackNumber: item.attributes.trackNumber,
+          trackNumber: item.attributes?.trackNumber,
           targetBitrate: mk.bitrate,
-          url: item.attributes.url,
+          url: item.attributes?.url,
+          discNumber: item.attributes?.discNumber,
+          composerName: item.attributes?.composerName,
+          releaseDate: item.attributes?.releaseDate,
+          contentRating: item.attributes?.contentRating,
+          itemType: item.attributes?.playParams?.kind,
+          containerId: item.container?.id,
+          containerType: item.container?.type,
+          containerName: item.container?.attributes?.name,
+          playParams: pp ? {
+            catalogId: pp.catalogId,
+            globalId: pp.globalId,
+            kind: pp.kind,
+            isLibrary: pp.isLibrary,
+          } : undefined,
+          isrc: item.attributes?.isrc,
+          queueLength: mk.queue?.length,
+          queueIndex: mk.nowPlayingItemIndex,
         });
       });
 

--- a/src/integrations/mpris/index.ts
+++ b/src/integrations/mpris/index.ts
@@ -165,6 +165,18 @@ function buildMetadata(payload: NowPlayingPayload): Record<string, InstanceType<
     metadata['xesam:trackNumber'] = new Variant('i', payload.trackNumber);
   }
 
+  if (payload.discNumber != null) {
+    metadata['xesam:discNumber'] = new Variant('i', payload.discNumber);
+  }
+
+  if (payload.composerName != null && payload.composerName !== '') {
+    metadata['xesam:composer'] = new Variant('as', [payload.composerName]);
+  }
+
+  if (payload.releaseDate != null) {
+    metadata['xesam:contentCreated'] = new Variant('s', payload.releaseDate);
+  }
+
   return metadata;
 }
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -4,6 +4,13 @@ import log from 'electron-log/main';
 
 const playerLog = log.scope('player');
 
+export interface PlayParams {
+  catalogId?: string;
+  globalId?: string;
+  kind?: string;
+  isLibrary?: boolean;
+}
+
 export interface NowPlayingPayload {
   name?: string;
   artistName?: string;
@@ -16,6 +23,18 @@ export interface NowPlayingPayload {
   trackNumber?: number;
   audioTraits?: string[];
   targetBitrate?: number;
+  discNumber?: number;
+  composerName?: string;
+  releaseDate?: string;
+  contentRating?: string;
+  itemType?: string;
+  containerId?: string;
+  containerType?: string;
+  containerName?: string;
+  playParams?: PlayParams;
+  isrc?: string;
+  queueLength?: number;
+  queueIndex?: number;
 }
 
 export const PlaybackState = {


### PR DESCRIPTION
- Extend NowPlayingPayload type with 12 optional metadata fields and PlayParams interface
- Capture container, queue, and content metadata in musicKitHook payload
- Wire Tier 1 MPRIS fields (discNumber, composerName, releaseDate) to xesam mappings
- Verified across library and catalogue playlists

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
