### PR TITLE
build(macos): build both x64 and arm64 DMG artefacts

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -145,7 +145,7 @@ jobs:
             targets: "--linux AppImage deb rpm snap"
           - os: macos
             runner: macos-latest
-            targets: "--mac dmg"
+            targets: "--mac dmg --x64 --arm64"
           - os: windows
             runner: windows-latest
             targets: "--win nsis"

--- a/justfile
+++ b/justfile
@@ -198,7 +198,7 @@ package: build
     trap 'npm version "$base_version" --no-git-tag-version --allow-same-version >/dev/null 2>&1' EXIT
 
     npm version "$dev_version" --no-git-tag-version --allow-same-version
-    npx electron-builder {{ if os() == "linux" { "--linux AppImage" } else if os() == "macos" { "--mac dmg" } else { "error('Unsupported platform')" } }}
+    npx electron-builder {{ if os() == "linux" { "--linux AppImage" } else if os() == "macos" { "--mac dmg --x64 --arm64" } else { "error('Unsupported platform')" } }}
 
 # Show log file location and tail recent entries
 logs:


### PR DESCRIPTION
- CI workflow now passes `--x64 --arm64` to electron-builder on macOS
- `just package` mirrors the same flags for local macOS DMG builds

Closes #99