### PR TITLE
build(ci): automate Electron toolchain updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: electron
+      - dependency-name: electron-builder
+      - dependency-name: electron-updater
     groups:
       npm:
         patterns:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -147,7 +147,7 @@ jobs:
         include:
           - os: linux
             runner: ubuntu-24.04
-            targets: "--linux AppImage deb rpm snap"
+            targets: "--linux AppImage deb rpm"
           - os: macos
             runner: macos-latest
             targets: "--mac dmg --x64 --arm64"
@@ -194,7 +194,12 @@ jobs:
         env:
           EVS_ACCOUNT_NAME: ${{ secrets.EVS_ACCOUNT_NAME }}
           EVS_PASSWD: ${{ secrets.EVS_PASSWD }}
-          SNAPCRAFT_BUILD_ENVIRONMENT: host
+      - name: Build snap
+        if: matrix.os == 'linux'
+        run: sudo env "PATH=$PATH" SNAPCRAFT_BUILD_ENVIRONMENT=host npx electron-builder --publish never --linux snap
+        env:
+          EVS_ACCOUNT_NAME: ${{ secrets.EVS_ACCOUNT_NAME }}
+          EVS_PASSWD: ${{ secrets.EVS_PASSWD }}
       - name: Upload artefacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -146,7 +146,7 @@ jobs:
       matrix:
         include:
           - os: linux
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
             targets: "--linux AppImage deb rpm snap"
           - os: macos
             runner: macos-latest

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -180,7 +180,7 @@ jobs:
         run: npm ci
       - name: Install uv
         if: matrix.os == 'macos' || matrix.os == 'windows'
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Install snap tooling
         if: matrix.os == 'linux'
         run: |

--- a/.github/workflows/publish-snap-manual.yml
+++ b/.github/workflows/publish-snap-manual.yml
@@ -40,11 +40,10 @@ jobs:
       - name: Compile TypeScript 🛠️
         run: npm run build
       - name: Build Snap 🏗️
-        run: npx electron-builder --publish never --linux snap
+        run: sudo env "PATH=$PATH" SNAPCRAFT_BUILD_ENVIRONMENT=host npx electron-builder --publish never --linux snap
         env:
           EVS_ACCOUNT_NAME: ${{ secrets.EVS_ACCOUNT_NAME }}
           EVS_PASSWD: ${{ secrets.EVS_PASSWD }}
-          SNAPCRAFT_BUILD_ENVIRONMENT: host
       - name: Upload Artefacts 📤
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/update-electron-toolchain.yml
+++ b/.github/workflows/update-electron-toolchain.yml
@@ -1,0 +1,67 @@
+name: Update Electron Toolchain
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: update-electron-toolchain
+  cancel-in-progress: false
+
+jobs:
+  update-electron-toolchain:
+    name: Update Electron Toolchain
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - name: Update package metadata
+        run: node scripts/update-electron-toolchain.cjs
+      - name: Refresh lockfile
+        run: npm install --package-lock-only --ignore-scripts
+      - name: Create pull request
+        env:
+          BRANCH: ci/update-electron-toolchain
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- package.json package-lock.json; then
+            echo "Electron toolchain is current"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          gh auth setup-git
+          git checkout -B "$BRANCH"
+          git add package.json package-lock.json
+          git commit -m "build(deps): update Electron toolchain"
+          git fetch origin "$BRANCH:refs/remotes/origin/$BRANCH" || true
+          git push --force-with-lease --set-upstream origin "$BRANCH"
+
+          if gh pr view "$BRANCH" --json url --jq .url >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" \
+              --title "build(deps): update Electron toolchain" \
+              --body "Update CastLabs Electron, electron-builder, and electron-updater to current stable releases."
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "build(deps): update Electron toolchain" \
+              --body "Update CastLabs Electron, electron-builder, and electron-updater to current stable releases."
+          fi

--- a/package.json
+++ b/package.json
@@ -187,16 +187,6 @@
           "y": 150,
           "type": "link",
           "path": "/Applications"
-        },
-        {
-          "x": 10000,
-          "y": 10000,
-          "path": ".background.tiff"
-        },
-        {
-          "x": 10000,
-          "y": 10000,
-          "path": ".VolumeIcon.icns"
         }
       ]
     },

--- a/scripts/update-electron-toolchain.cjs
+++ b/scripts/update-electron-toolchain.cjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+"use strict";
+
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+
+const packageJsonPath = "package.json";
+const castLabsStableTagPattern = /^v(\d+)\.(\d+)\.(\d+)\+wvcus$/;
+const electronBuilderRepo = "https://github.com/electron-userland/electron-builder.git";
+
+function run(command, args) {
+  return execFileSync(command, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  }).trim();
+}
+
+function compareTriplets(left, right) {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return left[index] - right[index];
+    }
+  }
+
+  return 0;
+}
+
+function parseCastLabsTag(tag) {
+  const match = castLabsStableTagPattern.exec(tag);
+  if (match === null) {
+    return null;
+  }
+
+  return match.slice(1).map((part) => Number.parseInt(part, 10));
+}
+
+function latestCastLabsElectronTag() {
+  const refs = run("git", [
+    "ls-remote",
+    "--tags",
+    "https://github.com/castlabs/electron-releases.git",
+    "refs/tags/v*+wvcus",
+  ]);
+
+  const latest = refs
+    .split(/\r?\n/)
+    .map((line) => line.split(/\s+/)[1])
+    .filter((ref) => ref !== undefined && !ref.endsWith("^{}"))
+    .map((ref) => ref.replace("refs/tags/", ""))
+    .map((tag) => ({ tag, parts: parseCastLabsTag(tag) }))
+    .filter((entry) => entry.parts !== null)
+    .sort((left, right) => compareTriplets(left.parts, right.parts))
+    .at(-1);
+
+  if (latest === undefined) {
+    throw new Error("No stable CastLabs Electron WVCUS tags found");
+  }
+
+  return latest.tag;
+}
+
+function latestElectronBuilderTag(packageName) {
+  const tagPattern = new RegExp(`^${packageName}@(\\d+)\\.(\\d+)\\.(\\d+)$`);
+  const refs = run("git", [
+    "ls-remote",
+    "--tags",
+    electronBuilderRepo,
+    `refs/tags/${packageName}@*`,
+  ]);
+
+  const latest = refs
+    .split(/\r?\n/)
+    .map((line) => line.split(/\s+/)[1])
+    .filter((ref) => ref !== undefined && !ref.endsWith("^{}"))
+    .map((ref) => ref.replace("refs/tags/", ""))
+    .map((tag) => {
+      const match = tagPattern.exec(tag);
+      return {
+        tag,
+        parts: match?.slice(1).map((part) => Number.parseInt(part, 10)) ?? null,
+      };
+    })
+    .filter((entry) => entry.parts !== null)
+    .sort((left, right) => compareTriplets(left.parts, right.parts))
+    .at(-1);
+
+  if (latest === undefined) {
+    throw new Error(`No stable ${packageName} tags found`);
+  }
+
+  return latest.tag.replace(`${packageName}@`, "");
+}
+
+function setDependency(packageJson, section, name, value) {
+  if (packageJson[section]?.[name] === undefined) {
+    throw new Error(`${section}.${name} is missing from package.json`);
+  }
+
+  if (packageJson[section][name] === value) {
+    return false;
+  }
+
+  packageJson[section][name] = value;
+  console.log(`${name}: ${value}`);
+  return true;
+}
+
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+const targets = {
+  electron: `github:castlabs/electron-releases#${latestCastLabsElectronTag()}`,
+  "electron-builder": `^${latestElectronBuilderTag("electron-builder")}`,
+  "electron-updater": `^${latestElectronBuilderTag("electron-updater")}`,
+};
+
+const changed = [
+  setDependency(packageJson, "devDependencies", "electron", targets.electron),
+  setDependency(packageJson, "devDependencies", "electron-builder", targets["electron-builder"]),
+  setDependency(packageJson, "dependencies", "electron-updater", targets["electron-updater"]),
+].some(Boolean);
+
+if (changed) {
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+} else {
+  console.log("Electron toolchain is current");
+}


### PR DESCRIPTION
  - Add a scheduled PR workflow for CastLabs Electron, electron-builder, and electron-updater.
  - Add a Node script that refreshes package metadata from the latest stable upstream tags.
  - Ignore those toolchain packages in Dependabot so one path owns the updates.
  - Pin `astral-sh/setup-uv` to `v8.2.0` in the builder workflow.