### PR TITLE
docs: re-point linuxmatters.png in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Sidra takes the opposite approach: wrap `music.apple.com` directly, stay out of 
 **As featured on [Linux Matters](https://linuxmatters.sh) podcast!** 🎙️ I am a presenter on Linux Matters and I discussed some of the backstory and how came to create Sidra on [Episode 79 - Pouring out the Sidra](https://linuxmatters.sh/79/).
 
 <div align="center">
-  <a href="https://linuxmatters.sh" target="_blank"><img src="https://github.com/wimpysworld/nix-config/raw/main/.github/screenshots/linuxmatters.png" alt="Linux Matters Podcast"/></a>
+  <a href="https://linuxmatters.sh" target="_blank"><img src="https://github.com/wimpysworld/nix-config/raw/main/assets/linuxmatters.png" alt="Linux Matters Podcast"/></a>
   <br />
   <em>Linux Matters Podcast</em>
 </div>


### PR DESCRIPTION
# Description

This image was moved in https://github.com/wimpysworld/nix-config/commit/96e4b69b7d953c0ca97397c8d52cff1daaa4c2fb 
Thus the README.md now has a broken image link which needs repointing to match the new location.

You might prefer to copy the asset locally. Are there any templates or automations that the above commit has affected?

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested my changes and confirmed there are no regressions
