### PR TITLE
feat(build): add snap package target with automated publishing

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -142,7 +142,7 @@ jobs:
         include:
           - os: linux
             runner: ubuntu-22.04
-            targets: "--linux AppImage deb rpm"
+            targets: "--linux AppImage deb rpm snap"
           - os: macos
             runner: macos-latest
             targets: "--mac dmg"
@@ -176,9 +176,12 @@ jobs:
       - name: Install uv
         if: matrix.os == 'macos' || matrix.os == 'windows'
         uses: astral-sh/setup-uv@v7
-      - name: Install RPM and SVG tools
+      - name: Install snap tooling
         if: matrix.os == 'linux'
-        run: sudo apt-get update && sudo apt-get install -y librsvg2-bin rpm
+        run: |
+          sudo snap install snapcraft --classic
+          sudo apt-get update
+          sudo apt-get install -y librsvg2-bin rpm
       - name: Compile TypeScript
         run: npm run build
       - name: Build distributables
@@ -186,6 +189,7 @@ jobs:
         env:
           EVS_ACCOUNT_NAME: ${{ secrets.EVS_ACCOUNT_NAME }}
           EVS_PASSWD: ${{ secrets.EVS_PASSWD }}
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
       - name: Upload artefacts
         uses: actions/upload-artifact@v7
         with:
@@ -194,6 +198,7 @@ jobs:
             release/*.AppImage
             release/*.deb
             release/*.rpm
+            release/*.snap
             release/*.dmg
             release/*.exe
             release/latest*.yml
@@ -228,9 +233,34 @@ jobs:
             release/*.AppImage
             release/*.deb
             release/*.rpm
+            release/*.snap
             release/*.dmg
             release/*.exe
             release/latest*.yml
+
+  publish-snap:
+    name: Publish Snap 📦
+    needs: [build]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download Linux artefacts
+        uses: actions/download-artifact@v8
+        with:
+          name: sidra-linux
+          path: release/
+      - name: Locate snap file
+        id: find
+        run: echo "snap=$(ls release/*.snap)" >> "$GITHUB_OUTPUT"
+      - name: Publish to Snap Store edge
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.find.outputs.snap }}
+          release: edge
 
   nix-hash:
     name: Nix Hash 🔑

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ sudo dnf install ./Sidra-*.rpm      # Fedora
 sudo zypper install ./Sidra-*.rpm   # openSUSE
 ```
 
+**Snap** - Ubuntu and other snapd-enabled distributions:
+
+```bash
+sudo snap install sidra
+```
+
 **Nix**:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
       "target": [
         "AppImage",
         "deb",
-        "rpm"
+        "rpm",
+        "snap"
       ],
       "category": "Audio",
       "executableName": "sidra",
@@ -102,6 +103,14 @@
     },
     "rpm": {
       "vendor": "Martin Wimpress"
+    },
+    "snap": {
+      "confinement": "strict",
+      "grade": "stable",
+      "base": "core22",
+      "summary": "An elegant Apple Music desktop client",
+      "plugs": ["default", "removable-media"],
+      "publish": false
     },
     "afterPack": "build/afterPack.cjs",
     "mac": {

--- a/src/autoUpdate.ts
+++ b/src/autoUpdate.ts
@@ -17,6 +17,12 @@ export function isAutoUpdateSupported(): boolean {
     return false;
   }
 
+  // Linux snap: snapd handles refresh, so electron-updater must stay disabled
+  if (process.env.SNAP) {
+    autoUpdateLog.info('auto-update not supported: snap detected (snapd handles refresh)');
+    return false;
+  }
+
   // Linux AppImage: process.env.APPIMAGE is set only when running as an AppImage
   if (process.env.APPIMAGE) {
     autoUpdateLog.info('auto-update supported: AppImage detected');


### PR DESCRIPTION
- Add snapcraft build target to electron-builder configuration with strict confinement, stable grade, and core22 base
- Install snapcraft tooling in CI pipeline and configure build environment
- Implement publish-snap job to push releases to Snap Store edge channel
- Gate auto-update in snap environment to defer to snapd refresh mechanism
- Include snap artefact (.snap) in build and release workflows

Snap confinement is strict with disabled auto-publishing to allow review before edge channel release. The publish-snap job only triggers on git tags, ensuring production releases flow through the intended channel.

Close #83