### PR TITLE
Fix visible DMG background helper icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
       "entitlementsInherit": "build/entitlements.mac.plist"
     },
     "dmg": {
-      "background": "build/background.png",
+      "backgroundColor": "#1a0a10",
       "window": {
         "width": 540,
         "height": 380

--- a/scripts/validate-build-config.cjs
+++ b/scripts/validate-build-config.cjs
@@ -35,7 +35,14 @@ async function main() {
   }
   console.log("  \u2713 no deprecated options detected");
 
-  // 4. Validate package.json author has email (required by RPM/DEB FPM targets)
+  // 4. Avoid image-backed DMG backgrounds: their helper files can appear as
+  //    visible icons in Finder on newer macOS releases.
+  if (config.dmg != null && config.dmg.background != null) {
+    throw new Error("dmg.background must not be set; use dmg.backgroundColor to avoid visible background helper files");
+  }
+  console.log("  \u2713 DMG uses backgroundColor instead of background image");
+
+  // 5. Validate package.json author has email (required by RPM/DEB FPM targets)
   const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, "package.json"), "utf8"));
   const author = pkg.author;
   const emailRegex = /<[^>]+@[^>]+>/;


### PR DESCRIPTION
## Summary
- Replace the image-backed DMG background with the same Sidra dark colour via `dmg.backgroundColor`.
- Add a build-config validation guard so `dmg.background` is not reintroduced.

## Why
The current image-backed DMG background relies on Finder/dmgbuild metadata to hide helper background files. On newer macOS releases those helpers can appear as extra unreadable icons in the mounted DMG window.

Fixes #114.

## Validation
- `node scripts/validate-build-config.cjs`
- `npm test`
- `npm run build`
