### PR TITLE
feat: support custom css

### DIFF
--- a/src/customCss.ts
+++ b/src/customCss.ts
@@ -1,0 +1,98 @@
+import { app, BrowserWindow } from 'electron';
+import fs from 'fs';
+import path from 'path';
+import log from 'electron-log/main';
+
+const customCssLog = log.scope('customCss');
+
+const WATCH_DEBOUNCE_MS = 150;
+const TARGET_FILE = 'custom.css';
+
+let cssKey: string | null = null;
+let watcher: fs.FSWatcher | null = null;
+let debounceTimer: NodeJS.Timeout | null = null;
+let cssOp: Promise<void> = Promise.resolve();
+let targetWindow: BrowserWindow | null = null;
+
+function customCssPath(): string {
+  return path.join(app.getPath('userData'), TARGET_FILE);
+}
+
+function readCustomCss(): string | null {
+  try {
+    return fs.readFileSync(customCssPath(), 'utf8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return null;
+    customCssLog.warn('failed to read custom.css', err);
+    return null;
+  }
+}
+
+export function applyCustomCss(win: BrowserWindow): Promise<void> {
+  cssOp = cssOp
+    .catch((err: unknown) => {
+      customCssLog.warn('custom CSS op failed', err);
+    })
+    .then(async () => {
+      if (cssKey !== null) {
+        // the key may be stale after a page navigation; if so the inserted
+        // stylesheet is already gone and remove throws
+        try {
+          await win.webContents.removeInsertedCSS(cssKey);
+        } catch {
+          // stale key, nothing to clean up
+        }
+        cssKey = null;
+      }
+      const css = readCustomCss();
+      if (css !== null && css.trim() !== '') {
+        cssKey = await win.webContents.insertCSS(css);
+        customCssLog.debug('custom.css applied');
+      }
+    });
+  return cssOp;
+}
+
+export function initCustomCss(win: BrowserWindow): void {
+  targetWindow = win;
+  const dir = app.getPath('userData');
+
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch (err) {
+    customCssLog.warn('failed to ensure userData dir exists', err);
+    return;
+  }
+
+  try {
+    watcher = fs.watch(dir, { persistent: false }, (_event, filename) => {
+      if (filename !== TARGET_FILE) return;
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        if (!targetWindow || targetWindow.isDestroyed()) return;
+        customCssLog.debug('custom.css changed, re-applying');
+        void applyCustomCss(targetWindow);
+      }, WATCH_DEBOUNCE_MS);
+    });
+    watcher.on('error', (err) => {
+      customCssLog.warn('watcher error', err);
+    });
+    customCssLog.debug(`watching ${path.join(dir, TARGET_FILE)}`);
+  } catch (err) {
+    customCssLog.warn('failed to watch userData for custom.css', err);
+  }
+
+  app.on('will-quit', () => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+    if (watcher) {
+      watcher.close();
+      watcher = null;
+    }
+    targetWindow = null;
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { Player, IntegrationContext } from './player';
 import { buildAppleMusicURL, buildItmsRouteURL, handleStorefrontNavigation } from './storefront';
 import { extractItmsUrlFromArgv, type ItmsTarget } from './itms';
 import { initThemeCSS, setThemeCssKey } from './theme';
+import { applyCustomCss, initCustomCss } from './customCss';
 import { createTray, getMenuIcon, initTrayStateManager, rebuildTrayMenu, setApplyZoomCallback, setSendCommandCallback } from './tray';
 import { showAboutWindow } from './aboutWindow';
 import { checkForUpdates } from './update';
@@ -566,6 +567,7 @@ function setupContentHandlers(win: BrowserWindow, player: Player, markCssReady: 
       setThemeCssKey(await win.webContents.insertCSS(assets.CATPPUCCIN_CSS));
       mainLog.debug(`Theme CSS injected: ${theme}`);
     }
+    await applyCustomCss(win);
     await win.webContents.executeJavaScript(assets.hookScript);
     mainLog.debug('MusicKit hook injected');
     await win.webContents.executeJavaScript(assets.navBarScript);
@@ -640,6 +642,7 @@ if (gotLock) {
     setTaskbarSendCommandCallback((channel, ...args) => win!.webContents.send(channel, ...args));
     setupWindowZoomAndNav(win);
     initThemeCSS(win, assets.CATPPUCCIN_CSS);
+    initCustomCss(win);
     setupSplashTransition(win, splash, minDisplay, cssReady, winReady);
     setupSessionHeaders(ses);
     setupContentHandlers(win, player, markCssReady, assets);


### PR DESCRIPTION
thanks for this project, it's great to finally have apple music working well on linux :D

my config is super dialed in in terms of theming, so i felt like sidra needed some way to not look way different compared to everything else i use. hence, custom css support! 

i tried to keep the changes to the absolute minimum required to make this work reliably. i wanted to focus on the implementation, rather than on decisions like "should this be a config toggle"

i also removed `nix_direnv_manual_reload` from `.envrc`, because it confusingly blocked direnv from setting up the development shell. if this is intended, feel free to ignore that commit (kept it separate on purpose), but you might want to add a note about the required extra `nix-direnv-reload` command in the development section of the readme.

also, while i tried to use os-independent mechanisms, i only tested the changes on nixos

nara