### PR TITLE
fix: bump castlabs electron to 40.8.6+wvcus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "electron-updater": "^6.8.3"
       },
       "devDependencies": {
-        "electron": "github:castlabs/electron-releases#v40.7.0+wvcus",
+        "electron": "github:castlabs/electron-releases#v40.8.6+wvcus",
         "electron-builder": "^26.8.2",
         "shx": "^0.4.0",
         "typescript": "^6.x",
@@ -2706,8 +2706,8 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.7.0+wvcus",
-      "resolved": "git+ssh://git@github.com/castlabs/electron-releases.git#3412c2dfbbaad4136f5b6767e902e3859222d1e8",
+      "version": "40.8.6+wvcus",
+      "resolved": "git+ssh://git@github.com/castlabs/electron-releases.git#f466da09e341c26efe6e72e32372f4d0473846e6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "BlueOak-1.0.0",
   "type": "commonjs",
   "devDependencies": {
-    "electron": "github:castlabs/electron-releases#v40.7.0+wvcus",
+    "electron": "github:castlabs/electron-releases#v40.8.6+wvcus",
     "electron-builder": "^26.8.2",
     "shx": "^0.4.0",
     "typescript": "^6.x",


### PR DESCRIPTION
## Summary
- update the pinned CastLabs Electron dependency from `v40.7.0+wvcus` to `v40.8.6+wvcus`
- refresh `package-lock.json` for the new Electron commit
- clear the current `npm audit` vulnerability affecting Electron 40.7.0

## Security context
The repository Dependabot alerts endpoint returned HTTP 403 for this token, so this change is based on local audit evidence. `npm audit` reported a high-severity Electron advisory set affecting `40.7.0+wvcus`; upgrading to `40.8.6+wvcus` clears the audit on this branch.

## Validation
- `nix develop -c sh -c 'npm audit --json'`
- `nix develop -c just lint`
- `nix develop -c just test`
- `git diff --check`