### PR TITLE
fix(deps): bump js-yaml to 4.3.0 for CVE-2026-59869

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3246,9 +3246,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
js-yaml 4.2.0 parses chained YAML merge keys (`<<: *prev`) in quadratic time, so a
document under 100 KB can stall the loader for over a second. GHSA-52cp-r559-cp3m /
CVE-2026-59869, CVSS 7.5, availability only, no confidentiality or integrity impact.

electron-updater@6.8.9 is a runtime dependency and parses `latest.yml` and
`latest-linux.yml` fetched over the network during update checks on AppImage and NSIS
builds, so the vulnerable parser sat on a runtime path. electron-builder@26.15.6 pulls
it in at build time only. Both already declare `js-yaml: ^4.1.0`, so 4.3.0 already
satisfied their ranges and the lockfile was simply stale. `npm update js-yaml` dedupes
all four consumers onto the single 4.3.0 install. package.json is untouched and no
overrides entry was needed.

Real-world exploitability is low: the YAML comes from the project's own GitHub
releases, not untrusted input.

Verified with `just test` (21 files, 585 tests passed) and `just lint` (exit 0).

Refs: GHSA-52cp-r559-cp3m
