### PR TITLE
fix(main): restore Cmd+Q and About menu, fix icon and fullscreen issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "sidra",
+  "productName": "Sidra",
   "version": "0.3.0",
   "description": "An elegant Apple Music desktop client for Linux, macOS and Windows. No frippery, just quality. A better class of Cider 🍎",
   "main": "dist/main.js",

--- a/src/integrations/discord-presence/index.ts
+++ b/src/integrations/discord-presence/index.ts
@@ -4,6 +4,7 @@ import { Client } from '@xhayper/discord-rpc';
 import { ActivityType } from 'discord-api-types/v10';
 import { Player, NowPlayingPayload, PlaybackState, PlaybackStatePayload, IntegrationContext } from '../../player';
 import { getDiscordEnabled } from '../../config';
+import { createPauseTimer } from '../../pauseTimer';
 
 const discordLog = log.scope('discord');
 
@@ -42,11 +43,15 @@ let previousState = 0;
 
 // Timers
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-let pauseTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let retryCount = 0;
 
 let client: Client;
+
+const pauseTimeout = createPauseTimer(PAUSE_TIMEOUT_MS, () => {
+  discordLog.debug('pause timeout reached, clearing activity');
+  client.user?.clearActivity().catch(() => {});
+});
 
 function scheduleUpdate(): void {
   if (debounceTimer) {
@@ -181,10 +186,7 @@ export function init(ctx: IntegrationContext): void {
     }
 
     // Cancel pause timer on new track
-    if (pauseTimer) {
-      clearTimeout(pauseTimer);
-      pauseTimer = null;
-    }
+    pauseTimeout.cancel();
 
     scheduleUpdate();
   };
@@ -194,18 +196,12 @@ export function init(ctx: IntegrationContext): void {
     const nowPlaying = payload?.state === PlaybackState.Playing;
     previousState = payload?.state ?? 0;
 
-    if (nowPlaying && pauseTimer) {
-      clearTimeout(pauseTimer);
-      pauseTimer = null;
+    if (nowPlaying) {
+      pauseTimeout.cancel();
     }
 
     if (!nowPlaying && wasPlaying) {
-      // Start pause timeout
-      pauseTimer = setTimeout(() => {
-        pauseTimer = null;
-        discordLog.debug('pause timeout reached, clearing activity');
-        client.user?.clearActivity().catch(() => {});
-      }, PAUSE_TIMEOUT_MS);
+      pauseTimeout.start();
     }
 
     scheduleUpdate();
@@ -216,7 +212,7 @@ export function init(ctx: IntegrationContext): void {
 
   app.on('will-quit', () => {
     if (debounceTimer) clearTimeout(debounceTimer);
-    if (pauseTimer) clearTimeout(pauseTimer);
+    pauseTimeout.destroy();
     if (reconnectTimer) clearTimeout(reconnectTimer);
 
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,6 +100,8 @@ function createSplash(): { splash: BrowserWindow; minDisplay: Promise<void>; css
     height: Math.round(SPLASH_HEIGHT_PX * splashZoom),
     frame: false,
     resizable: false,
+    fullscreenable: false,
+    fullscreen: false,
     center: true,
     skipTaskbar: true,
     backgroundColor: '#1a0a10',

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { getAssetPath } from './paths';
 import { Player, IntegrationContext } from './player';
 import { buildAppleMusicURL, handleStorefrontNavigation } from './storefront';
 import { initThemeCSS, setThemeCssKey } from './theme';
-import { createTray, initTrayStateManager, rebuildTrayMenu, setApplyZoomCallback, setSendCommandCallback } from './tray';
+import { createTray, initTrayStateManager, rebuildTrayMenu, setApplyZoomCallback, setSendCommandCallback, showAboutWindow } from './tray';
 import { checkForUpdates } from './update';
 import { isAutoUpdateSupported, initAutoUpdate } from './autoUpdate';
 import { init as initNotifications } from './integrations/notifications';
@@ -140,7 +140,11 @@ function setupApplicationMenu(): void {
   } else if (process.platform === 'darwin') {
     Menu.setApplicationMenu(Menu.buildFromTemplate([{
       label: app.name,
-      submenu: [{ role: 'quit' }],
+      submenu: [
+        { label: `About ${app.name}`, click: () => showAboutWindow() },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
     }]));
   } else {
     Menu.setApplicationMenu(null);

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,6 +135,8 @@ function setupApplicationMenu(): void {
       },
     ];
     Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
+  } else if (process.platform === 'darwin') {
+    Menu.setApplicationMenu(Menu.buildFromTemplate([]));
   } else {
     Menu.setApplicationMenu(null);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -138,7 +138,10 @@ function setupApplicationMenu(): void {
     ];
     Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
   } else if (process.platform === 'darwin') {
-    Menu.setApplicationMenu(Menu.buildFromTemplate([]));
+    Menu.setApplicationMenu(Menu.buildFromTemplate([{
+      label: app.name,
+      submenu: [{ role: 'quit' }],
+    }]));
   } else {
     Menu.setApplicationMenu(null);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,15 +5,15 @@ import log from 'electron-log/main';
 import { getTheme, setLastPageUrl, getZoomFactor } from './config';
 import { getLoadingText } from './i18n';
 import { getAssetPath } from './paths';
-import { Player, PlaybackState, IntegrationContext, type NowPlayingPayload } from './player';
+import { Player, IntegrationContext } from './player';
 import { buildAppleMusicURL, handleStorefrontNavigation } from './storefront';
 import { initThemeCSS, setThemeCssKey } from './theme';
-import { createTray, rebuildTrayMenu, setApplyZoomCallback, setSendCommandCallback, updateNowPlayingState, updateTrayTooltip } from './tray';
+import { createTray, initTrayStateManager, rebuildTrayMenu, setApplyZoomCallback, setSendCommandCallback } from './tray';
 import { checkForUpdates } from './update';
 import { isAutoUpdateSupported, initAutoUpdate } from './autoUpdate';
 import { init as initNotifications } from './integrations/notifications';
 import { init as initDiscordPresence } from './integrations/discord-presence';
-import { cleanArtworkCache, downloadArtwork } from './artwork';
+import { cleanArtworkCache } from './artwork';
 import { init as initWedgeDetector, reset as resetWedgeDetector } from './wedgeDetector';
 
 const SPLASH_MIN_DISPLAY_MS = 500;
@@ -373,90 +373,9 @@ function setupContentHandlers(win: BrowserWindow, player: Player, markCssReady: 
 
       initWedgeDetector({ player, getMainWindow: () => win });
 
-      const TRAY_PAUSE_TIMEOUT_MS = 30_000;
-      let currentVolume = 1;
-      let currentPayload: NowPlayingPayload | null = null;
-      let currentArtworkPath: string | null = null;
-      let trayPauseTimer: ReturnType<typeof setTimeout> | null = null;
-      let previousPlaying = false;
-
-      player.on('nowPlayingItemDidChange', async (payload) => {
-        if (!appTray) return;
-        // Cancel pause timer on track change
-        if (trayPauseTimer) {
-          clearTimeout(trayPauseTimer);
-          trayPauseTimer = null;
-        }
-        if (!payload) {
-          mainLog.debug('nowPlayingItemDidChange (tray handler): null payload, clearing state');
-          currentPayload = null;
-          currentArtworkPath = null;
-          updateTrayTooltip(appTray, null);
-          updateNowPlayingState(null, null, false, currentVolume);
-          rebuildTrayMenu(appTray);
-          return;
-        }
-        mainLog.debug('nowPlayingItemDidChange (tray handler):', `"${payload.name}"`);
-        currentPayload = payload;
-        updateTrayTooltip(appTray, payload);
-        let artworkPath: string | null = null;
-        if (payload.artworkUrl) {
-          const expectedPayload = payload;
-          artworkPath = await downloadArtwork(payload.artworkUrl);
-          if (currentPayload !== expectedPayload) return;
-        }
-        currentArtworkPath = artworkPath;
-        const { isPlaying } = player.playbackSnapshot();
-        updateNowPlayingState(payload, artworkPath, isPlaying, currentVolume);
-        rebuildTrayMenu(appTray);
-      });
-      player.on('playbackStateDidChange', (payload) => {
-        if (!appTray) return;
-        const state = payload?.state ?? 0;
-        if (state === PlaybackState.None || state === PlaybackState.Stopped ||
-            state === PlaybackState.Ended || state === PlaybackState.Completed) {
-          if (trayPauseTimer) {
-            clearTimeout(trayPauseTimer);
-            trayPauseTimer = null;
-          }
-          updateTrayTooltip(appTray, null);
-          currentPayload = null;
-          currentArtworkPath = null;
-          updateNowPlayingState(null, null, false, currentVolume);
-          rebuildTrayMenu(appTray);
-          return;
-        }
-        const { isPlaying } = player.playbackSnapshot();
-
-        // Pause timeout: clear Now Playing after 30s of inactivity
-        if (isPlaying && trayPauseTimer) {
-          clearTimeout(trayPauseTimer);
-          trayPauseTimer = null;
-        }
-        if (!isPlaying && previousPlaying) {
-          trayPauseTimer = setTimeout(() => {
-            trayPauseTimer = null;
-            mainLog.debug('tray pause timeout reached, clearing Now Playing');
-            if (!appTray) return;
-            updateTrayTooltip(appTray, null);
-            currentPayload = null;
-            currentArtworkPath = null;
-            updateNowPlayingState(null, null, false, currentVolume);
-            rebuildTrayMenu(appTray);
-          }, TRAY_PAUSE_TIMEOUT_MS);
-        }
-        previousPlaying = isPlaying;
-
-        updateNowPlayingState(currentPayload, currentArtworkPath, isPlaying, currentVolume);
-        rebuildTrayMenu(appTray);
-      });
-      player.on('volumeDidChange', (volume) => {
-        if (!appTray || volume == null) return;
-        currentVolume = volume;
-        const { isPlaying } = player.playbackSnapshot();
-        updateNowPlayingState(currentPayload, currentArtworkPath, isPlaying, currentVolume);
-        rebuildTrayMenu(appTray);
-      });
+      if (appTray) {
+        initTrayStateManager(player, appTray);
+      }
 
       markCssReady();
       setTimeout(() => {

--- a/src/pauseTimer.ts
+++ b/src/pauseTimer.ts
@@ -1,0 +1,26 @@
+export interface PauseTimer {
+  start(): void;
+  cancel(): void;
+  destroy(): void;
+}
+
+export function createPauseTimer(timeoutMs: number, onExpiry: () => void): PauseTimer {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function start(): void {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      onExpiry();
+    }, timeoutMs);
+  }
+
+  function cancel(): void {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  return { start, cancel, destroy: cancel };
+}

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -147,7 +147,7 @@ let sendCommandCallback: ((channel: string, ...args: unknown[]) => void) | null 
 let aboutWindow: BrowserWindow | null = null;
 let applyZoomCallback: ((factor: number) => void) | null = null;
 
-function showAboutWindow(): void {
+export function showAboutWindow(): void {
   if (aboutWindow) {
     aboutWindow.focus();
     return;

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -160,6 +160,8 @@ function showAboutWindow(): void {
     height: Math.round(ABOUT_WINDOW_HEIGHT_PX * zoomFactor),
     frame: false,
     resizable: false,
+    fullscreenable: false,
+    fullscreen: false,
     center: true,
     skipTaskbar: true,
     backgroundColor: '#1a0a10',

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -3,11 +3,12 @@ import path from 'path';
 import log from 'electron-log/main';
 import { getTrayStrings, getAboutStrings, getUpdateStrings, getAutoUpdateStrings, type TrayStrings } from './i18n';
 import { getAssetPath, getProductInfo } from './paths';
-import type { NowPlayingPayload } from './player';
+import { Player, PlaybackState, type NowPlayingPayload } from './player';
 import { getNotificationsEnabled, setNotificationsEnabled, getDiscordEnabled, setDiscordEnabled, getTheme, setTheme, getStartPage, setStartPage, getZoomFactor, setZoomFactor } from './config';
 import { getUpdateInfo } from './update';
 import { quitAndInstall } from './autoUpdate';
 import { applyTheme } from './theme';
+import { downloadArtwork } from './artwork';
 
 const ABOUT_WINDOW_WIDTH_PX = 400;
 const ABOUT_WINDOW_HEIGHT_PX = 400;
@@ -596,4 +597,104 @@ export function createTray(applyZoom?: (factor: number) => void): Tray {
   trayLog.info('tray created');
 
   return tray;
+}
+
+export function initTrayStateManager(player: Player, tray: Tray): () => void {
+  const TRAY_PAUSE_TIMEOUT_MS = 30_000;
+  let currentVolume = 1;
+  let currentPayload: NowPlayingPayload | null = null;
+  let currentArtworkPath: string | null = null;
+  let trayPauseTimer: ReturnType<typeof setTimeout> | null = null;
+  let previousPlaying = false;
+
+  const onNowPlayingItemDidChange = async (payload: NowPlayingPayload | null): Promise<void> => {
+    // Cancel pause timer on track change
+    if (trayPauseTimer) {
+      clearTimeout(trayPauseTimer);
+      trayPauseTimer = null;
+    }
+    if (!payload) {
+      trayLog.debug('nowPlayingItemDidChange (tray handler): null payload, clearing state');
+      currentPayload = null;
+      currentArtworkPath = null;
+      updateTrayTooltip(tray, null);
+      updateNowPlayingState(null, null, false, currentVolume);
+      rebuildTrayMenu(tray);
+      return;
+    }
+    trayLog.debug('nowPlayingItemDidChange (tray handler):', `"${payload.name}"`);
+    currentPayload = payload;
+    updateTrayTooltip(tray, payload);
+    let artworkPath: string | null = null;
+    if (payload.artworkUrl) {
+      const expectedPayload = payload;
+      artworkPath = await downloadArtwork(payload.artworkUrl);
+      if (currentPayload !== expectedPayload) return;
+    }
+    currentArtworkPath = artworkPath;
+    const { isPlaying } = player.playbackSnapshot();
+    updateNowPlayingState(payload, artworkPath, isPlaying, currentVolume);
+    rebuildTrayMenu(tray);
+  };
+
+  const onPlaybackStateDidChange = (payload: { status: boolean; state: number } | null): void => {
+    const state = payload?.state ?? 0;
+    if (state === PlaybackState.None || state === PlaybackState.Stopped ||
+        state === PlaybackState.Ended || state === PlaybackState.Completed) {
+      if (trayPauseTimer) {
+        clearTimeout(trayPauseTimer);
+        trayPauseTimer = null;
+      }
+      updateTrayTooltip(tray, null);
+      currentPayload = null;
+      currentArtworkPath = null;
+      updateNowPlayingState(null, null, false, currentVolume);
+      rebuildTrayMenu(tray);
+      return;
+    }
+    const { isPlaying } = player.playbackSnapshot();
+
+    // Pause timeout: clear Now Playing after 30s of inactivity
+    if (isPlaying && trayPauseTimer) {
+      clearTimeout(trayPauseTimer);
+      trayPauseTimer = null;
+    }
+    if (!isPlaying && previousPlaying) {
+      trayPauseTimer = setTimeout(() => {
+        trayPauseTimer = null;
+        trayLog.debug('tray pause timeout reached, clearing Now Playing');
+        updateTrayTooltip(tray, null);
+        currentPayload = null;
+        currentArtworkPath = null;
+        updateNowPlayingState(null, null, false, currentVolume);
+        rebuildTrayMenu(tray);
+      }, TRAY_PAUSE_TIMEOUT_MS);
+    }
+    previousPlaying = isPlaying;
+
+    updateNowPlayingState(currentPayload, currentArtworkPath, isPlaying, currentVolume);
+    rebuildTrayMenu(tray);
+  };
+
+  const onVolumeDidChange = (volume: number | null): void => {
+    if (volume == null) return;
+    currentVolume = volume;
+    const { isPlaying } = player.playbackSnapshot();
+    updateNowPlayingState(currentPayload, currentArtworkPath, isPlaying, currentVolume);
+    rebuildTrayMenu(tray);
+  };
+
+  player.on('nowPlayingItemDidChange', onNowPlayingItemDidChange);
+  player.on('playbackStateDidChange', onPlaybackStateDidChange);
+  player.on('volumeDidChange', onVolumeDidChange);
+
+  return () => {
+    if (trayPauseTimer) {
+      clearTimeout(trayPauseTimer);
+      trayPauseTimer = null;
+    }
+    player.off('nowPlayingItemDidChange', onNowPlayingItemDidChange);
+    player.off('playbackStateDidChange', onPlaybackStateDidChange);
+    player.off('volumeDidChange', onVolumeDidChange);
+  };
 }

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -9,6 +9,7 @@ import { getUpdateInfo } from './update';
 import { quitAndInstall } from './autoUpdate';
 import { applyTheme } from './theme';
 import { downloadArtwork } from './artwork';
+import { createPauseTimer } from './pauseTimer';
 
 const ABOUT_WINDOW_WIDTH_PX = 400;
 const ABOUT_WINDOW_HEIGHT_PX = 400;
@@ -604,15 +605,22 @@ export function initTrayStateManager(player: Player, tray: Tray): () => void {
   let currentVolume = 1;
   let currentPayload: NowPlayingPayload | null = null;
   let currentArtworkPath: string | null = null;
-  let trayPauseTimer: ReturnType<typeof setTimeout> | null = null;
   let previousPlaying = false;
+
+  const clearNowPlaying = (): void => {
+    trayLog.debug('tray pause timeout reached, clearing Now Playing');
+    updateTrayTooltip(tray, null);
+    currentPayload = null;
+    currentArtworkPath = null;
+    updateNowPlayingState(null, null, false, currentVolume);
+    rebuildTrayMenu(tray);
+  };
+
+  const trayPauseTimer = createPauseTimer(TRAY_PAUSE_TIMEOUT_MS, clearNowPlaying);
 
   const onNowPlayingItemDidChange = async (payload: NowPlayingPayload | null): Promise<void> => {
     // Cancel pause timer on track change
-    if (trayPauseTimer) {
-      clearTimeout(trayPauseTimer);
-      trayPauseTimer = null;
-    }
+    trayPauseTimer.cancel();
     if (!payload) {
       trayLog.debug('nowPlayingItemDidChange (tray handler): null payload, clearing state');
       currentPayload = null;
@@ -641,10 +649,7 @@ export function initTrayStateManager(player: Player, tray: Tray): () => void {
     const state = payload?.state ?? 0;
     if (state === PlaybackState.None || state === PlaybackState.Stopped ||
         state === PlaybackState.Ended || state === PlaybackState.Completed) {
-      if (trayPauseTimer) {
-        clearTimeout(trayPauseTimer);
-        trayPauseTimer = null;
-      }
+      trayPauseTimer.cancel();
       updateTrayTooltip(tray, null);
       currentPayload = null;
       currentArtworkPath = null;
@@ -655,20 +660,11 @@ export function initTrayStateManager(player: Player, tray: Tray): () => void {
     const { isPlaying } = player.playbackSnapshot();
 
     // Pause timeout: clear Now Playing after 30s of inactivity
-    if (isPlaying && trayPauseTimer) {
-      clearTimeout(trayPauseTimer);
-      trayPauseTimer = null;
+    if (isPlaying) {
+      trayPauseTimer.cancel();
     }
     if (!isPlaying && previousPlaying) {
-      trayPauseTimer = setTimeout(() => {
-        trayPauseTimer = null;
-        trayLog.debug('tray pause timeout reached, clearing Now Playing');
-        updateTrayTooltip(tray, null);
-        currentPayload = null;
-        currentArtworkPath = null;
-        updateNowPlayingState(null, null, false, currentVolume);
-        rebuildTrayMenu(tray);
-      }, TRAY_PAUSE_TIMEOUT_MS);
+      trayPauseTimer.start();
     }
     previousPlaying = isPlaying;
 
@@ -689,10 +685,7 @@ export function initTrayStateManager(player: Player, tray: Tray): () => void {
   player.on('volumeDidChange', onVolumeDidChange);
 
   return () => {
-    if (trayPauseTimer) {
-      clearTimeout(trayPauseTimer);
-      trayPauseTimer = null;
-    }
+    trayPauseTimer.destroy();
     player.off('nowPlayingItemDidChange', onNowPlayingItemDidChange);
     player.off('playbackStateDidChange', onPlaybackStateDidChange);
     player.off('volumeDidChange', onVolumeDidChange);

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -75,8 +75,17 @@ export function getMenuIcon(action: string): Electron.NativeImage | undefined {
     const symbolName = menuIconSFSymbolMap[action];
     if (!symbolName) return undefined;
 
-    const img = nativeImage.createFromNamedImage(symbolName);
-    return img.isEmpty() ? undefined : img;
+    // hslShift [-1, 0, 1] marks the image as a template so macOS
+    // automatically adapts its colour to match the menu text (light/dark).
+    const raw = nativeImage.createFromNamedImage(symbolName, [-1, 0, 1]);
+    if (raw.isEmpty()) return undefined;
+
+    // SF Symbols render at their intrinsic size, which is too large for
+    // menu items. Resize to 18px with HiDPI representations.
+    const img = nativeImage.createEmpty();
+    img.addRepresentation({ scaleFactor: 1.0, buffer: raw.resize({ width: 18, height: 18 }).toPNG() });
+    img.addRepresentation({ scaleFactor: 2.0, buffer: raw.resize({ width: 36, height: 36 }).toPNG() });
+    return img;
   }
 
   // Linux and Windows: resolve themed PNG

--- a/test/pauseTimer.test.ts
+++ b/test/pauseTimer.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createPauseTimer } from '../src/pauseTimer';
+
+describe('createPauseTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calls onExpiry after the timeout', () => {
+    const onExpiry = vi.fn();
+    const timer = createPauseTimer(1000, onExpiry);
+
+    timer.start();
+    expect(onExpiry).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1000);
+    expect(onExpiry).toHaveBeenCalledOnce();
+  });
+
+  it('does not call onExpiry if cancelled before timeout', () => {
+    const onExpiry = vi.fn();
+    const timer = createPauseTimer(1000, onExpiry);
+
+    timer.start();
+    vi.advanceTimersByTime(500);
+    timer.cancel();
+
+    vi.advanceTimersByTime(1000);
+    expect(onExpiry).not.toHaveBeenCalled();
+  });
+
+  it('restarts the timer when start is called while running', () => {
+    const onExpiry = vi.fn();
+    const timer = createPauseTimer(1000, onExpiry);
+
+    timer.start();
+    vi.advanceTimersByTime(800);
+    expect(onExpiry).not.toHaveBeenCalled();
+
+    // Restart resets the timeout
+    timer.start();
+    vi.advanceTimersByTime(800);
+    expect(onExpiry).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(200);
+    expect(onExpiry).toHaveBeenCalledOnce();
+  });
+
+  it('destroy clears any pending timer', () => {
+    const onExpiry = vi.fn();
+    const timer = createPauseTimer(1000, onExpiry);
+
+    timer.start();
+    vi.advanceTimersByTime(500);
+    timer.destroy();
+
+    vi.advanceTimersByTime(1000);
+    expect(onExpiry).not.toHaveBeenCalled();
+  });
+
+  it('cancel is safe to call when no timer is running', () => {
+    const onExpiry = vi.fn();
+    const timer = createPauseTimer(1000, onExpiry);
+
+    // Should not throw
+    timer.cancel();
+    expect(onExpiry).not.toHaveBeenCalled();
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -44,6 +44,8 @@ vi.mock('electron', () => ({
     })),
     createFromNamedImage: vi.fn(() => ({
       isEmpty: () => false,
+      resize: vi.fn(function (this: { isEmpty: () => boolean; toPNG: () => Buffer }) { return this; }),
+      toPNG: vi.fn(() => Buffer.from([])),
     })),
     createEmpty: vi.fn(() => ({
       isEmpty: () => true,

--- a/test/tray.test.ts
+++ b/test/tray.test.ts
@@ -296,7 +296,7 @@ describe('createTray - menu template inspection', () => {
       const template = getLastTemplate();
       const aboutItem = findItem(template, 'About Sidra');
       expect(aboutItem!.icon).toBeDefined();
-      expect(vi.mocked(nativeImage.createFromNamedImage)).toHaveBeenCalledWith('info.circle');
+      expect(vi.mocked(nativeImage.createFromNamedImage)).toHaveBeenCalledWith('info.circle', [-1, 0, 1]);
     });
 
     it('attaches SF Symbol icon to Quit on macOS Tahoe+', () => {
@@ -884,7 +884,7 @@ describe('getMenuIcon', () => {
     it('returns a NativeImage from createFromNamedImage with SF Symbol name', () => {
       const icon = getMenuIcon('about');
       expect(icon).toBeDefined();
-      expect(vi.mocked(nativeImage.createFromNamedImage)).toHaveBeenCalledWith('info.circle');
+      expect(vi.mocked(nativeImage.createFromNamedImage)).toHaveBeenCalledWith('info.circle', [-1, 0, 1]);
     });
 
     it('returns undefined for an unknown action', () => {
@@ -911,7 +911,7 @@ describe('getMenuIcon', () => {
       for (const [action, symbol] of cases) {
         vi.mocked(nativeImage.createFromNamedImage).mockClear();
         getMenuIcon(action);
-        expect(vi.mocked(nativeImage.createFromNamedImage)).toHaveBeenCalledWith(symbol);
+        expect(vi.mocked(nativeImage.createFromNamedImage)).toHaveBeenCalledWith(symbol, [-1, 0, 1]);
       }
     });
   });

--- a/test/tray.test.ts
+++ b/test/tray.test.ts
@@ -64,6 +64,10 @@ vi.mock('../src/theme', () => ({
   applyTheme: vi.fn(),
 }));
 
+vi.mock('../src/artwork', () => ({
+  downloadArtwork: vi.fn(() => Promise.resolve('/tmp/downloaded-artwork.png')),
+}));
+
 vi.mock('../src/paths', () => ({
   getAssetPath: vi.fn((...parts: string[]) => parts.join('/')),
   getProductInfo: () => ({ productName: 'Sidra', description: 'Apple Music client', author: 'Test', license: 'MIT' }),
@@ -71,7 +75,10 @@ vi.mock('../src/paths', () => ({
 
 import { Menu, Tray, nativeImage, nativeTheme } from 'electron';
 import { getUpdateInfo } from '../src/update';
-import { truncateMenuLabel, sanitiseLinuxLabel, createTray, getMenuIcon, updateNowPlayingState, rebuildTrayMenu } from '../src/tray';
+import { truncateMenuLabel, sanitiseLinuxLabel, createTray, getMenuIcon, updateNowPlayingState, updateTrayTooltip, rebuildTrayMenu, initTrayStateManager } from '../src/tray';
+import { downloadArtwork } from '../src/artwork';
+import { Player, PlaybackState } from '../src/player';
+import type { NowPlayingPayload } from '../src/player';
 
 // Helper: extract the template array from the last Menu.buildFromTemplate call
 function getLastTemplate(): Electron.MenuItemConstructorOptions[] {
@@ -923,6 +930,290 @@ describe('getMenuIcon', () => {
       getMenuIcon('about');
       expect(vi.mocked(nativeImage.createFromPath)).not.toHaveBeenCalled();
       expect(vi.mocked(nativeImage.createFromNamedImage)).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('initTrayStateManager', () => {
+  let mockPlayer: {
+    on: ReturnType<typeof vi.fn>;
+    off: ReturnType<typeof vi.fn>;
+    playbackSnapshot: ReturnType<typeof vi.fn>;
+    listeners: Record<string, ((...args: unknown[]) => unknown)>;
+  };
+  let mockTray: InstanceType<typeof Tray>;
+
+  function createMockPlayer() {
+    const listeners: Record<string, ((...args: unknown[]) => unknown)> = {};
+    return {
+      listeners,
+      on: vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
+        listeners[event] = handler;
+      }),
+      off: vi.fn((event: string, _handler: (...args: unknown[]) => unknown) => {
+        delete listeners[event];
+      }),
+      playbackSnapshot: vi.fn(() => ({ isPlaying: false, positionUs: 0, state: 0 })),
+    };
+  }
+
+  beforeEach(() => {
+    mockPlayer = createMockPlayer();
+    mockTray = new Tray('test-icon.png');
+    vi.mocked(Menu.buildFromTemplate).mockClear();
+    vi.mocked(downloadArtwork).mockReset();
+    vi.mocked(downloadArtwork).mockResolvedValue('/tmp/downloaded-artwork.png');
+  });
+
+  describe('event subscription', () => {
+    it('registers all three event listeners on the player', () => {
+      initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+      expect(mockPlayer.on).toHaveBeenCalledWith('nowPlayingItemDidChange', expect.any(Function));
+      expect(mockPlayer.on).toHaveBeenCalledWith('playbackStateDidChange', expect.any(Function));
+      expect(mockPlayer.on).toHaveBeenCalledWith('volumeDidChange', expect.any(Function));
+      expect(mockPlayer.on).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('cleanup function', () => {
+    it('removes all three event listeners from the player', () => {
+      const cleanup = initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+      cleanup();
+      expect(mockPlayer.off).toHaveBeenCalledWith('nowPlayingItemDidChange', expect.any(Function));
+      expect(mockPlayer.off).toHaveBeenCalledWith('playbackStateDidChange', expect.any(Function));
+      expect(mockPlayer.off).toHaveBeenCalledWith('volumeDidChange', expect.any(Function));
+      expect(mockPlayer.off).toHaveBeenCalledTimes(3);
+    });
+
+    it('clears the pause timer when called during an active pause timeout', () => {
+      vi.useFakeTimers();
+      try {
+        const cleanup = initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+
+        // Simulate playing then pausing to start the pause timer
+        mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: true, positionUs: 0, state: PlaybackState.Playing });
+        mockPlayer.listeners['playbackStateDidChange']({ status: true, state: PlaybackState.Playing });
+
+        mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: false, positionUs: 0, state: PlaybackState.Paused });
+        mockPlayer.listeners['playbackStateDidChange']({ status: true, state: PlaybackState.Paused });
+
+        // Timer is now pending. Cleanup should clear it.
+        cleanup();
+
+        // Advance past the 30s timeout - should not trigger any state clearing
+        vi.mocked(Menu.buildFromTemplate).mockClear();
+        vi.advanceTimersByTime(35_000);
+
+        // No additional menu rebuild from the timer callback
+        expect(vi.mocked(Menu.buildFromTemplate)).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('pause timeout', () => {
+    it('clears Now Playing after 30s of inactivity when paused', () => {
+      vi.useFakeTimers();
+      try {
+        initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+
+        // Transition to playing first (sets previousPlaying = true)
+        mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: true, positionUs: 0, state: PlaybackState.Playing });
+        mockPlayer.listeners['playbackStateDidChange']({ status: true, state: PlaybackState.Playing });
+
+        // Transition to paused
+        mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: false, positionUs: 0, state: PlaybackState.Paused });
+        mockPlayer.listeners['playbackStateDidChange']({ status: true, state: PlaybackState.Paused });
+
+        // Advance 29s - should not have cleared yet
+        vi.mocked(Menu.buildFromTemplate).mockClear();
+        const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
+        setToolTipFn.mockClear();
+
+        vi.advanceTimersByTime(29_000);
+        // The tooltip should not have been cleared to the product name yet
+        expect(setToolTipFn).not.toHaveBeenCalled();
+
+        // Advance past 30s
+        vi.advanceTimersByTime(2_000);
+
+        // Now the tooltip should be reset (updateTrayTooltip(tray, null) sets product name)
+        expect(setToolTipFn).toHaveBeenCalled();
+        // And the menu should be rebuilt
+        expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('cancels the pause timer when playback resumes', () => {
+      vi.useFakeTimers();
+      try {
+        initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+
+        // Play -> Pause (start timer)
+        mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: true, positionUs: 0, state: PlaybackState.Playing });
+        mockPlayer.listeners['playbackStateDidChange']({ status: true, state: PlaybackState.Playing });
+
+        mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: false, positionUs: 0, state: PlaybackState.Paused });
+        mockPlayer.listeners['playbackStateDidChange']({ status: true, state: PlaybackState.Paused });
+
+        // Resume playing before timeout
+        vi.advanceTimersByTime(10_000);
+        mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: true, positionUs: 0, state: PlaybackState.Playing });
+        mockPlayer.listeners['playbackStateDidChange']({ status: true, state: PlaybackState.Playing });
+
+        // Advance past original timeout - should not clear
+        vi.mocked(Menu.buildFromTemplate).mockClear();
+        const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
+        setToolTipFn.mockClear();
+        vi.advanceTimersByTime(25_000);
+
+        expect(setToolTipFn).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('cancels the pause timer on track change', async () => {
+      vi.useFakeTimers();
+      try {
+        initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+
+        // Play -> Pause (start timer)
+        mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: true, positionUs: 0, state: PlaybackState.Playing });
+        mockPlayer.listeners['playbackStateDidChange']({ status: true, state: PlaybackState.Playing });
+
+        mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: false, positionUs: 0, state: PlaybackState.Paused });
+        mockPlayer.listeners['playbackStateDidChange']({ status: true, state: PlaybackState.Paused });
+
+        // New track arrives - should cancel timer
+        const payload: NowPlayingPayload = { name: 'New Track', artistName: 'Artist' };
+        vi.mocked(downloadArtwork).mockResolvedValue(null);
+        mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: true, positionUs: 0, state: PlaybackState.Playing });
+        await mockPlayer.listeners['nowPlayingItemDidChange'](payload);
+
+        // Advance past original timeout - should not clear
+        vi.mocked(Menu.buildFromTemplate).mockClear();
+        const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
+        setToolTipFn.mockClear();
+        vi.advanceTimersByTime(35_000);
+
+        // No timeout-triggered tooltip reset
+        expect(setToolTipFn).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('nowPlayingItemDidChange handler', () => {
+    it('updates tooltip and menu when a new track arrives', async () => {
+      initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+      const payload: NowPlayingPayload = { name: 'Test Song', artistName: 'Test Artist' };
+      vi.mocked(downloadArtwork).mockResolvedValue(null);
+      mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: true, positionUs: 0, state: PlaybackState.Playing });
+
+      await mockPlayer.listeners['nowPlayingItemDidChange'](payload);
+
+      const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
+      expect(setToolTipFn).toHaveBeenCalled();
+      expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalled();
+    });
+
+    it('clears state when null payload is received', async () => {
+      initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+
+      await mockPlayer.listeners['nowPlayingItemDidChange'](null);
+
+      const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
+      expect(setToolTipFn).toHaveBeenCalled();
+      expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalled();
+    });
+
+    it('downloads artwork when artworkUrl is present', async () => {
+      initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+      const payload: NowPlayingPayload = { name: 'Song', artworkUrl: 'https://example.com/art.jpg' };
+      mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: true, positionUs: 0, state: PlaybackState.Playing });
+
+      await mockPlayer.listeners['nowPlayingItemDidChange'](payload);
+
+      expect(vi.mocked(downloadArtwork)).toHaveBeenCalledWith('https://example.com/art.jpg');
+    });
+
+    it('guards against stale payload after artwork download', async () => {
+      initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+
+      // First track starts downloading artwork slowly
+      let resolveFirst: (value: string | null) => void;
+      const firstDownload = new Promise<string | null>((resolve) => { resolveFirst = resolve; });
+      vi.mocked(downloadArtwork).mockReturnValueOnce(firstDownload);
+
+      const payload1: NowPlayingPayload = { name: 'First Song', artworkUrl: 'https://example.com/art1.jpg' };
+      const payload2: NowPlayingPayload = { name: 'Second Song', artworkUrl: 'https://example.com/art2.jpg' };
+
+      mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: true, positionUs: 0, state: PlaybackState.Playing });
+
+      // Fire first track
+      const firstPromise = mockPlayer.listeners['nowPlayingItemDidChange'](payload1) as Promise<void>;
+
+      // Fire second track before first artwork resolves
+      vi.mocked(downloadArtwork).mockResolvedValueOnce('/tmp/art2.png');
+      await mockPlayer.listeners['nowPlayingItemDidChange'](payload2);
+
+      // Clear the mock calls from the second track handler
+      vi.mocked(Menu.buildFromTemplate).mockClear();
+
+      // Resolve first artwork download - should be discarded (stale)
+      resolveFirst!('/tmp/art1.png');
+      await firstPromise;
+
+      // No additional menu rebuild from the stale first track
+      expect(vi.mocked(Menu.buildFromTemplate)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('playbackStateDidChange handler', () => {
+    it('clears state on terminal playback states', () => {
+      initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+
+      for (const state of [PlaybackState.None, PlaybackState.Stopped, PlaybackState.Ended, PlaybackState.Completed]) {
+        vi.mocked(Menu.buildFromTemplate).mockClear();
+        mockPlayer.listeners['playbackStateDidChange']({ status: true, state });
+        expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalled();
+      }
+    });
+
+    it('rebuilds menu on playback state change', () => {
+      initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+      mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: true, positionUs: 0, state: PlaybackState.Playing });
+
+      vi.mocked(Menu.buildFromTemplate).mockClear();
+      mockPlayer.listeners['playbackStateDidChange']({ status: true, state: PlaybackState.Playing });
+
+      expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalled();
+    });
+  });
+
+  describe('volumeDidChange handler', () => {
+    it('updates state and rebuilds menu on volume change', () => {
+      initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+      mockPlayer.playbackSnapshot.mockReturnValue({ isPlaying: true, positionUs: 0, state: PlaybackState.Playing });
+
+      vi.mocked(Menu.buildFromTemplate).mockClear();
+      mockPlayer.listeners['volumeDidChange'](0.5);
+
+      expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalled();
+    });
+
+    it('ignores null volume', () => {
+      initTrayStateManager(mockPlayer as unknown as Player, mockTray);
+
+      vi.mocked(Menu.buildFromTemplate).mockClear();
+      mockPlayer.listeners['volumeDidChange'](null);
+
+      expect(vi.mocked(Menu.buildFromTemplate)).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixes critical issues affecting menu functionality and window behaviour. Restores Cmd+Q quit functionality and About menu on macOS, prevents About and splash windows from entering fullscreen, and corrects SF Symbol icon rendering with proper sizing and theme adaptation.

## Changes
- Restore Cmd+Q quit functionality on macOS via app menu
- Add About menu item to main application menu
- Prevent About and splash windows from entering fullscreen
- Fix SF Symbol icon rendering with correct size and theme
- Extract pause timer logic into reusable utility module
- Extract tray state machine logic into initTrayStateManager function
- Add comprehensive tests for tray state management and pause timer utility
- Suppress empty menu bar on macOS

## Testing
- Verify Cmd+Q closes application on macOS
- Verify About menu item appears and opens dialog
- Verify About and splash windows stay in windowed mode
- Verify SF Symbol icons display with correct sizing and adapt to light/dark theme
- Tray state machine tests passing
- Pause timer utility tests passing