### PR TITLE
fix(ui): refresh theme styling and splash readiness probe

### DIFF
--- a/assets/catppuccin.css
+++ b/assets/catppuccin.css
@@ -85,17 +85,25 @@
     --systemToolbarTitlebarMaterialSover: rgba(24,24,37,0.8) !important;
   }
 
-  /* Top player bar: amp-chrome-player::before paints the bar background
-     independently of :root variables - must be overridden directly */
-  .wrapper amp-chrome-player::before {
-    background-color: rgba(24, 24, 37, 0.88) !important;
+  /* Scrollbars */
+  * {
+    scrollbar-color: #45475a #181825 !important;
   }
 
-  /* Prevent .player-bar from painting its own light background over the top */
-  .player-bar,
-  .chrome-player.chrome-player__music {
-    background: none !important;
-    box-shadow: none !important;
+  *::-webkit-scrollbar {
+    width: 12px !important;
+    height: 12px !important;
+    background-color: #181825 !important;
+  }
+
+  *::-webkit-scrollbar-thumb {
+    background-color: #45475a !important;
+    border: 3px solid #181825 !important;
+    border-radius: 999px !important;
+  }
+
+  *::-webkit-scrollbar-track {
+    background-color: #181825 !important;
   }
 
   /* Force variables into shadow-DOM-scoped elements */
@@ -125,14 +133,51 @@
     background-color: rgba(24, 24, 37, 0.97) !important;
   }
 
-  /* LCD now-playing text/info area background */
-  amp-lcd {
-    --lcd-bg-color: #313244 !important;
+  /* Footer */
+  :is(
+    footer,
+    .scrollable-page footer,
+    .dt-footer,
+    [class*="page-footer"],
+    [class*="dt-footer"]
+  ) {
+    background: #11111b !important;
+    background-color: #11111b !important;
+    border-color: rgba(88,91,112,0.2) !important;
+    color: rgba(205,214,244,0.85) !important;
   }
 
-  /* Footer */
-  .scrollable-page > footer {
-    background-color: #11111b !important;
+  :is(
+    footer,
+    .scrollable-page footer,
+    .dt-footer
+  ) :is(a, button, select, [role="button"], [class*="dropdown"]) {
+    background-color: #181825 !important;
+    border-color: rgba(88,91,112,0.25) !important;
+    color: rgba(205,214,244,0.85) !important;
+  }
+
+  /* Country/location banner background */
+  :is(
+    [class*="locale-banner"],
+    [class*="locale-switcher"],
+    [class*="localization"],
+    [class*="country-banner"],
+    [class*="country-picker"],
+    [class*="location-banner"],
+    [class*="location-picker"],
+    [class*="storefront-banner"],
+    [class*="storefront-picker"],
+    [class*="storefront-switcher"],
+    [class*="geo-banner"],
+    [class*="geo-location"],
+    [role="dialog"]:has(select):has(button),
+    body > :is(div, section, aside)[style*="bottom"]:has(select):has(button),
+    body > :is(div, section, aside)[class*="fixed"]:has(select):has(button),
+    body > :is(div, section, aside)[class*="banner"]:has(select):has(button)
+  ) {
+    background: #181825 !important;
+    background-color: #181825 !important;
   }
 }
 
@@ -218,15 +263,25 @@
     --systemToolbarTitlebarMaterialSover: rgba(230,233,239,0.8) !important;
   }
 
-  /* Top player bar */
-  .wrapper amp-chrome-player::before {
-    background-color: rgba(230, 233, 239, 0.88) !important;
+  /* Scrollbars */
+  * {
+    scrollbar-color: #bcc0cc #e6e9ef !important;
   }
 
-  .player-bar,
-  .chrome-player.chrome-player__music {
-    background: none !important;
-    box-shadow: none !important;
+  *::-webkit-scrollbar {
+    width: 12px !important;
+    height: 12px !important;
+    background-color: #e6e9ef !important;
+  }
+
+  *::-webkit-scrollbar-thumb {
+    background-color: #bcc0cc !important;
+    border: 3px solid #e6e9ef !important;
+    border-radius: 999px !important;
+  }
+
+  *::-webkit-scrollbar-track {
+    background-color: #e6e9ef !important;
   }
 
   * {
@@ -255,14 +310,51 @@
     background-color: rgba(230, 233, 239, 0.97) !important;
   }
 
-  /* LCD now-playing text/info area background */
-  amp-lcd {
-    --lcd-bg-color: #ccd0da !important;
+  /* Footer */
+  :is(
+    footer,
+    .scrollable-page footer,
+    .dt-footer,
+    [class*="page-footer"],
+    [class*="dt-footer"]
+  ) {
+    background: #dce0e8 !important;
+    background-color: #dce0e8 !important;
+    border-color: rgba(172,176,190,0.2) !important;
+    color: rgba(76,79,105,0.85) !important;
   }
 
-  /* Footer */
-  .scrollable-page > footer {
-    background-color: #dce0e8 !important;
+  :is(
+    footer,
+    .scrollable-page footer,
+    .dt-footer
+  ) :is(a, button, select, [role="button"], [class*="dropdown"]) {
+    background-color: #e6e9ef !important;
+    border-color: rgba(172,176,190,0.25) !important;
+    color: rgba(76,79,105,0.85) !important;
+  }
+
+  /* Country/location banner background */
+  :is(
+    [class*="locale-banner"],
+    [class*="locale-switcher"],
+    [class*="localization"],
+    [class*="country-banner"],
+    [class*="country-picker"],
+    [class*="location-banner"],
+    [class*="location-picker"],
+    [class*="storefront-banner"],
+    [class*="storefront-picker"],
+    [class*="storefront-switcher"],
+    [class*="geo-banner"],
+    [class*="geo-location"],
+    [role="dialog"]:has(select):has(button),
+    body > :is(div, section, aside)[style*="bottom"]:has(select):has(button),
+    body > :is(div, section, aside)[class*="fixed"]:has(select):has(button),
+    body > :is(div, section, aside)[class*="banner"]:has(select):has(button)
+  ) {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
   }
 }
 

--- a/assets/styleFix.css
+++ b/assets/styleFix.css
@@ -18,8 +18,3 @@
   footer.dt-footer {
     display: none !important;
   }
-
-  /* Bigger transport bar - zoom controls, LCD, and icons */
-  amp-chrome-player {
-    zoom: 1.25;
-  }

--- a/src/contentReady.ts
+++ b/src/contentReady.ts
@@ -1,0 +1,5 @@
+export const CONTENT_READY_SELECTOR = '.app-container .navigation__header .logo';
+
+export function contentReadyProbeScript(): string {
+  return `!!document.querySelector(${JSON.stringify(CONTENT_READY_SELECTOR)})`;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { init as initDock, setDockSendCommandCallback } from './integrations/mac
 import { init as initWindowsTaskbar, setTaskbarSendCommandCallback } from './integrations/windows-taskbar';
 import { cleanArtworkCache } from './artwork';
 import { init as initWedgeDetector, reset as resetWedgeDetector } from './wedgeDetector';
+import { contentReadyProbeScript } from './contentReady';
 
 const SPLASH_MIN_DISPLAY_MS = 500;
 const CONTENT_READY_POLL_MS = 100;
@@ -234,7 +235,7 @@ function createMainWindow(ses: Electron.Session): { win: BrowserWindow; winReady
       win.webContents.once('did-navigate-in-page', () => {
         const poll = () => {
           if (pollCancelled) return;
-          win.webContents.executeJavaScript('!!document.querySelector("amp-lcd[hydrated]")')
+          win.webContents.executeJavaScript(contentReadyProbeScript())
             .then(ready => { if (ready) resolve(); else if (!pollCancelled) setTimeout(poll, CONTENT_READY_POLL_MS); })
             .catch(() => { if (!pollCancelled) setTimeout(poll, CONTENT_READY_POLL_MS); });
         };

--- a/test/catppuccin.test.ts
+++ b/test/catppuccin.test.ts
@@ -1,0 +1,116 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const catppuccinCss = fs.readFileSync(path.join(__dirname, '..', 'assets', 'catppuccin.css'), 'utf-8');
+const styleFixCss = fs.readFileSync(path.join(__dirname, '..', 'assets', 'styleFix.css'), 'utf-8');
+
+function mediaBlock(css: string, query: string): string {
+  const start = css.indexOf(`@media (${query})`);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const next = css.indexOf('@media (', start + 1);
+  return next === -1 ? css.slice(start) : css.slice(start, next);
+}
+
+describe('catppuccin.css', () => {
+  it('styles scrollbars in both colour-scheme variants', () => {
+    const darkCss = mediaBlock(catppuccinCss, 'prefers-color-scheme: dark');
+    const lightCss = mediaBlock(catppuccinCss, 'prefers-color-scheme: light');
+
+    expect(darkCss).toContain('scrollbar-color: #45475a #181825 !important;');
+    expect(darkCss).toContain('*::-webkit-scrollbar');
+    expect(darkCss).toContain('*::-webkit-scrollbar-thumb');
+    expect(darkCss).toContain('*::-webkit-scrollbar-track');
+
+    expect(lightCss).toContain('scrollbar-color: #bcc0cc #e6e9ef !important;');
+    expect(lightCss).toContain('*::-webkit-scrollbar');
+    expect(lightCss).toContain('*::-webkit-scrollbar-thumb');
+    expect(lightCss).toContain('*::-webkit-scrollbar-track');
+  });
+
+  it('keeps scrollbar styling out of styleFix.css', () => {
+    expect(styleFixCss).not.toContain('scrollbar-color');
+    expect(styleFixCss).not.toContain('::-webkit-scrollbar');
+  });
+
+  it('keeps old player structural selectors out while retaining player variables', () => {
+    const darkCss = mediaBlock(catppuccinCss, 'prefers-color-scheme: dark');
+    const lightCss = mediaBlock(catppuccinCss, 'prefers-color-scheme: light');
+
+    expect(catppuccinCss).not.toContain('.wrapper amp-chrome-player::before');
+    expect(catppuccinCss).not.toContain('.player-bar');
+    expect(catppuccinCss).not.toContain('.chrome-player.chrome-player__music');
+    expect(catppuccinCss).not.toContain('amp-lcd');
+
+    expect(darkCss).toContain('--playerBackground: rgba(24,24,37,0.88) !important;');
+    expect(darkCss).toContain('--playerBGFill: rgba(24, 24, 37, 0.88) !important;');
+    expect(darkCss).toContain('--keyColor: #f38ba8 !important;');
+
+    expect(lightCss).toContain('--playerBackground: rgba(230,233,239,0.88) !important;');
+    expect(lightCss).toContain('--playerBGFill: rgba(230, 233, 239, 0.88) !important;');
+    expect(lightCss).toContain('--keyColor: #d20f39 !important;');
+  });
+
+  it('styles footer areas in both colour-scheme variants', () => {
+    const darkCss = mediaBlock(catppuccinCss, 'prefers-color-scheme: dark');
+    const lightCss = mediaBlock(catppuccinCss, 'prefers-color-scheme: light');
+
+    expect(darkCss).toContain('/* Footer */');
+    expect(darkCss).toContain('.scrollable-page footer');
+    expect(darkCss).toContain('background: #11111b !important;');
+    expect(darkCss).toContain('background-color: #181825 !important;');
+
+    expect(lightCss).toContain('/* Footer */');
+    expect(lightCss).toContain('.scrollable-page footer');
+    expect(lightCss).toContain('background: #dce0e8 !important;');
+    expect(lightCss).toContain('background-color: #e6e9ef !important;');
+  });
+
+  it('sets country/location banner container backgrounds in both colour-scheme variants', () => {
+    const darkCss = mediaBlock(catppuccinCss, 'prefers-color-scheme: dark');
+    const lightCss = mediaBlock(catppuccinCss, 'prefers-color-scheme: light');
+
+    expect(darkCss).toContain('/* Country/location banner background */');
+    expect(darkCss).toContain('[class*="country-banner"]');
+    expect(darkCss).toContain('[class*="location-banner"]');
+    expect(darkCss).toContain('[class*="storefront-banner"]');
+    expect(darkCss).toContain('[role="dialog"]:has(select):has(button)');
+    expect(darkCss).toContain('body > :is(div, section, aside)[style*="bottom"]:has(select):has(button)');
+    expect(darkCss).toContain('background: #181825 !important;');
+    expect(darkCss).toContain('background-color: #181825 !important;');
+
+    expect(lightCss).toContain('/* Country/location banner background */');
+    expect(lightCss).toContain('[class*="country-banner"]');
+    expect(lightCss).toContain('[class*="location-banner"]');
+    expect(lightCss).toContain('[class*="storefront-banner"]');
+    expect(lightCss).toContain('[role="dialog"]:has(select):has(button)');
+    expect(lightCss).toContain('body > :is(div, section, aside)[style*="bottom"]:has(select):has(button)');
+    expect(lightCss).toContain('background: #e6e9ef !important;');
+    expect(lightCss).toContain('background-color: #e6e9ef !important;');
+  });
+
+  it('keeps country/location banner control styling on Apple Music defaults', () => {
+    expect(catppuccinCss).not.toContain('[class*="country-select"]');
+    expect(catppuccinCss).not.toContain('[class*="country-selector"]');
+    expect(catppuccinCss).not.toContain('[class*="location-selector"]');
+    expect(catppuccinCss).not.toContain('[class*="storefront-selector"]');
+    expect(catppuccinCss).not.toContain('[data-testid*="country" i]');
+    expect(catppuccinCss).not.toContain('[aria-label*="country" i]');
+    expect(catppuccinCss).not.toContain('[role="combobox"]');
+    expect(catppuccinCss).not.toContain('[class*="menu"]');
+    expect(catppuccinCss).not.toContain('[class*="continue"]');
+    expect(catppuccinCss).not.toContain('[aria-label*="continue" i]');
+    expect(catppuccinCss).not.toContain('[class*="close-button"]');
+    expect(catppuccinCss).not.toContain('[aria-label*="close" i]');
+  });
+
+  it('keeps Catppuccin footer and prompt styling out of styleFix.css', () => {
+    expect(styleFixCss).not.toContain('[class*="country-banner"]');
+    expect(styleFixCss).not.toContain('[class*="location-banner"]');
+    expect(styleFixCss).not.toContain('[class*="storefront-banner"]');
+    expect(styleFixCss).not.toContain('[class*="country-selector"]');
+    expect(styleFixCss).not.toContain('[data-testid*="country" i]');
+    expect(styleFixCss).not.toContain('[role="dialog"]:has(select):has(button)');
+  });
+});

--- a/test/contentReady.test.ts
+++ b/test/contentReady.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { CONTENT_READY_SELECTOR, contentReadyProbeScript } from '../src/contentReady';
+
+describe('content readiness marker', () => {
+  it('uses the Apple Music app shell navigation logo', () => {
+    expect(CONTENT_READY_SELECTOR).toBe('.app-container .navigation__header .logo');
+  });
+
+  it('does not use the stale amp-lcd hydration marker', () => {
+    expect(contentReadyProbeScript()).toBe('!!document.querySelector(".app-container .navigation__header .logo")');
+    expect(contentReadyProbeScript()).not.toContain('amp-lcd');
+  });
+});

--- a/test/styleFix.test.ts
+++ b/test/styleFix.test.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const styleFixCss = fs.readFileSync(path.join(__dirname, '..', 'assets', 'styleFix.css'), 'utf-8');
+
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function globalAmpChromePlayerBlocks(css: string): string[] {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^{}]+)\}/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = rulePattern.exec(stripComments(css))) !== null) {
+    const selectors = match[1].split(',').map(selector => selector.trim());
+    if (selectors.includes('amp-chrome-player')) {
+      blocks.push(match[2]);
+    }
+  }
+
+  return blocks;
+}
+
+function containsPlayerEnlargement(declarations: string): boolean {
+  const enlargementProperty = /(?:^|;)\s*(?:zoom|scale|width|height|min-width|min-height|inline-size|block-size|min-inline-size|min-block-size|padding|padding-block|padding-inline|gap)\s*:/i;
+  const transformScale = /(?:^|;)\s*transform\s*:\s*[^;]*\bscale(?:3d|x|y|z)?\s*\(/i;
+
+  return enlargementProperty.test(declarations) || transformScale.test(declarations);
+}
+
+describe('styleFix.css', () => {
+  it('does not globally enlarge amp-chrome-player', () => {
+    const forbiddenBlocks = globalAmpChromePlayerBlocks(styleFixCss)
+      .filter(containsPlayerEnlargement);
+
+    expect(forbiddenBlocks).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Refresh the Catppuccin styling and keep the app splash flow aligned with the current startup sequence, while removing an obsolete player enlargement rule.

## Changes
- Refresh the Catppuccin theme CSS for the current UI
- Remove the obsolete player enlargement rule from the style-fix stylesheet
- Update the splash readiness probe in the main process
- Add and adjust tests for the changed styling and startup behaviour

## Testing
- Verified the branch is clean with `git status`
- Reviewed the branch diff and commit set before pushing