### PR TITLE
fix: update Nix package for Sidra 0.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sidra",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sidra",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@holusion/dbus-next": "^0.11.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sidra",
   "productName": "Sidra",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "An elegant Apple Music desktop client for Linux, macOS and Windows. No frippery, just quality. A better class of Cider 🍎",
   "main": "dist/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps Sidra package metadata from `0.3.3` to `0.3.4`.
- Uses the existing 0.3.4 release asset hashes already present on `main`.
- Corrects the previous PR revision, which only handled the stale 0.3.3 `.deb` hash mismatch.

## Validation
- `nix store prefetch-file --json --hash-type sha256 "https://github.com/wimpysworld/sidra/releases/download/0.3.4/Sidra-0.3.4-linux-amd64.deb"`
- `nix store prefetch-file --json --hash-type sha256 "https://github.com/wimpysworld/sidra/releases/download/0.3.4/Sidra-0.3.4-mac-arm64.dmg"`
- `git diff --check upstream/main..HEAD`
- `nix build --no-link --print-build-logs .#packages.x86_64-linux.sidra`
