### PR TITLE
ci: add Dependabot Nix updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,8 @@ updates:
       npm:
         patterns:
           - "*"
+
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/tailor-automerge.yml
+++ b/.github/workflows/tailor-automerge.yml
@@ -43,14 +43,6 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Automerge flake.lock update
-        if: >-
-          github.event.pull_request.user.login == 'github-actions[bot]'
-          && startsWith(github.event.pull_request.head.ref, 'update_flake_lock')
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   automerge-existing:
     runs-on: ubuntu-slim

--- a/.github/workflows/tailor.yml
+++ b/.github/workflows/tailor.yml
@@ -28,25 +28,3 @@ jobs:
         with:
           branch: tailor-alter
           title: "chore: alter tailor swatches"
-
-  update-flake-lock:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Check for flake.lock
-        id: check
-        run: test -f flake.lock && echo "found=true" >> "$GITHUB_OUTPUT" || echo "found=false" >> "$GITHUB_OUTPUT"
-
-      - name: Install Nix
-        if: steps.check.outputs.found == 'true'
-        uses: DeterminateSystems/determinate-nix-action@v3
-
-      - name: Update flake.lock
-        if: steps.check.outputs.found == 'true'
-        uses: DeterminateSystems/update-flake-lock@v28
-        with:
-          pr-title: "chore: update flake.lock"


### PR DESCRIPTION
## Summary
- enable Dependabot version updates for Nix flakes
- let Dependabot maintain `flake.lock` inputs on a weekly schedule
- remove the old `DeterminateSystems/update-flake-lock` automation to avoid duplicate lockfile PRs

## Context
GitHub now supports Nix flakes in Dependabot version updates:
https://github.blog/changelog/2026-04-07-dependabot-version-updates-now-support-the-nix-ecosystem/

## Validation
- `git diff --check`
- verified every active flake repo has a `nix` Dependabot entry
- verified no `DeterminateSystems/update-flake-lock`, `update_flake_lock`, or `update-flake-lock` references remain
