### PR TITLE
fix(musicKitHook): prevent duplicate command listeners

### DIFF
--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -1,6 +1,9 @@
 (function () {
   if (window.MusicKit && window.__sidraHookedMk === MusicKit.getInstance()) return;
 
+  if (window.__sidraHookInitializing) return;
+  window.__sidraHookInitializing = true;
+
   const waitForMK = setInterval(() => {
     if (!window.MusicKit) return;
     clearInterval(waitForMK);

--- a/src/types/hook.d.ts
+++ b/src/types/hook.d.ts
@@ -68,6 +68,7 @@ interface SidraCommandMessage {
 
 interface Window {
   __sidra: SidraHook;
+  __sidraHookInitializing: boolean;
   __sidraHookedMk: unknown;
   AMWrapper: AMWrapperBridge;
 }

--- a/test/musicKitHook.test.ts
+++ b/test/musicKitHook.test.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+
+const hookScript = fs.readFileSync(
+  path.join(__dirname, '..', 'assets', 'musicKitHook.js'),
+  'utf-8',
+);
+
+describe('musicKitHook', () => {
+  it('handles one player command after repeated injection before MusicKit loads', () => {
+    const intervalCallbacks: Array<() => void> = [];
+    const messageListeners: Array<(event: unknown) => void> = [];
+    const skipToNextItem = vi.fn();
+    const musicKit = {
+      addEventListener: vi.fn(),
+      currentPlaybackTime: 0,
+      isPlaying: true,
+      pause: vi.fn(),
+      play: vi.fn(),
+      queue: { length: 1 },
+      repeatMode: 0,
+      seekToTime: vi.fn(),
+      setVolume: vi.fn(),
+      shuffleMode: 0,
+      skipToNextItem,
+      skipToPreviousItem: vi.fn(),
+      volume: 1,
+    };
+    const window = {
+      AMWrapper: { ipcRenderer: { send: vi.fn() } },
+      addEventListener: vi.fn((event: string, listener: (event: unknown) => void) => {
+        if (event === 'message') messageListeners.push(listener);
+      }),
+    };
+    const context = vm.createContext({
+      clearInterval: vi.fn(),
+      console,
+      setInterval: vi.fn((callback: () => void) => {
+        intervalCallbacks.push(callback);
+        return intervalCallbacks.length;
+      }),
+      window,
+    });
+
+    vm.runInContext(hookScript, context);
+    vm.runInContext(hookScript, context);
+
+    const musicKitApi = {
+      getInstance: () => musicKit,
+      PlaybackStates: { playing: 2 },
+    };
+    Object.assign(context, { MusicKit: musicKitApi });
+    Object.assign(window, { MusicKit: musicKitApi });
+    for (const callback of intervalCallbacks.slice()) callback();
+
+    const event = {
+      data: { type: 'sidra:command', channel: 'player:next', args: [] },
+      source: window,
+    };
+    for (const listener of messageListeners) listener(event);
+
+    expect(skipToNextItem).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# Prevent duplicate MusicKit command listeners

Guard hook initialization before starting the MusicKit polling interval. This prevents repeated script injection from registering multiple command listeners.

Fixes #153.

The regression test injects the real hook twice before MusicKit loads, sends one `player:next` command, and expects one `skipToNextItem()` call.

## Verification

- Test fails before the fix with two calls.
- Test passes after the fix with one call.
- Live MPRIS testing confirms `Next` and `Previous` each change tracks once.
- Full suite: 284 tests passed; one unrelated suite could not load because local npm policy blocked the Git-sourced Electron dependency.
