### PR TITLE
docs(readme): update deprecated Nix install alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ yay -S sidra-bin
 **Nix**:
 
 ```bash
-nix profile install github:wimpysworld/sidra
+nix profile add github:wimpysworld/sidra
 ```
 
 For NixOS or Home Manager, add `github:wimpysworld/sidra` as a flake input and reference `inputs.sidra.packages.<system>.default`.


### PR DESCRIPTION
Updates the readme installation instructions for Nix to favor the new alias (`nix profile install` is now deprecated).

Deprecation details: https://github.com/NixOS/nix/blob/master/doc/manual/source/release-notes/rl-2.30.md?plain=1#L22-L24

<img width="767" height="182" alt="image" src="https://github.com/user-attachments/assets/d70fc976-1ee9-4b19-bed4-9b0ed6df77b2" />
