### PR TITLE
fix: remediate the six Copilot PRs merged 12 July (WW-91)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ When adding a language, add an entry to every record in every JSON file:
 | `startPage` | `'home' \| 'new' \| 'radio' \| 'all-playlists' \| 'last'` | Page to load on launch (default: `'new'`) |
 | `lastPageUrl` | `string` | Last visited page URL; used when `startPage` is `'last'` |
 | `musicService` | `MusicServiceId` (`'music' \| 'classical'`) | Active music service (default: `'music'`) |
-| `classical.startPage` | `string` | Start page for Apple Music Classical (default: `'home'`); valid values: `'home'`, `'browse'`, `'library'`, `'playlists'`, `'search'`, `'last'` |
+| `classical.startPage` | `string` | Start page for Apple Music Classical (default: `'home'`); valid values: `'home'`, `'browse'`, `'playlists'`, `'search'`, `'last'`. Classical has no library route on the web, so none is offered; an unknown stored id falls back to `'home'` |
 | `classical.lastPageUrl` | `string` | Last visited Classical page URL; used when `classical.startPage` is `'last'` |
 
 - Getters return `undefined` when no value has been persisted - absence of a key is intentional and drives the storefront fallback chain in `main.ts`; do not add default values to the store schema

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Sidra
 
-Minimal Apple Music desktop client. CastLabs Electron wraps `music.apple.com` directly, injecting a lightweight hook script to bridge MusicKit.js events to native platform media controls.
+Minimal Apple Music desktop client. CastLabs Electron wraps `music.apple.com` and `classical.music.apple.com` directly, injecting a lightweight hook script to bridge MusicKit.js events to native platform media controls. `src/musicService.ts` holds the registry of both services.
 
 ## Technology stack
 
@@ -8,7 +8,7 @@ Minimal Apple Music desktop client. CastLabs Electron wraps `music.apple.com` di
 |---|---|---|
 | Shell | CastLabs Electron (`castlabs/electron-releases`, wvcus) | Widevine CDM for DRM playback |
 | Language | TypeScript | Application code |
-| Renderer | `music.apple.com` | Apple maintains the UI |
+| Renderer | `music.apple.com` and `classical.music.apple.com` | Apple maintains the UI |
 | Package manager | npm | Dependency management |
 | Build | electron-builder | Platform installers (AppImage, deb, rpm, DMG, NSIS) |
 | Dev environment | Nix flake + direnv | Reproducible tooling |
@@ -59,6 +59,8 @@ The `10_15_7` macOS version freeze is intentional - Chrome itself freezes this v
 **Tests**
 - Tests cover pure logic and event forwarding; shared mock fixtures live in `test/mocks/` to avoid duplication
 - Type-level assertions (`expectTypeOf`) used to verify event map contracts at compile time
+- `src/config.ts` is exercised directly, never through a hand-written stand-in; `electron-conf/main` is mocked in `test/setup.ts` so the real module loads, and a self-mock makes every assertion read its own defaults back
+- `tsconfig.json` sets `"include": ["src/**/*.ts"]`, so `just lint` type-checks `src/` only and Vitest transpiles without type-checking; a type error in `test/` is invisible to both gates
 
 **Dependencies**
 - Minimise runtime dependencies; each must be purpose-driven
@@ -109,6 +111,8 @@ When adding a language, add an entry to every record in every JSON file:
 | `storefront` | `string` | Apple Music storefront code (e.g. `gb`, `us`) |
 | `language` | `string \| null` | BCP 47 language override for the storefront `?l=` parameter |
 | `theme` | `ThemeName` (`'apple-music' \| BundledThemeName \| 'custom'`) | Active theme (default: `'apple-music'`, meaning no override CSS) |
+| `zoomFactor` | `number` | Renderer zoom factor (default: `1.0`) |
+| `closeToTray.enabled` | `boolean` | Keep Sidra running in the tray when the window closes (default: false); gates the Hide/Show Window tray items and the tray left-click handler, so with it off, clicking the tray icon does nothing |
 | `notifications.enabled` | `boolean` | Toggle desktop notifications (default: true) |
 | `discord.enabled` | `boolean` | Toggle Discord Rich Presence (default: false) |
 | `lastfm.enabled` | `boolean` | Toggle Last.fm scrobbling (default: false) |
@@ -126,17 +130,21 @@ When adding a language, add an entry to every record in every JSON file:
 
 ### Service switching
 
-Switching services (tray Player submenu or itms:// deep-link routing) follows a strict sequence to avoid stale state:
-1. `resetWedgeDetector()` — clears the `isPlaying` flag so no spurious skip-forward attempts occur after page re-init
-2. `setMusicService(id)` — persists the new service id
-3. `rebuildTrayMenu(appTray)` — updates tray to reflect the new service
-4. `win.loadURL(buildAppleMusicURL())` — navigates to the new service's start page
+`switchService(id, targetUrl?)` in `src/serviceSwitch.ts` is the only switch sequence that ships. The tray Player submenu and `itms://` routing both call it; the tray click passes the id and nothing else, so the click itself neither persists the service nor rebuilds the menu. The steps, in order:
 
-`itms://` deep links always target the music service; if Classical is active when an itms:// link arrives, the sequence above runs with id `'music'` before navigating.
+1. `resetWedgeDetector()` - `reset()` sets `skipAttempts` to 0 and stops the timer; stopping the timer suppresses the spurious skip-forward after the page re-initialises
+2. `setMusicService(id)` - persists the new service id
+3. `rebuildTrayMenu(tray)` - runs when a tray exists, so the menu reflects the new service
+4. `setThemeCssKey(null)` - the navigation replaces the document, so the next injection must not call `removeInsertedCSS()` with a key from the old one
+5. `loadURL(targetUrl ?? buildAppleMusicURL())` - `buildAppleMusicURL()` resolves after `setMusicService`, so the default reads the service just persisted
+
+`main.ts` supplies the window and the tray through `initServiceSwitch({ getTray, loadURL })`, because `serviceSwitch.ts` cannot import `main.ts`: it runs `app.whenReady()` at import.
+
+`routeToMusicService(url)` in the same module handles `itms://` links, which always target the music service. It calls `switchService('music', url)` when Classical is active and navigates directly otherwise, so the switch costs one navigation.
 
 ### Theme gating
 
-`resolveTheme()` in `src/theme.ts` forces `'apple-music'` when the classical service is active, so no override CSS is injected. The stored `theme` value is left unchanged — switching back to the music service restores the user's preferred theme. The Style submenu in the tray is disabled (`enabled: false`) when Classical is active.
+`resolveTheme()` in `src/theme.ts` forces `'apple-music'` when the classical service is active, so no override CSS is injected. The stored `theme` value is left unchanged, so switching back to the music service restores the user's preferred theme. The Style submenu in the tray is disabled (`enabled: false`) when Classical is active.
 
 ### postMessage target origin
 
@@ -157,7 +165,6 @@ Most Apple Music styling responds to `:root` custom property overrides. These el
 | Player bar background | `.wrapper amp-chrome-player::before` | `::before` pseudo paints the bar |
 | Side panels (Lyrics/Up Next) | `.side-panel`, `.side-panel-header-wrapper` | Direct `background-color` |
 | Page footer | `.scrollable-page > footer` | Direct `background-color` |
-| LCD now-playing widget | `amp-lcd { --lcd-bg-color }` | Shadow DOM scoped variable |
 | Accent-coloured buttons | `.button.primary button.click-action` | Direct `background-color: rgb(214, 0, 23)` ignores `--keyColor` |
 | Accent CSS variables (`--keyColor` and variants) | `*` | Shadow DOM of `amp-*` elements does not inherit from `:root` |
 
@@ -181,7 +188,9 @@ CSS files read via `fs.readFileSync` at runtime must be listed individually in `
 - A failed `track.scrobble` is not retried: `scrobbled` stays set, so each track is submitted once. Rolling the flag back re-opened the submission without re-arming anything, and any timer that fires on a failure is a retry loop, which this project does not want
 - Last.fm connect-failure notifications are sent with `notify(..., true)`, which bypasses `notifications.enabled`: the failure answers an action the user just took in the tray, and silence there leaves the menu back at "Connect" with no explanation. Success and routine notifications stay gated on the preference
 - Event flow: MusicKit.js events in the renderer are captured by `assets/musicKitHook.js` (injected post-load), forwarded via IPC to `src/player.ts` (EventEmitter), then distributed to integrations; controls flow in reverse via `webContents.send()` to the preload, which uses `window.postMessage()` to bridge the context isolation boundary, and `musicKitHook.js` listens for `sidra:command` messages and dispatches to `window.__sidra` methods
-- Three artefacts define the hook-preload contract and must stay in sync: `src/types/hook.d.ts` (type declarations), `assets/musicKitHook.js` (JSDoc-annotated runtime), and `src/preload.ts` (typed channel sets); contract tests in `test/player.test.ts` verify alignment at compile time via `expectTypeOf`
+- Three artefacts define the hook-preload contract and must stay in sync: `src/types/hook.d.ts` (type declarations), `assets/musicKitHook.js` (JSDoc-annotated runtime), and `src/preload.ts` (typed channel sets); contract tests in `test/player.test.ts` verify alignment at compile time via `expectTypeOf`. The hook sets `window.__sidraHookInjected` synchronously at the top of its IIFE and never clears it; re-running the IIFE installs duplicate message listeners (#154 and issue #153). `window.__sidraHookedMk`, assigned at the end of `attachToInstance`, is a different marker: the 5-second monitor compares the current `MusicKit.getInstance()` against it to detect a replaced singleton. The top-of-IIFE guard that read `__sidraHookedMk` was removed; do not reintroduce one
+- `reportPositionState()` in `assets/musicKitHook.js` reports explicit media session position state. Duration comes from `mk.currentPlaybackDuration` when finite and positive, else from `nowPlayingItem.attributes.durationInMillis / 1000`; the reported position is clamped with `Math.min(position, duration)`. Every bail-out calls `clearPositionState()`, so no return path leaves a previous item's state installed; it clears rather than reporting `duration: Infinity` because the hook cannot tell genuinely unbounded media (a radio station) from a duration not yet resolved. The `playbackTimeDidChange` listener calls it on every tick, and that frequency is deliberate: `music.apple.com` writes to the same MediaSession from the same world, and the repeated call keeps Sidra's value in place. Do not debounce it. That does not breach the `playbackTimeDidChange` rule below, which is about debounce-timer starvation: this call starts no debounce
+- `isAllowedNavigationUrl()` in `src/musicService.ts` gates the `will-navigate` handler in `src/main.ts`, which calls `event.preventDefault()` when the predicate is false. `ALLOWED_NAVIGATION_HOSTS` is derived from every service host plus its `authFrameHosts`, so a new service widens the allowlist automatically. The match is on `URL.hostname` and exact: a subdomain, a suffix or a userinfo prefix of an allowed host is rejected. Main-process `loadURL()` calls raise no `will-navigate` event, so launch, service switching and `itms://` routing are unaffected. The same predicate gates hook injection at both sites: `injectContent()` and the `did-navigate-in-page` handler each skip `hookScript` on a disallowed host
 - `assets/musicKitHook.js` is read with `fs.readFileSync` at runtime; it must be listed in `asarUnpack` in the electron-builder config or AppImage builds will crash on startup
 - Chromium's built-in `MediaSessionService` must be disabled on Linux to avoid conflicting MPRIS registrations; Sidra registers its own `org.mpris.MediaPlayer2.sidra` service via dbus-next
 - macOS and Windows use Chromium's native mediaSession bridges (no extra libraries)
@@ -199,8 +208,8 @@ CSS files read via `fs.readFileSync` at runtime must be listed individually in `
 - MPRIS `Stop()` must map to `window.__sidra.pause()`, not `MusicKit.stop()`; `stop()` clears the queue, which violates the MPRIS spec requirement that calling `Play()` after `Stop()` resumes from the beginning of the track
 - MPRIS `PlaybackStatus` maps all MusicKit states - including transient ones (1=loading, 6=seeking, 7=waiting, 8=stalled) - directly to MPRIS values; transient states fall through to `'Stopped'` intentionally so MPRIS always reflects the actual MusicKit state; do not add early-return guards for transient states
 - MPRIS `Volume` controls MusicKit's software volume (`HTMLMediaElement.volume`) only - the PulseAudio/PipeWire sink input volume is independent; this matches the behaviour of Rhythmbox, Spotify, VLC, and every other major Linux music player; do not attempt to sync them
-- Chromium hard-codes `application.name = "Chromium"` and `application.icon_name = "chromium-browser"` on PulseAudio streams; `PULSE_PROP_*` environment variables are ineffective (Chromium's explicit API calls override them); the fix is `disable-features=AudioServiceOutOfProcess` (moves audio in-process so `SetGlobalAppName` reaches PulseAudio) combined with `app.setDesktopName('sidra.desktop')` (sets `CHROME_DESKTOP` for `GetXdgAppId()`); see [electron/electron#27581](https://github.com/electron/electron/issues/27581) and `docs/PULSE.md`
-- `music.apple.com` registers a `beforeunload` event handler while audio is playing; this silently blocks `BrowserWindow.close()` and `app.quit()` with no dialog or error (standard Chromium/Electron behaviour - unlike Chrome, Electron does not show a confirmation dialog); fix with `win.webContents.on('will-prevent-unload', (event) => event.preventDefault())`; see [electron/electron#8468](https://github.com/electron/electron/issues/8468) and `docs/QUIT.md`
+- Chromium hard-codes `application.name = "Chromium"` and `application.icon_name = "chromium-browser"` on PulseAudio streams; `PULSE_PROP_*` environment variables are ineffective (Chromium's explicit API calls override them); the fix is `disable-features=AudioServiceOutOfProcess` (moves audio in-process so `SetGlobalAppName` reaches PulseAudio) combined with `app.setDesktopName('sidra.desktop')` (sets `CHROME_DESKTOP` for `GetXdgAppId()`); see [electron/electron#27581](https://github.com/electron/electron/issues/27581)
+- `music.apple.com` registers a `beforeunload` event handler while audio is playing; this silently blocks `BrowserWindow.close()` and `app.quit()` with no dialog or error (standard Chromium/Electron behaviour - unlike Chrome, Electron does not show a confirmation dialog); fix with `win.webContents.on('will-prevent-unload', (event) => event.preventDefault())`; see [electron/electron#8468](https://github.com/electron/electron/issues/8468)
 - `electron-updater` must be lazy-required inside `initAutoUpdate()` only - never at module top level; on unsupported platforms the module must never load; verify via log output: `autoUpdate` scope logs must not appear on deb/rpm/Nix builds
 - `electron-updater` implements its own download/install pipeline and does not use Electron's built-in `autoUpdater`; all APIs it uses are unmodified in CastLabs ECS; the known `app.relaunch()` bug (CastLabs issue #164) does NOT affect `AppImageUpdater` - it spawns the new binary via `child_process.spawn()` directly
 - Platform detection for auto-update: `process.env.APPIMAGE` is set only when running as an AppImage (present = enable updater, absent = notification-only); on Windows, `app.isPackaged` on `win32` indicates an NSIS installation
@@ -210,11 +219,12 @@ CSS files read via `fs.readFileSync` at runtime must be listed individually in `
 - `SIDRA_DISABLE_AUTO_UPDATE=1` env var disables auto-update for AppImage/NSIS builds; future package managers (Scoop, Chocolatey) must set this in their install manifests
 - AppImage `artifactName` must omit the version component (use `${productName}-${os}-${arch}.${ext}`) to prevent filename changes breaking desktop shortcuts after update
 - On NixOS, `libxcrypt-legacy` must be in `LD_LIBRARY_PATH` (already added to `flake.nix`) for fpm's bundled Ruby to find `libcrypt.so.1` during deb/rpm builds; without it, deb/rpm targets fail at the fpm stage
-- `webContents.reload()` must be preceded by `wedgeDetector.reset()` when called from an IPC handler; without this, the wedge detector's `isPlaying` flag remains `true` through the reload, causing spurious skip-forward attempts after the page re-initialises
+- `webContents.reload()` must be preceded by `wedgeDetector.reset()` when called from an IPC handler; without it the detector's timer survives the reload and attempts a spurious skip-forward after the page re-initialises
 - CastLabs Electron type definitions omit `App.setDesktopName()` and `'cache'` from `app.getPath()` - both methods work at runtime; use module augmentations in `src/types/electron.d.ts` rather than type casts at call sites
 - `dbus-next` has no public API to fully close its socket; `bus.disconnect()` calls `stream.end()` only (half-close); `(bus as DbusMessageBusInternals)._connection?.stream?.destroy()` is the only way to force-close - the `DbusMessageBusInternals` interface in `src/integrations/mpris/index.ts` documents this and is compatible with `@holusion/dbus-next ^0.11.2`
-- `setupContentHandlers()` uses a single `on('did-finish-load')` handler with an `initialized` flag (not `once`/`on` split) - both `once` and `on` fire on the first load, and async `executeJavaScript` injection cannot rely on script-level idempotency guards to prevent double event listener registration
-- Theme system uses `ThemeName = 'apple-music' | BundledThemeName | 'custom'` and `applyTheme(name)` in `src/theme.ts`; `'apple-music'` means no override CSS is injected; adding a bundled theme only requires adding a palette entry in `src/palettes.ts`
+- `setupContentHandlers()` uses a single `on('did-finish-load')` handler with an `initialized` flag (not a `once`/`on` split) - both `once` and `on` fire on the first load, so the flag guards one-time integration initialisation while `injectContent()` runs on every load; the hook's own `__sidraHookInjected` guard stops duplicate listener registration, not this flag
+- Theme system uses `ThemeName = 'apple-music' | BundledThemeName | 'custom'` and `applyTheme(name)` in `src/theme.ts`; `'apple-music'` means no override CSS is injected. A new bundled theme needs a palette entry in `src/palettes.ts` that also passes `test/themes.test.ts`: keep `overlay` distinct from `subtext0` and `crust` distinct from `surface0` in both schemes, and reach 4.5:1 WCAG contrast against `pageBG` on `--systemPrimary` and `--systemSecondary-vibrant` (Catppuccin Latte's secondary is the one documented exception, at 4.37:1)
+- `hasCustomCss()` is `getThemeCss('custom') !== null`, so presence means readable and non-blank, not merely existing. `getThemeCss('custom')` caches the file contents. The `fs.watch` callback calls `invalidateCustomCssCache()` before the 150ms debounce, so a tray rebuild inside the debounce window cannot read the previous contents back. A watcher that never starts or dies calls `disableCustomCssCache()`, which switches caching off rather than leaving a stale cache for the life of the process. The debounced callback re-applies CSS when needed, then calls `rebuildTrayCallback()` unconditionally: creating or deleting `custom.css` adds or removes the tray Style entry whichever theme is stored. `main.ts` supplies that callback through `setRebuildTrayCallback()`, because `tray.ts` imports `theme.ts` and `theme.ts` cannot import it back
 - `test/mocks/storefront-deps.ts` contains shared `vi.mock()` declarations for tests that import storefront code; Vitest hoists `vi.mock()` calls within the fixture file itself, so the fixture uses `../../src/` paths (relative to `test/mocks/`, not `test/`) - do not change these paths
 - `API_KEY` and `API_SECRET` in `src/integrations/lastfm/index.ts` resolve once at module load and are empty under test, so `isConfigured()` is false and every request path short-circuits; behavioural tests must take the module from `loadLastfm()` in `test/lastfm.test.ts` (`vi.resetModules()`, `vi.stubEnv(...)`, then a dynamic `import()`) rather than the static import
 - Electron fixtures in `test/setup.ts` that stand in for a promise-returning API must return a promise: production code attaches `.catch()` to `shell.openExternal()`, and a bare `vi.fn()` makes that throw inside a `try`/`catch` that silently abandons the flow

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Theme selection lives in the tray **Style** submenu. Sidra ships with **Catppucc
 
 As an unsupported escape hatch, you can place a `custom.css` file in Sidra's user data directory and it will live-reload without restarting:
 
-- Linux: `~/.config/sidra/custom.css`
-- macOS: `~/Library/Application Support/sidra/custom.css`
-- Windows: `%APPDATA%\sidra\custom.css`
+- Linux: `~/.config/Sidra/custom.css`
+- macOS: `~/Library/Application Support/Sidra/custom.css`
+- Windows: `%APPDATA%\Sidra\custom.css`
 
 The **Custom** menu entry only appears when that file exists.
 
@@ -80,9 +80,9 @@ Once connected, the **Last.fm** submenu turns scrobbling on and off and offers *
 
 Connecting stores a Last.fm session key and your username in Sidra's configuration file, in plain text:
 
-- Linux: `~/.config/sidra/config.json`
-- macOS: `~/Library/Application Support/sidra/config.json`
-- Windows: `%APPDATA%\sidra\config.json`
+- Linux: `~/.config/Sidra/config.json`
+- macOS: `~/Library/Application Support/Sidra/config.json`
+- Windows: `%APPDATA%\Sidra\config.json`
 
 > [!IMPORTANT]
 > Last.fm session keys never expire, and the Last.fm API has no call to revoke one. **Disconnect** deletes Sidra's copy of the key, which stops this installation scrobbling, but only Last.fm can invalidate the key itself. Remove Sidra under [Applications in your Last.fm settings](https://www.last.fm/settings/applications) to do that. Sidra notices the revoked session on its next request, disconnects, and tells you.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Sidra takes the opposite approach: wrap `music.apple.com` directly, stay out of 
 - Desktop notifications and Discord Rich Presence
 - Last.fm scrobbling, opt-in: connect from the tray and approve Sidra on the page that opens in your browser
 - Injected Back, Forward, and Reload navigation controls on both Apple Music and Apple Music Classical
-- Apple Music Classical support (switchable at runtime from the tray Player submenu)
+- Apple Music Classical support (switchable at runtime from the tray Player submenu):
+  - Start pages are Home, Browse, Playlists, Search, or your last page; Apple Music's are Home, New, Radio, All Playlists, or your last page
+  - Theming is unavailable: the tray **Style** submenu is disabled and Sidra injects no override CSS
 - **Linux**:
   - Widevine DRM via CastLabs Electron
   - Wayland and X11 support
@@ -69,6 +71,8 @@ As an unsupported escape hatch, you can place a `custom.css` file in Sidra's use
 - Windows: `%APPDATA%\Sidra\custom.css`
 
 The **Custom** menu entry only appears when that file exists.
+
+Themes apply to Apple Music only. Sidra keeps your choice while Apple Music Classical is active and restores it when you switch back.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Sidra takes the opposite approach: wrap `music.apple.com` directly, stay out of 
 - Localised storefront and interface in 32 languages
 - Desktop notifications and Discord Rich Presence
 - Last.fm scrobbling, opt-in: connect from the tray and approve Sidra on the page that opens in your browser
-- Injected Back, Forward, and Reload navigation controls
+- Injected Back, Forward, and Reload navigation controls on both Apple Music and Apple Music Classical
 - Apple Music Classical support (switchable at runtime from the tray Player submenu)
 - **Linux**:
   - Widevine DRM via CastLabs Electron

--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -42,18 +42,27 @@
           return;
         }
 
+        // An unresolvable duration or position clears the state rather than
+        // reporting duration: Infinity, because the hook cannot tell genuinely
+        // unbounded media (a radio station) from a duration not yet resolved.
         let duration;
         if (Number.isFinite(mk.currentPlaybackDuration) &&
             mk.currentPlaybackDuration > 0) {
           duration = mk.currentPlaybackDuration;
         } else {
           const durationInMillis = mk.nowPlayingItem?.attributes?.durationInMillis;
-          if (!Number.isFinite(durationInMillis) || durationInMillis <= 0) return;
+          if (!Number.isFinite(durationInMillis) || durationInMillis <= 0) {
+            clearPositionState();
+            return;
+          }
           duration = durationInMillis / 1000;
         }
 
         const position = mk.currentPlaybackTime;
-        if (!Number.isFinite(position) || position < 0) return;
+        if (!Number.isFinite(position) || position < 0) {
+          clearPositionState();
+          return;
+        }
 
         try {
           navigator.mediaSession.setPositionState({

--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -1,6 +1,4 @@
 (function () {
-  if (window.MusicKit && window.__sidraHookedMk === MusicKit.getInstance()) return;
-
   // This flag persists for the page lifetime and is never cleared. Re-injection
   // must not re-run the IIFE: the 5-second monitor inside the hook already
   // handles MusicKit instance replacement, and re-running would install

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1,6 +1,6 @@
 # Sidra - Specification
 
-A minimal Apple Music desktop client. CastLabs Electron wraps `music.apple.com` directly, injecting a lightweight hook script to bridge MusicKit.js events to native platform media controls. Apple maintains the UI; Sidra maintains the bridge.
+A minimal Apple Music desktop client. CastLabs Electron wraps `music.apple.com` and `classical.music.apple.com` directly, injecting a lightweight hook script to bridge MusicKit.js events to native platform media controls. `src/musicService.ts` holds the registry of both services. Apple maintains the UI; Sidra maintains the bridge.
 
 The codebase is tightly focused and as lean as possible. Five runtime dependencies.
 
@@ -18,6 +18,7 @@ The codebase is tightly focused and as lean as possible. Five runtime dependenci
 - [MPRIS Specification](#mpris-specification)
 - [Volume Sync](#volume-sync)
 - [Region and Storefront](#region-and-storefront)
+- [Apple Music Classical](#apple-music-classical)
 - [Authentication](#authentication)
 - [Theming](#theming)
 - [Discord Rich Presence](#discord-rich-presence)
@@ -41,7 +42,7 @@ The codebase is tightly focused and as lean as possible. Five runtime dependenci
 |---|---|---|
 | Shell | `castlabs/electron-releases` (wvcus) | Widevine CDM - no alternative exists |
 | Language | TypeScript | Type safety, ecosystem match |
-| Renderer content | `music.apple.com` | Zero UI code; Apple maintains it |
+| Renderer content | `music.apple.com` and `classical.music.apple.com` | Zero UI code; Apple maintains it |
 | MusicKit hook | Injected JS script post-page-load | Hooks `MusicKit.getInstance()` events |
 | Preload | `contextBridge` IPC bridge | Standard Electron security pattern |
 | MPRIS (Linux) | `dbus-next` directly | Full control, clean service name |
@@ -58,30 +59,30 @@ The codebase is tightly focused and as lean as possible. Five runtime dependenci
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│ CastLabs Electron (Widevine CDM auto-installed)         │
-│                                                         │
-│  ┌──────────────────────┐      ┌────────────────────┐   │
-│  │  Main Process        │◄─IPC─│  Renderer Process  │   │
-│  │                      │      │                    │   │
-│  │  ┌────────────────┐  │      │  music.apple.com   │   │
-│  │  │ IPC event hub  │  │      │  ┌──────────────┐  │   │
-│  │  │ (player.ts)    │  │      │  │ MusicKit.js  │  │   │
-│  │  └───────┬────────┘  │      │  └──────┬───────┘  │   │
-│  │          │           │      │         │ events   │   │
-│  │  ┌───────▼────────┐  │      │  ┌──────▼───────┐  │   │
-│  │  │ Integrations   │  │      │  │ Hook script  │  │   │
-│  │  │ ├─ MPRIS       │◄─┼──────┼──┤(injected JS) │  │   │
-│  │  │ ├─ Discord RPC │  │      │  └──────────────┘  │   │
-│  │  │ ├─ Notifier    │  │      │                    │   │
-│  │  │ └─ Taskbar/Dock│  │      │  ┌──────────────┐  │   │
-│  │  └───────┬────────┘  │      │  │  preload.ts  │  │   │
-│  │          │           │      │  │ (IPC bridge) │  │   │
-│  │  ┌───────▼────────┐  │      │  └──────────────┘  │   │
-│  │  │ electron-conf  │  │      └────────────────────┘   │
-│  │  └────────────────┘  │                               │
-│  └──────────────────────┘                               │
-└─────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│ CastLabs Electron (Widevine CDM auto-installed)                  │
+│                                                                  │
+│  ┌──────────────────────┐      ┌─────────────────────────────┐   │
+│  │  Main Process        │◄─IPC─│  Renderer Process           │   │
+│  │                      │      │  music.apple.com            │   │
+│  │  ┌────────────────┐  │      │  classical.music.apple.com  │   │
+│  │  │ IPC event hub  │  │      │  ┌──────────────┐           │   │
+│  │  │ (player.ts)    │  │      │  │ MusicKit.js  │           │   │
+│  │  └───────┬────────┘  │      │  └──────┬───────┘           │   │
+│  │          │           │      │         │ events            │   │
+│  │  ┌───────▼────────┐  │      │  ┌──────▼───────┐           │   │
+│  │  │ Integrations   │  │      │  │ Hook script  │           │   │
+│  │  │ ├─ MPRIS       │◄─┼──────┼──┤(injected JS) │           │   │
+│  │  │ ├─ Discord RPC │  │      │  └──────────────┘           │   │
+│  │  │ ├─ Notifier    │  │      │                             │   │
+│  │  │ └─ Taskbar/Dock│  │      │  ┌──────────────┐           │   │
+│  │  └───────┬────────┘  │      │  │  preload.ts  │           │   │
+│  │          │           │      │  │ (IPC bridge) │           │   │
+│  │  ┌───────▼────────┐  │      │  └──────────────┘           │   │
+│  │  │ electron-conf  │  │      └─────────────────────────────┘   │
+│  │  └────────────────┘  │                                        │
+│  └──────────────────────┘                                        │
+└──────────────────────────────────────────────────────────────────┘
          │ D-Bus (Linux)
     ┌────▼───────┐
     │  playerctl │
@@ -97,67 +98,74 @@ The codebase is tightly focused and as lean as possible. Five runtime dependenci
 ```
 sidra/
 ├── src/
-│   ├── main.ts                    — bootstrap, Widevine wait, window, IPC hub
-│   ├── preload.ts                 — contextBridge IPC exposure (AMWrapper)
-│   ├── config.ts                  — electron-conf wrapper
-│   ├── i18n.ts                    — locale detection, JSON loader, and re-exported translation records
-│   ├── paths.ts                   — getAssetPath() and getProductInfo() utilities
-│   ├── player.ts                  — TypedEmitter, PlayerEvents, PlaybackState (0-9), IntegrationContext
-│   ├── storefront.ts              — buildAppleMusicURL(), extractStorefrontFromURL(), handleStorefrontNavigation()
+│   ├── main.ts                    - bootstrap, Widevine wait, window, IPC hub
+│   ├── preload.ts                 - contextBridge IPC exposure (AMWrapper)
+│   ├── config.ts                  - electron-conf wrapper
+│   ├── i18n.ts                    - locale detection, JSON loader, and re-exported translation records
+│   ├── paths.ts                   - getAssetPath() and getProductInfo() utilities
+│   ├── player.ts                  - TypedEmitter, PlayerEvents, PlaybackState (0-9), IntegrationContext
+│   ├── storefront.ts              - buildAppleMusicURL(), buildItmsRouteURL(), extractStorefrontFromURL(), handleStorefrontNavigation()
+│   ├── musicService.ts            - music service registry (MUSIC_SERVICES): host, origin, start pages, navigation allowlist
+│   ├── serviceSwitch.ts           - switchService() and routeToMusicService(); the one service-switch sequence
+│   ├── contentReady.ts            - CONTENT_READY_SELECTOR and contentReadyProbeScript()
+│   ├── itms.ts                    - pure itms:// URL parser and argv extraction
 │   ├── types/
-│   │   ├── electron.d.ts          — module augmentations for CastLabs type gaps
-│   │   └── hook.d.ts              — hook-preload contract: SidraHook, AMWrapperBridge, SendChannel, ReceiveChannel, SidraCommandMessage, Window augmentations
-│   ├── theme.ts                   — theme lifecycle: ThemeName, resolveTheme(), getThemeCss(), applyTheme(), initThemeCSS()
-│   ├── palettes.ts                — bundled theme registry (BUNDLED_THEMES), BundledThemeName, themeLabel()
-│   ├── themeTemplate.ts           — pure palette→CSS renderer (buildThemeCss())
-│   ├── artwork.ts                 — downloadArtwork(), cleanArtworkCache(); UUID-based multi-file cache
-│   ├── autoUpdate.ts              — isAutoUpdateSupported(), initAutoUpdate(), quitAndInstall(); electron-updater
-│   ├── update.ts                  — checkForUpdates() via GitHub API; UpdateInfo state
-│   ├── wedgeDetector.ts           — detects playback stalls and auto-skips forward
-│   ├── pauseTimer.ts              — createPauseTimer() factory; shared by tray, dock, Discord integrations
-│   ├── utils.ts                   — errorMessage() utility
+│   │   ├── electron.d.ts          - module augmentations for CastLabs type gaps
+│   │   └── hook.d.ts              - hook-preload contract: SidraHook, AMWrapperBridge, SendChannel, ReceiveChannel, SidraCommandMessage, Window augmentations
+│   ├── theme.ts                   - theme lifecycle: ThemeName, resolveTheme(), getThemeCss(), applyTheme(), initThemeCSS()
+│   ├── palettes.ts                - bundled theme registry (BUNDLED_THEMES), BundledThemeName, themeLabel()
+│   ├── themeTemplate.ts           - pure palette→CSS renderer (buildThemeCss())
+│   ├── artwork.ts                 - downloadArtwork(), cleanArtworkCache(); UUID-based multi-file cache
+│   ├── autoUpdate.ts              - isAutoUpdateSupported(), initAutoUpdate(), quitAndInstall(); electron-updater
+│   ├── update.ts                  - checkForUpdates() via GitHub API; UpdateInfo state
+│   ├── wedgeDetector.ts           - detects playback stalls and auto-skips forward
+│   ├── pauseTimer.ts              - createPauseTimer() factory; shared by tray, dock, Discord integrations
+│   ├── utils.ts                   - errorMessage() utility
 │   ├── utils/
-│   │   └── progressBar.ts         — updateProgressBar() / clearProgressBar(); platform-agnostic win.setProgressBar()
-│   ├── aboutWindow.ts             — showAboutWindow() and related constants (extracted from tray.ts)
-│   ├── tray.ts                    — system tray icon, context menu, tray state manager
+│   │   └── progressBar.ts         - updateProgressBar() / clearProgressBar(); platform-agnostic win.setProgressBar()
+│   ├── aboutWindow.ts             - showAboutWindow() and related constants (extracted from tray.ts)
+│   ├── tray.ts                    - system tray icon, context menu, tray state manager
 │   └── integrations/
 │       ├── mpris/
-│       │   └── index.ts           — D-Bus MPRIS service (Linux only)
+│       │   └── index.ts           - D-Bus MPRIS service (Linux only)
 │       ├── discord-presence/
-│       │   └── index.ts           — Discord RPC with retry/debounce
+│       │   └── index.ts           - Discord RPC with retry/debounce
+│       ├── lastfm/
+│       │   └── index.ts           - Last.fm auth, now-playing and scrobble submission
 │       ├── notifications/
-│       │   └── index.ts           — Track change desktop notifications
+│       │   └── index.ts           - Track change desktop notifications
 │       ├── macos-dock/
-│       │   └── index.ts           — Dock right-click menu + progress bar (macOS only)
+│       │   └── index.ts           - Dock right-click menu + progress bar (macOS only)
 │       └── windows-taskbar/
-│           └── index.ts           — Thumbnail toolbar + overlay icon + progress bar (Windows only)
+│           └── index.ts           - Thumbnail toolbar + overlay icon + progress bar (Windows only)
 ├── assets/
-│   ├── musicKitHook.js            — Injected into music.apple.com post-load
-│   │                                 Must be listed in electron-builder's `asarUnpack` —
-│   │                                 it is read with readFileSync at runtime and will crash
-│   │                                 AppImage builds if packed inside the asar archive
-│   ├── navigationBar.js           — Injected post-load; adds back/forward/reload buttons to sidebar
-│   ├── about.html                 — About window content, receives product info via query params
-│   ├── splash.html                — Splash screen shown during startup
-│   ├── sidra-logo.png             — Product logo used in About window
+│   ├── musicKitHook.js            - Injected post-load into music.apple.com and
+│   │                                 classical.music.apple.com. Must be listed in
+│   │                                 electron-builder's `asarUnpack`: it is read with
+│   │                                 readFileSync at runtime and will crash AppImage
+│   │                                 builds if packed inside the asar archive
+│   ├── navigationBar.js           - Injected post-load; adds back/forward/reload buttons to sidebar
+│   ├── about.html                 - About window content, receives product info via query params
+│   ├── splash.html                - Splash screen shown during startup
+│   ├── sidra-logo.png             - Product logo used in About window
 │   ├── locales/
-│   │   ├── loading.json           — 1 translation record: LOADING_TEXT
-│   │   ├── tray.json              — 21 translation records: tray menu labels
-│   │   ├── about.json             — 4 translation records: about window labels
-│   │   └── update.json            — 5 translation records: auto-update labels
-│   ├── styleFix.css               — CSS overrides injected via webContents.insertCSS()
+│   │   ├── loading.json           - 1 translation record: LOADING_TEXT
+│   │   ├── tray.json              - 33 translation records: tray menu labels
+│   │   ├── about.json             - 4 translation records: about window labels
+│   │   └── update.json            - 5 translation records: auto-update labels
+│   ├── styleFix.css               - CSS overrides injected via webContents.insertCSS()
 │   │                                 Hides "Get the app" and "Open in Music" banners
 │   │                                 that Apple shows to push users toward native apps
-│   ├── authStyleFix.css           — CSS injected into Apple auth iframes to hide
+│   ├── authStyleFix.css           - CSS injected into Apple auth iframes to hide
 │   │                                 unsupported passkey and "Sign in with iPhone" options
 │   └── icons/
-│       ├── sidraTemplate.png      — macOS tray (template image)
-│       ├── sidra-tray.png         — Windows tray
-│       ├── sidra-tray-dark.png    — Linux tray (dark theme)
-│       ├── sidra-tray-light.png   — Linux tray (light theme)
+│       ├── sidraTemplate.png      - macOS tray (template image)
+│       ├── sidra-tray.png         - Windows tray
+│       ├── sidra-tray-dark.png    - Linux tray (dark theme)
+│       ├── sidra-tray-light.png   - Linux tray (light theme)
 │       └── tray/menu/
-│           ├── dark/              — 18px dark-theme menu item PNGs
-│           └── light/             — 18px light-theme menu item PNGs
+│           ├── dark/              - 18px dark-theme menu item PNGs
+│           └── light/             - 18px light-theme menu item PNGs
 ├── build/
 │   ├── icon.png, icon.icns, icon.ico
 │   └── afterPack.cjs
@@ -275,23 +283,28 @@ The command bridge uses the `RECEIVE_CHANNELS` allowlist in `src/preload.ts` and
 
 ## MusicKit Hook Script
 
-Injected into `music.apple.com` after page load via `webContents.executeJavaScript()`. Polls for `MusicKit` availability, hooks events, and exposes the `window.__sidra` control object.
+Injected into `music.apple.com` and `classical.music.apple.com` after page load via `webContents.executeJavaScript()`. Polls for `MusicKit` availability, hooks events, and exposes the `window.__sidra` control object. `isAllowedNavigationUrl()` gates both injection sites, so the hook never reaches a third host.
 
 `assets/musicKitHook.js` is read with `fs.readFileSync` at runtime in the main process. It must be listed in the `asarUnpack` array in `electron-builder` configuration; without it, AppImage builds will crash on startup because the file is inaccessible inside the packed asar archive.
 
 ```javascript
-// Structure of assets/musicKitHook.js (~153 lines)
+// Structure of assets/musicKitHook.js
 // Not inlined in full; see the source file for the complete implementation.
 
 (function () {
-  function attachToInstance(mk) {
-    // Idempotency guard
-    if (window.MusicKit && window.__sidraHookedMk === MusicKit.getInstance()) return;
-    window.__sidraHookedMk = mk;
+  // Injection guard: set synchronously at IIFE top level and never cleared.
+  // Re-running the IIFE would install duplicate message listeners (#154, #153).
+  if (window.__sidraHookInjected) return;
+  window.__sidraHookInjected = true;
 
+  function attachToInstance(mk) {
     // Event listeners: playbackStateDidChange, nowPlayingItemDidChange,
-    // playbackTimeDidChange, repeatModeDidChange, shuffleModeDidChange,
+    // playbackTimeDidChange (forwards the position, then calls
+    // reportPositionState()), repeatModeDidChange, shuffleModeDidChange,
     // volumeDidChange
+
+    // reportPositionState() writes navigator.mediaSession.setPositionState().
+    // clearPositionState() runs when nowPlayingItemDidChange delivers null.
 
     // nowPlayingItemDidChange sends ALL fields including:
     // audioTraits, trackNumber, targetBitrate, discNumber, composerName,
@@ -309,16 +322,29 @@ Injected into `music.apple.com` after page load via `webContents.executeJavaScri
     //   window.addEventListener('message', ...) dispatches
     //   incoming { type: 'sidra:command', channel, args } messages
     //   to the matching window.__sidra method via a COMMANDS allowlist
+
+    // Per-instance marker, read by the 5-second monitor below.
+    // This is not an injection guard: __sidraHookInjected is.
+    window.__sidraHookedMk = mk;
   }
 
-  // 5-second interval monitors for MusicKit instance replacement
-  // and re-calls attachToInstance() when a new instance is detected
   const waitForMK = setInterval(() => {
     if (!window.MusicKit) return;
+    clearInterval(waitForMK);
     attachToInstance(MusicKit.getInstance());
-  }, 5000);
+
+    // 5-second monitor: compares MusicKit.getInstance() against
+    // window.__sidraHookedMk and re-attaches when the singleton is replaced.
+    setInterval(() => { /* ... */ }, 5000);
+  }, 500);
 })();
 ```
+
+### Media session position state
+
+`reportPositionState()` gives the OS media controls an explicit position rather than letting Chromium infer one. It runs on every `playbackTimeDidChange` tick. Duration comes from `mk.currentPlaybackDuration` when that value is finite and positive, otherwise from `nowPlayingItem.attributes.durationInMillis / 1000`. Position is clamped with `Math.min(position, duration)`.
+
+Every bail-out calls `clearPositionState()`, so no return path leaves the previous item's state installed. An unresolvable duration or position clears the state instead of reporting `duration: Infinity`, because the hook cannot tell genuinely unbounded media (a radio station) from a duration that has not resolved yet.
 
 ### Audio Quality Metadata Caveats
 
@@ -348,7 +374,7 @@ if (process.platform === 'linux') {
 }
 ```
 
-**PulseAudio stream identity**: Chromium hard-codes `application.name = "Chromium"` and `application.icon_name = "chromium-browser"` on PulseAudio/PipeWire streams via explicit API calls; `PULSE_PROP_*` environment variables are ineffective. Sidra fixes this by disabling `AudioServiceOutOfProcess` (moves audio in-process so `SetGlobalAppName` reaches PulseAudio) and calling `app.setDesktopName('sidra.desktop')` (sets `CHROME_DESKTOP` for `GetXdgAppId()`). See [electron/electron#27581](https://github.com/electron/electron/issues/27581) and `docs/PULSE.md` for full details.
+**PulseAudio stream identity**: Chromium hard-codes `application.name = "Chromium"` and `application.icon_name = "chromium-browser"` on PulseAudio/PipeWire streams via explicit API calls; `PULSE_PROP_*` environment variables are ineffective. Sidra fixes this by disabling `AudioServiceOutOfProcess` (moves audio in-process so `SetGlobalAppName` reaches PulseAudio) and calling `app.setDesktopName('sidra.desktop')` (sets `CHROME_DESKTOP` for `GetXdgAppId()`). See [electron/electron#27581](https://github.com/electron/electron/issues/27581).
 
 ### macOS: Chromium's Built-in mediaSession Bridge
 
@@ -496,6 +522,76 @@ Apple Music storefront codes are ISO 3166-1 alpha-2 codes lowercased (e.g. `gb`,
 
 ---
 
+## Apple Music Classical
+
+Sidra loads two Apple web apps from one shell. `src/musicService.ts` holds the registry that describes them. It imports nothing from `electron`, `electron-log`, or `config`, so `src/itms.ts` and the tests can import it without loading Electron.
+
+### Service registry
+
+`MUSIC_SERVICES` maps each `MusicServiceId` to a record with these fields:
+
+| Field | Purpose |
+|---|---|
+| `id` | `'music'` or `'classical'` |
+| `host` | Hostname, matched exactly by the navigation allowlist |
+| `origin` | URL prefix used by `buildAppleMusicURL()` |
+| `displayName` | Label shown in the tray Player submenu |
+| `authFrameHosts` | Authentication iframe hostnames `setupAuthFrameInjection()` accepts |
+| `contentReadySelector` | Selector probed to detect an interactive web app |
+| `startPages` | Ordered start page entries rendered in the tray Start Page submenu |
+| `defaultStartPage` | Start page id used when nothing is persisted |
+
+`defineService()` infers the page id union from `startPages` alone and wraps `defaultStartPage` in `NoInfer`, so a typo there fails to compile instead of widening the union.
+
+Accessors: `isMusicServiceId()`, `getService()`, `getServiceByHost()` and `allServices()`. `getService()` is total at runtime as well as in the type: `?? MUSIC_SERVICES[DEFAULT_SERVICE_ID]` catches an unknown id. Every call runs while the tray menu is built, and the tray is the app's only settings surface.
+
+### The two services
+
+| | Apple Music | Apple Music Classical |
+|---|---|---|
+| `id` | `music` | `classical` |
+| `host` | `music.apple.com` | `classical.music.apple.com` |
+| Start pages | Home (`home`), New (`new`), Radio (`radio`), All Playlists (`library/all-playlists/`) | Home (empty path), Browse (`browse/catalog`), Playlists (`browse/playlists`), Search (`search`) |
+| Default | `new` | `home` |
+
+Classical has no library route. Both services accept `last`, which restores the page the user left.
+
+### Navigation allowlist
+
+`ALLOWED_NAVIGATION_HOSTS` is built from every service `host` plus its `authFrameHosts`, so adding a service widens the allowlist without a second edit. `isAllowedNavigationUrl()` takes a URL string, parses it, and compares `URL.hostname` exactly: a subdomain, a suffix, or a userinfo prefix of an allowed host is not an allowed host.
+
+The `will-navigate` handler in `src/main.ts` calls `event.preventDefault()` when the predicate returns false. Main-process `loadURL()` calls do not raise `will-navigate`, so launch, service switching and `itms://` routing are unaffected. The same predicate gates hook injection at both injection sites.
+
+### Persistence and URL building
+
+Each service keeps its own start page and last page. `classical.startPage` and `classical.lastPageUrl` sit alongside `startPage` and `lastPageUrl` in `electron-conf`.
+
+`buildAppleMusicURL()` in `src/storefront.ts` branches on `getMusicService() === 'classical'` to pick the pair to read. The stored path is read only in the `'last'` branch. The Classical home entry has an empty path and must not gain a trailing slash, so the path segment is built as `pageEntry.path === '' ? '' : '/' + pageEntry.path`.
+
+`handleLastPageNavigation()` resolves the host of each navigation through `getServiceByHost()` and writes to `setClassicalLastPageUrl()` or `setLastPageUrl()` accordingly.
+
+`buildItmsRouteURL()` is pinned to `getService('music').origin`. `itms://` links always target Apple Music, and `transformItmsUrl()` in `src/itms.ts` pins the host on the parsing side.
+
+### Theme gate
+
+`resolveTheme()` returns `'apple-music'` for Classical before it reads the stored value, so no override CSS is injected. Bundled themes target the `music.apple.com` DOM and do not apply. The tray Style submenu renders with `enabled: false` under Classical, and `styleMenuTheme()` labels it from `getTheme()` rather than `resolveTheme()` so the user's stored choice stays visible.
+
+### Switching
+
+`switchService(id, targetUrl?)` in `src/serviceSwitch.ts` is the only switch sequence that ships. Both the tray Player submenu and `itms://` routing call it. In order:
+
+1. `resetWedgeDetector()` clears `skipAttempts` and stops the timer. Stopping the timer suppresses a spurious skip-forward after the page re-initialises
+2. `setMusicService(id)` persists the new service
+3. `rebuildTrayMenu(tray)` runs when a tray exists
+4. `setThemeCssKey(null)` drops the tracked inserted-CSS key. The navigation below replaces the document, so the next injection must not call `removeInsertedCSS()` with a key from the old one
+5. `loadURL(targetUrl ?? buildAppleMusicURL())`. The default resolves after step 2, so it reads the service just persisted
+
+`routeToMusicService(url)` handles `itms://` links. When the active service is not `music` it calls `switchService('music', url)`, otherwise it navigates directly. Passing the link into `switchService()` rather than navigating after it keeps the switch to one navigation.
+
+`main.ts` owns the window and the tray but cannot be imported, because it runs `app.whenReady()` at import. It supplies both through `initServiceSwitch({ getTray, loadURL })`.
+
+---
+
 ## Authentication
 
 Non-issue by design. Cider's auth breaks because it uses MusicKit.js with a developer token it controls and the OAuth user-token flow. Sidra loads `music.apple.com` - Apple handles authentication entirely. Identical to opening Chrome and navigating to `music.apple.com`.
@@ -524,7 +620,7 @@ Implementation:
 win.webContents.on('will-prevent-unload', (event) => event.preventDefault());
 ```
 
-This is standard Chromium/Electron behaviour, not CastLabs-specific. The same issue was documented for Google Music in [electron/electron#8468](https://github.com/electron/electron/issues/8468). See `docs/QUIT.md` for full research.
+This is standard Chromium/Electron behaviour, not CastLabs-specific. The same issue was documented for Google Music in [electron/electron#8468](https://github.com/electron/electron/issues/8468).
 
 ---
 
@@ -536,9 +632,12 @@ The default colour scheme is Apple Music's own (`'apple-music'`). Bundled themes
 
 Theme preference is stored in `electron-conf` as `theme` (`ThemeName`: `'apple-music'` | `BundledThemeName` | `'custom'`). `resolveTheme()` guards startup/runtime behaviour:
 
+- Apple Music Classical returns `'apple-music'` before the stored value is read, so no override CSS is injected. The stored theme is left untouched and returns on the switch back
 - Unknown stored values fall back to `'apple-music'`
-- `'custom'` falls back to `'apple-music'` when `custom.css` does not exist
+- `'custom'` falls back to `'apple-music'` when `custom.css` holds no usable CSS
 - Bundled values pass through directly
+
+`hasCustomCss()` is `getThemeCss('custom') !== null`, so a present `custom.css` means a readable, non-blank file rather than one that merely exists.
 
 ### Implementation
 
@@ -546,14 +645,18 @@ Theme preference is stored in `electron-conf` as `theme` (`ThemeName`: `'apple-m
 
 - `'apple-music'` → `null` (remove any injected override)
 - bundled themes → lazily rendered via `buildThemeCss(...)` and cached in memory
-- `'custom'` → `userData/custom.css`, read fresh on each apply; missing/empty/whitespace-only files are treated as absent
+- `'custom'` → `userData/custom.css`, cached in memory; missing, unreadable, or whitespace-only files are treated as absent
 
 `custom.css` lifecycle:
 
 - Path: `path.join(app.getPath('userData'), 'custom.css')`
 - `initThemeCSS()` ensures the user data directory exists, then installs `fs.watch(..., { persistent: false })`
 - Watcher reacts to `filename === 'custom.css'` and `filename === null` (macOS behaviour), debounced by 150ms
-- Re-apply occurs only when `resolveTheme() === 'custom'` and the window is still alive
+- The file contents are cached, because `hasCustomCss()` and `resolveTheme()` both read them on every tray rebuild
+- The watcher calls `invalidateCustomCssCache()` before the debounce, not inside it, so a tray rebuild during the debounce window cannot read stale contents from the cache
+- A watcher that fails to start, or that errors and closes, calls `disableCustomCssCache()`. Caching switches off, rather than leaving a cache that goes stale for the life of the process
+- The debounced callback re-applies `'custom'` when `resolveTheme()` returns it, and falls back to `'apple-music'` when the stored theme is `'custom'` but the file no longer holds usable CSS. Both paths need the window to be alive
+- It then calls the tray rebuild callback unconditionally, because creating or deleting `custom.css` adds or removes the tray Style entry whichever theme is stored. `main.ts` supplies that callback through `setRebuildTrayCallback()`, since `tray.ts` imports `theme.ts` and the import cannot run back the other way
 - Watcher setup and runtime errors are logged as warnings; they never crash the app
 - Timer cleanup and watcher close run on `app.on('will-quit')`
 
@@ -898,7 +1001,7 @@ electron-updater manifest filenames are hardcoded and cannot be changed:
 | Windows overlay icon | `win.setOverlayIcon()` | Play/pause badge; skipped during transient states |
 | Windows taskbar progress bar | `win.setProgressBar()` via `progressBar.ts` | Same utility as macOS dock |
 | Splash screen | `assets/splash.html` | Localised loading text via `loading.json` |
-| Content readiness polling | `amp-lcd[hydrated]` selector | Waits for Apple Music UI to hydrate before removing splash |
+| Content readiness polling | `CONTENT_READY_SELECTOR` in `src/contentReady.ts`: `[data-testid="app-container"] amp-playback-controls-play[hydrated]` | Waits for the UI to hydrate before removing splash; both services share the selector |
 | About window | Frameless `BrowserWindow` + `assets/about.html` | Localised labels via `about.json` |
 | Navigation bar | `assets/navigationBar.js` injected post-load | Back/forward/reload buttons in sidebar |
 | Auth iframe filtering | `authStyleFix.css` + `webFrameMain.executeJavaScript()` | Hides unsupported passkey and "Sign in with iPhone" desktop flows |

--- a/justfile
+++ b/justfile
@@ -171,18 +171,20 @@ generate-menu-icons:
 clean:
     rm -rf dist/
 
+# The cache directory is lowercase because src/artwork.ts builds it from app.getName().toLowerCase()
 # Clear all Sidra user data and caches
 [macos]
 clear:
     rm -rf ~/Library/Application\ Support/Sidra
-    rm -rf ~/Library/Caches/Sidra
+    rm -rf ~/Library/Caches/sidra
     rm -rf ~/Library/Logs/Sidra
     @echo "Sidra data cleared"
 
+# The cache directory is lowercase because src/artwork.ts builds it from app.getName().toLowerCase()
 # Clear all Sidra user data and caches
 [linux]
 clear:
-    rm -rf ~/.config/sidra
+    rm -rf ~/.config/Sidra
     rm -rf ~/.cache/sidra
     @echo "Sidra data cleared"
 
@@ -202,9 +204,16 @@ package: build
     npx electron-builder {{ if os() == "linux" { "--linux AppImage" } else if os() == "macos" { "--mac dmg --x64 --arm64" } else { "error('Unsupported platform')" } }}
 
 # Show log file location and tail recent entries
+[linux]
 logs:
-    @echo "Log file: ~/.config/sidra/logs/main.log"
-    @tail -50 ~/.config/sidra/logs/main.log 2>/dev/null || echo "No log file yet. Run the app first."
+    @echo "Log file: ~/.config/Sidra/logs/main.log"
+    @tail -50 ~/.config/Sidra/logs/main.log 2>/dev/null || echo "No log file yet. Run the app first."
+
+# Show log file location and tail recent entries
+[macos]
+logs:
+    @echo "Log file: ~/Library/Logs/Sidra/main.log"
+    @tail -50 ~/Library/Logs/Sidra/main.log 2>/dev/null || echo "No log file yet. Run the app first."
 
 # Cut a release: just release 1.2.3
 release VERSION:

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,12 @@
 import log from 'electron-log/main';
 import type { ThemeName } from './theme';
-import { DEFAULT_SERVICE_ID, isMusicServiceId, type ClassicalStartPageId, type MusicServiceId } from './musicService';
+import {
+  DEFAULT_SERVICE_ID,
+  isMusicServiceId,
+  type ClassicalStartPageId,
+  type MusicServiceId,
+  type MusicStartPageId,
+} from './musicService';
 
 const configLog = log.scope('config');
 
@@ -15,7 +21,7 @@ interface StoreSchema {
   'lastfm.username': string | null;
   theme: ThemeName;
   'autoUpdate.enabled': boolean;
-  startPage: 'home' | 'new' | 'radio' | 'all-playlists' | 'last';
+  startPage: MusicStartPageId | 'last';
   lastPageUrl: string;
   'classical.startPage': ClassicalStartPageId | 'last';
   'classical.lastPageUrl': string;
@@ -138,11 +144,11 @@ export function setLastPageUrl(url: string): void {
   configLog.info('lastPageUrl set:', url);
 }
 
-export function getStartPage(): 'home' | 'new' | 'radio' | 'all-playlists' | 'last' {
+export function getStartPage(): MusicStartPageId | 'last' {
   return getConfigValue('startPage', 'new');
 }
 
-export function setStartPage(page: 'home' | 'new' | 'radio' | 'all-playlists' | 'last'): void {
+export function setStartPage(page: MusicStartPageId | 'last'): void {
   store.set('startPage', page);
   configLog.info('startPage set:', page);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import log from 'electron-log/main';
 import type { ThemeName } from './theme';
-import type { MusicServiceId } from './musicService';
+import { DEFAULT_SERVICE_ID, isMusicServiceId, type ClassicalStartPageId, type MusicServiceId } from './musicService';
 
 const configLog = log.scope('config');
 
@@ -17,7 +17,7 @@ interface StoreSchema {
   'autoUpdate.enabled': boolean;
   startPage: 'home' | 'new' | 'radio' | 'all-playlists' | 'last';
   lastPageUrl: string;
-  'classical.startPage': string;
+  'classical.startPage': ClassicalStartPageId | 'last';
   'classical.lastPageUrl': string;
   zoomFactor: number;
   musicService: MusicServiceId;
@@ -157,7 +157,12 @@ export function setZoomFactor(factor: number): void {
 }
 
 export function getMusicService(): MusicServiceId {
-  return getConfigValue('musicService', 'music');
+  const id = getConfigValue('musicService', DEFAULT_SERVICE_ID);
+  if (!isMusicServiceId(id)) {
+    configLog.warn('musicService not registered:', id, '- falling back to:', DEFAULT_SERVICE_ID);
+    return DEFAULT_SERVICE_ID;
+  }
+  return id;
 }
 
 export function setMusicService(id: MusicServiceId): void {
@@ -165,11 +170,11 @@ export function setMusicService(id: MusicServiceId): void {
   configLog.info('musicService set:', id);
 }
 
-export function getClassicalStartPage(): string {
+export function getClassicalStartPage(): ClassicalStartPageId | 'last' {
   return getConfigValue('classical.startPage', 'home');
 }
 
-export function setClassicalStartPage(page: string): void {
+export function setClassicalStartPage(page: ClassicalStartPageId | 'last'): void {
   store.set('classical.startPage', page);
   configLog.info('classical.startPage set:', page);
 }

--- a/src/integrations/mpris/index.ts
+++ b/src/integrations/mpris/index.ts
@@ -4,8 +4,7 @@ import log from 'electron-log/main';
 import { Player, NowPlayingPayload, PlaybackState, PlaybackStatePayload, IntegrationContext } from '../../player';
 import { downloadArtwork } from '../../artwork';
 import { errorMessage } from '../../utils';
-import { getMusicService } from '../../config';
-import { getService } from '../../musicService';
+import { getServiceByHost } from '../../musicService';
 
 // @holusion/dbus-next is lazy-required because the MPRIS module only loads on Linux
 const dbus = require('@holusion/dbus-next');
@@ -521,7 +520,7 @@ class MediaPlayer2Player extends Interface {
   OpenUri(uri: string): void {
     try {
       const parsed = new URL(uri);
-      if (parsed.hostname !== getService(getMusicService()).host || parsed.protocol !== 'https:') {
+      if (getServiceByHost(parsed.hostname) === undefined || parsed.protocol !== 'https:') {
         mprisLog.warn('OpenUri rejected:', uri);
         return;
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -363,12 +363,10 @@ function setupNavigationHandlers(win: BrowserWindow, navBarScript: string, hookS
     } catch (e: unknown) {
       mainLog.warn('failed to inject hookScript on SPA navigation:', e);
     }
-    if (getMusicService() === 'music') {
-      try {
-        await win.webContents.executeJavaScript(navBarScript);
-      } catch (e: unknown) {
-        mainLog.warn('failed to inject navBarScript on SPA navigation:', e);
-      }
+    try {
+      await win.webContents.executeJavaScript(navBarScript);
+    } catch (e: unknown) {
+      mainLog.warn('failed to inject navBarScript on SPA navigation:', e);
     }
   });
 }
@@ -594,10 +592,8 @@ function setupContentHandlers(win: BrowserWindow, player: Player, markCssReady: 
     }
     await win.webContents.executeJavaScript(assets.hookScript);
     mainLog.debug('MusicKit hook injected');
-    if (activeService === 'music') {
-      await win.webContents.executeJavaScript(assets.navBarScript);
-      mainLog.debug('Navigation bar injected');
-    }
+    await win.webContents.executeJavaScript(assets.navBarScript);
+    mainLog.debug('Navigation bar injected');
   }
 
   let initialized = false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import { createTray, getMenuIcon, initTrayStateManager, rebuildTrayMenu, setAppl
 import { showAboutWindow } from './aboutWindow';
 import { checkForUpdates } from './update';
 import { isAutoUpdateSupported, initAutoUpdate } from './autoUpdate';
-import { getService, allServices } from './musicService';
+import { getService, allServices, isAllowedNavigationUrl } from './musicService';
 import { init as initNotifications } from './integrations/notifications';
 import { init as initDiscordPresence } from './integrations/discord-presence';
 import { init as initLastfm } from './integrations/lastfm';
@@ -346,6 +346,15 @@ function setupWindowZoomAndNav(win: BrowserWindow): void {
 }
 
 function setupNavigationHandlers(win: BrowserWindow, navBarScript: string, hookScript: string): void {
+  // Keeps the main frame on Apple's hosts, so the preload command bridge and the
+  // injected hook can only ever reach Apple Music. Main-process loadURL() calls do
+  // not raise this event, so launch, service switching and itms:// routing are unaffected.
+  win.webContents.on('will-navigate', (event, url) => {
+    if (!isAllowedNavigationUrl(url)) {
+      event.preventDefault();
+      mainLog.warn('blocked navigation to disallowed host:', url);
+    }
+  });
   win.webContents.on('did-start-navigation', (_event, url, isInPlace, isMainFrame) => {
     if (isMainFrame) {
       mainLog.debug('did-start-navigation:', url);
@@ -358,10 +367,15 @@ function setupNavigationHandlers(win: BrowserWindow, navBarScript: string, hookS
   win.webContents.on('did-navigate-in-page', async (_event, url) => {
     handleStorefrontNavigation(url);
     handleLastPageNavigation(url);
-    try {
-      await win.webContents.executeJavaScript(hookScript);
-    } catch (e: unknown) {
-      mainLog.warn('failed to inject hookScript on SPA navigation:', e);
+    const currentUrl = win.webContents.getURL();
+    if (!isAllowedNavigationUrl(currentUrl)) {
+      mainLog.warn('skipped hookScript injection on disallowed host:', currentUrl);
+    } else {
+      try {
+        await win.webContents.executeJavaScript(hookScript);
+      } catch (e: unknown) {
+        mainLog.warn('failed to inject hookScript on SPA navigation:', e);
+      }
     }
     try {
       await win.webContents.executeJavaScript(navBarScript);
@@ -590,8 +604,13 @@ function setupContentHandlers(win: BrowserWindow, player: Player, markCssReady: 
     } else {
       setThemeCssKey(null);
     }
-    await win.webContents.executeJavaScript(assets.hookScript);
-    mainLog.debug('MusicKit hook injected');
+    const currentUrl = win.webContents.getURL();
+    if (isAllowedNavigationUrl(currentUrl)) {
+      await win.webContents.executeJavaScript(assets.hookScript);
+      mainLog.debug('MusicKit hook injected');
+    } else {
+      mainLog.warn('skipped hookScript injection on disallowed host:', currentUrl);
+    }
     await win.webContents.executeJavaScript(assets.navBarScript);
     mainLog.debug('Navigation bar injected');
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { getAssetPath } from './paths';
 import { Player, IntegrationContext } from './player';
 import { buildAppleMusicURL, buildItmsRouteURL, handleStorefrontNavigation, handleLastPageNavigation } from './storefront';
 import { extractItmsUrlFromArgv, type ItmsTarget } from './itms';
-import { getThemeCss, initThemeCSS, resolveTheme, setThemeCssKey } from './theme';
+import { getThemeCss, initThemeCSS, resolveTheme, setRebuildTrayCallback, setThemeCssKey } from './theme';
 import { createTray, getMenuIcon, initTrayStateManager, rebuildTrayMenu, setApplyZoomCallback, setSendCommandCallback, setGetMainWindowCallback, setSwitchServiceCallback } from './tray';
 import { showAboutWindow } from './aboutWindow';
 import { checkForUpdates } from './update';
@@ -672,6 +672,9 @@ if (gotLock) {
       resetWedgeDetector();
       setThemeCssKey(null);
       win!.loadURL(buildAppleMusicURL(), { userAgent: UA });
+    });
+    setRebuildTrayCallback(() => {
+      if (appTray) rebuildTrayMenu(appTray);
     });
     setupWindowZoomAndNav(win);
     initThemeCSS(win);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,12 +2,13 @@ import { app, BrowserWindow, components, ipcMain, Menu, session, shell, Tray, we
 import fs from 'fs';
 import path from 'path';
 import log from 'electron-log/main';
-import { getZoomFactor, getCloseToTrayEnabled, getMusicService, setMusicService } from './config';
+import { getZoomFactor, getCloseToTrayEnabled, getMusicService } from './config';
 import { getLoadingText } from './i18n';
 import { getAssetPath } from './paths';
 import { Player, IntegrationContext } from './player';
 import { buildAppleMusicURL, buildItmsRouteURL, handleStorefrontNavigation, handleLastPageNavigation } from './storefront';
 import { extractItmsUrlFromArgv, type ItmsTarget } from './itms';
+import { initServiceSwitch, routeToMusicService, switchService } from './serviceSwitch';
 import { getThemeCss, initThemeCSS, resolveTheme, setRebuildTrayCallback, setThemeCssKey } from './theme';
 import { createTray, getMenuIcon, initTrayStateManager, rebuildTrayMenu, setApplyZoomCallback, setSendCommandCallback, setGetMainWindowCallback, setSwitchServiceCallback } from './tray';
 import { showAboutWindow } from './aboutWindow';
@@ -133,22 +134,9 @@ function routeItmsTarget(target: ItmsTarget | null): void {
     pendingItmsTarget = target;
     return;
   }
-  // itms:// always targets the music service; switch back if classical is active
-  if (getMusicService() !== 'music') {
-    setMusicService('music');
-    if (appTray) rebuildTrayMenu(appTray);
-    resetWedgeDetector();
-  }
-  if (target.kind === 'url') {
-    win.loadURL(target.url, { userAgent: UA }).catch(err =>
-      mainLog.warn('itms loadURL failed:', (err as Error).message)
-    );
-  } else {
-    const url = buildItmsRouteURL(target.token);
-    win.loadURL(url, { userAgent: UA }).catch(err =>
-      mainLog.warn('itms route loadURL failed:', (err as Error).message)
-    );
-  }
+  // Resolved before the switch; buildItmsRouteURL pins the music origin itself.
+  const url = target.kind === 'url' ? target.url : buildItmsRouteURL(target.token);
+  routeToMusicService(url);
   mainLog.info(`itms target routed: kind=${target.kind}`);
 }
 
@@ -683,11 +671,15 @@ if (gotLock) {
     setGetMainWindowCallback(() => win);
     setDockSendCommandCallback((channel, ...args) => win!.webContents.send(channel, ...args));
     setTaskbarSendCommandCallback((channel, ...args) => win!.webContents.send(channel, ...args));
-    setSwitchServiceCallback((_serviceId) => {
-      resetWedgeDetector();
-      setThemeCssKey(null);
-      win!.loadURL(buildAppleMusicURL(), { userAgent: UA });
+    initServiceSwitch({
+      getTray: () => appTray,
+      loadURL: url => {
+        win?.loadURL(url, { userAgent: UA }).catch(err =>
+          mainLog.warn('service navigation loadURL failed:', (err as Error).message)
+        );
+      },
     });
+    setSwitchServiceCallback(switchService);
     setRebuildTrayCallback(() => {
       if (appTray) rebuildTrayMenu(appTray);
     });

--- a/src/musicService.ts
+++ b/src/musicService.ts
@@ -106,9 +106,14 @@ export const ALLOWED_NAVIGATION_HOSTS: ReadonlySet<string> = new Set(
 // Takes a URL string rather than a hostname so malformed input is rejected in one place.
 // URL.hostname is lowercased, punycoded and port-free, and the match is exact: a subdomain,
 // a suffix or a userinfo prefix of an allowed host is not an allowed host.
+// The scheme is checked too, because hostname alone does not imply a web origin: the parser
+// reads an authority out of any URL carrying '//', so 'javascript://music.apple.com/%0aalert(1)'
+// and 'file://music.apple.com/etc/passwd' both yield an allowed hostname. Apple serves both
+// services and the authentication flow over https, so nothing legitimate needs another scheme.
 export function isAllowedNavigationUrl(url: string): boolean {
   try {
-    return ALLOWED_NAVIGATION_HOSTS.has(new URL(url).hostname);
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' && ALLOWED_NAVIGATION_HOSTS.has(parsed.hostname);
   } catch {
     return false;
   }

--- a/src/musicService.ts
+++ b/src/musicService.ts
@@ -47,8 +47,7 @@ export const MUSIC_SERVICES: Record<MusicServiceId, MusicService> = {
     contentReadySelector: SHARED_CONTENT_READY_SELECTOR,
     startPages: [
       { id: 'home', path: '' },
-      { id: 'browse', path: 'browse' },
-      { id: 'library', path: 'library' },
+      { id: 'browse', path: 'browse/catalog' },
       { id: 'playlists', path: 'browse/playlists' },
       { id: 'search', path: 'search' },
     ],

--- a/src/musicService.ts
+++ b/src/musicService.ts
@@ -2,6 +2,8 @@
 // Pure music service registry: no imports from electron, electron-log, or config.
 // Kept dependency-free so itms.ts and tests can import without pulling in Electron.
 
+import { CONTENT_READY_SELECTOR } from './contentReady';
+
 export type MusicServiceId = 'music' | 'classical';
 
 export interface StartPage<PageId extends string = string> {
@@ -32,7 +34,6 @@ function defineService<const PageId extends string>(
   return def;
 }
 
-const SHARED_CONTENT_READY_SELECTOR = '[data-testid="app-container"] amp-playback-controls-play[hydrated]';
 const SHARED_AUTH_FRAME_HOSTS = ['auth.music.apple.com', 'idmsa.apple.com'] as const;
 
 export const MUSIC_SERVICES = {
@@ -42,7 +43,7 @@ export const MUSIC_SERVICES = {
     origin: 'https://music.apple.com',
     displayName: 'Apple Music',
     authFrameHosts: SHARED_AUTH_FRAME_HOSTS,
-    contentReadySelector: SHARED_CONTENT_READY_SELECTOR,
+    contentReadySelector: CONTENT_READY_SELECTOR,
     startPages: [
       { id: 'home', path: 'home' },
       { id: 'new', path: 'new' },
@@ -57,7 +58,7 @@ export const MUSIC_SERVICES = {
     origin: 'https://classical.music.apple.com',
     displayName: 'Apple Music Classical',
     authFrameHosts: SHARED_AUTH_FRAME_HOSTS,
-    contentReadySelector: SHARED_CONTENT_READY_SELECTOR,
+    contentReadySelector: CONTENT_READY_SELECTOR,
     startPages: [
       { id: 'home', path: '' },
       { id: 'browse', path: 'browse/catalog' },
@@ -68,8 +69,14 @@ export const MUSIC_SERVICES = {
   }),
 } satisfies Record<MusicServiceId, MusicService>;
 
+/** Start page ids offered by Apple Music, derived from the registry. */
+export type MusicStartPageId = typeof MUSIC_SERVICES.music.startPages[number]['id'];
+
 /** Start page ids offered by Apple Music Classical, derived from the registry. */
 export type ClassicalStartPageId = typeof MUSIC_SERVICES.classical.startPages[number]['id'];
+
+/** Every start page id in the registry, for records that must cover both services. */
+export type AnyStartPageId = MusicStartPageId | ClassicalStartPageId;
 
 export const DEFAULT_SERVICE_ID: MusicServiceId = 'music';
 

--- a/src/musicService.ts
+++ b/src/musicService.ts
@@ -4,7 +4,12 @@
 
 export type MusicServiceId = 'music' | 'classical';
 
-export interface MusicService {
+export interface StartPage<PageId extends string = string> {
+  id: PageId;
+  path: string;
+}
+
+export interface MusicService<PageId extends string = string> {
   id: MusicServiceId;
   host: string;
   origin: string;
@@ -13,17 +18,25 @@ export interface MusicService {
   authFrameHosts: readonly string[];
   /** CSS selector probed to detect when the web app is interactive. */
   contentReadySelector: string;
-  /** Ordered start page entries rendered in the tray Start Page submenu. */
-  startPages: readonly { id: string; path: string }[];
+  /** Ordered start page entries rendered in the tray Start Page submenu. Non-empty, so [0] is total. */
+  startPages: readonly [StartPage<PageId>, ...StartPage<PageId>[]];
   /** Default start page id used when no persisted value exists. */
-  defaultStartPage: string;
+  defaultStartPage: PageId;
+}
+
+// PageId is inferred from startPages alone; NoInfer keeps defaultStartPage out of the inference,
+// so a typo there fails to compile instead of widening the union.
+function defineService<const PageId extends string>(
+  def: Omit<MusicService<PageId>, 'defaultStartPage'> & { defaultStartPage: NoInfer<PageId> },
+): MusicService<PageId> {
+  return def;
 }
 
 const SHARED_CONTENT_READY_SELECTOR = '[data-testid="app-container"] amp-playback-controls-play[hydrated]';
 const SHARED_AUTH_FRAME_HOSTS = ['auth.music.apple.com', 'idmsa.apple.com'] as const;
 
-export const MUSIC_SERVICES: Record<MusicServiceId, MusicService> = {
-  music: {
+export const MUSIC_SERVICES = {
+  music: defineService({
     id: 'music',
     host: 'music.apple.com',
     origin: 'https://music.apple.com',
@@ -37,8 +50,8 @@ export const MUSIC_SERVICES: Record<MusicServiceId, MusicService> = {
       { id: 'all-playlists', path: 'library/all-playlists/' },
     ],
     defaultStartPage: 'new',
-  },
-  classical: {
+  }),
+  classical: defineService({
     id: 'classical',
     host: 'classical.music.apple.com',
     origin: 'https://classical.music.apple.com',
@@ -52,13 +65,22 @@ export const MUSIC_SERVICES: Record<MusicServiceId, MusicService> = {
       { id: 'search', path: 'search' },
     ],
     defaultStartPage: 'home',
-  },
-};
+  }),
+} satisfies Record<MusicServiceId, MusicService>;
+
+/** Start page ids offered by Apple Music Classical, derived from the registry. */
+export type ClassicalStartPageId = typeof MUSIC_SERVICES.classical.startPages[number]['id'];
 
 export const DEFAULT_SERVICE_ID: MusicServiceId = 'music';
 
+export function isMusicServiceId(value: string): value is MusicServiceId {
+  return Object.hasOwn(MUSIC_SERVICES, value);
+}
+
+// Total at runtime as well as in the type. An id that escaped validation must not throw here:
+// every dereference is on the path that builds the tray, the app's only settings surface.
 export function getService(id: MusicServiceId): MusicService {
-  return MUSIC_SERVICES[id];
+  return MUSIC_SERVICES[id] ?? MUSIC_SERVICES[DEFAULT_SERVICE_ID];
 }
 
 export function getServiceByHost(host: string): MusicService | undefined {

--- a/src/musicService.ts
+++ b/src/musicService.ts
@@ -90,3 +90,19 @@ export function getServiceByHost(host: string): MusicService | undefined {
 export function allServices(): readonly MusicService[] {
   return Object.values(MUSIC_SERVICES);
 }
+
+// Derived from the registry so a new service or auth host widens the allowlist automatically.
+export const ALLOWED_NAVIGATION_HOSTS: ReadonlySet<string> = new Set(
+  allServices().flatMap(svc => [svc.host, ...svc.authFrameHosts]),
+);
+
+// Takes a URL string rather than a hostname so malformed input is rejected in one place.
+// URL.hostname is lowercased, punycoded and port-free, and the match is exact: a subdomain,
+// a suffix or a userinfo prefix of an allowed host is not an allowed host.
+export function isAllowedNavigationUrl(url: string): boolean {
+  try {
+    return ALLOWED_NAVIGATION_HOSTS.has(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}

--- a/src/palettes.ts
+++ b/src/palettes.ts
@@ -5,6 +5,12 @@
 // marked "derived" have no upstream equivalent and are interpolated to
 // fit the slot's role.
 //
+// Two rules, checked by test/themes.test.ts:
+// - overlay differs from subtext0, and crust from surface0. Each pair
+//   paints a different part of the UI, so one hex in both flattens it.
+// - text and subtext0 reach 4.5:1 against base once the template applies
+//   its alpha. Catppuccin Latte holds its shipped 4.37:1 instead.
+//
 // Upstream palettes (colour values only; palettes are not creative
 // works, attribution given as a courtesy):
 // - Catppuccin (Mocha/Latte)  https://github.com/catppuccin/palette      MIT
@@ -107,10 +113,10 @@ export const BUNDLED_THEMES: readonly BundledTheme[] = [
       base: '#fbf1c7',
       mantle: '#f2e5bc',
       crust: '#ebdbb2',
-      surface0: '#ebdbb2',
-      surface1: '#d5c4a1',
-      surface2: '#bdae93',
-      overlay: '#a89984',
+      surface0: '#d5c4a1',
+      surface1: '#bdae93',
+      surface2: '#a89984',
+      overlay: '#928374',
       text: '#3c3836',
       subtext1: '#504945',
       subtext0: '#665c54',
@@ -141,7 +147,7 @@ export const BUNDLED_THEMES: readonly BundledTheme[] = [
       base: '#eceff4',
       mantle: '#e5e9f0',
       crust: '#d8dee9',
-      surface0: '#d8dee9',
+      surface0: '#cdd4e0', // derived
       surface1: '#c2c9d6', // derived
       surface2: '#aab2c4', // derived
       overlay: '#7b88a1', // derived
@@ -165,8 +171,8 @@ export const BUNDLED_THEMES: readonly BundledTheme[] = [
       surface2: '#524f67',
       overlay: '#6e6a86',
       text: '#e0def4',
-      subtext1: '#908caa',
-      subtext0: '#6e6a86',
+      subtext1: '#b8b5cf', // derived
+      subtext0: '#908caa',
       accent: '#ebbcba',
       accentHover: '#eb6f92',
     },
@@ -181,7 +187,7 @@ export const BUNDLED_THEMES: readonly BundledTheme[] = [
       overlay: '#9893a5',
       text: '#575279',
       subtext1: '#797593',
-      subtext0: '#9893a5',
+      subtext0: '#686486', // derived
       accent: '#d7827e',
       accentHover: '#b4637a',
     },
@@ -197,9 +203,9 @@ export const BUNDLED_THEMES: readonly BundledTheme[] = [
       surface1: '#0e4552', // derived
       surface2: '#586e75',
       overlay: '#657b83',
-      text: '#93a1a1',
+      text: '#eee8d5',
       subtext1: '#839496',
-      subtext0: '#657b83',
+      subtext0: '#93a1a1',
       accent: '#268bd2',
       accentHover: '#2aa198',
     },
@@ -207,13 +213,13 @@ export const BUNDLED_THEMES: readonly BundledTheme[] = [
       base: '#fdf6e3',
       mantle: '#f5eed9', // derived
       crust: '#eee8d5',
-      surface0: '#eee8d5',
+      surface0: '#e6dfcb', // derived
       surface1: '#ddd6c1', // derived
       surface2: '#93a1a1',
       overlay: '#839496',
-      text: '#586e75',
+      text: '#073642',
       subtext1: '#657b83',
-      subtext0: '#839496',
+      subtext0: '#586e75',
       accent: '#268bd2',
       accentHover: '#2aa198',
     },

--- a/src/serviceSwitch.ts
+++ b/src/serviceSwitch.ts
@@ -1,0 +1,44 @@
+// src/serviceSwitch.ts
+// The one service-switch sequence. Both the tray Player submenu and itms:// routing
+// go through switchService(), so the order below is the only order that ships.
+
+import type { Tray } from 'electron';
+import { getMusicService, setMusicService } from './config';
+import type { MusicServiceId } from './musicService';
+import { buildAppleMusicURL } from './storefront';
+import { setThemeCssKey } from './theme';
+import { rebuildTrayMenu } from './tray';
+import { reset as resetWedgeDetector } from './wedgeDetector';
+
+// main.ts owns the window and the tray but cannot be imported (it runs app.whenReady()
+// at import), so it supplies both here, as it does for setSendCommandCallback and friends.
+let getTrayCallback: (() => Tray | null) | null = null;
+let loadURLCallback: ((url: string) => void) | null = null;
+
+export function initServiceSwitch(deps: { getTray: () => Tray | null; loadURL: (url: string) => void }): void {
+  getTrayCallback = deps.getTray;
+  loadURLCallback = deps.loadURL;
+}
+
+export function switchService(id: MusicServiceId, targetUrl?: string): void {
+  resetWedgeDetector();
+  setMusicService(id);
+  const tray = getTrayCallback?.() ?? null;
+  if (tray) rebuildTrayMenu(tray);
+  // Drop the tracked inserted-CSS key. The navigation below replaces the document, so
+  // the next injection must not call removeInsertedCSS() with a key from the old one.
+  setThemeCssKey(null);
+  // Resolved after setMusicService, so the default reads the service just persisted.
+  const url = targetUrl ?? buildAppleMusicURL();
+  loadURLCallback?.(url);
+}
+
+// itms:// links always target the music service. Passing the link to switchService()
+// rather than navigating after it keeps the switch to one navigation.
+export function routeToMusicService(url: string): void {
+  if (getMusicService() !== 'music') {
+    switchService('music', url);
+    return;
+  }
+  loadURLCallback?.(url);
+}

--- a/src/storefront.ts
+++ b/src/storefront.ts
@@ -40,44 +40,25 @@ export function buildAppleMusicURL(): string {
   const serviceId = getMusicService();
   const service = getService(serviceId);
 
-  if (serviceId === 'classical') {
-    const classicalStartPage = getClassicalStartPage();
-    if (classicalStartPage === 'last') {
-      const lastPath = getClassicalLastPageUrl();
-      if (lastPath) {
-        return appendLanguage(`${service.origin}/${storefront}/${lastPath}`, language);
-      }
-      // fall through: no stored path yet, use default
-    }
-    const pageEntry = service.startPages.find(p => p.id === classicalStartPage)
-      ?? service.startPages.find(p => p.id === service.defaultStartPage)
-      ?? service.startPages[0];
-    const pagePath = pageEntry.path;
-    if (pagePath === '') {
-      return appendLanguage(`${service.origin}/${storefront}`, language);
-    }
-    return appendLanguage(`${service.origin}/${storefront}/${pagePath}`, language);
-  }
+  const isClassical = serviceId === 'classical';
+  const startPage = isClassical ? getClassicalStartPage() : getStartPage();
 
-  // music service
-  const startPage = getStartPage();
   if (startPage === 'last') {
-    const lastPath = getLastPageUrl();
+    // Read the stored path only in this branch; the getters stay untouched for every other page.
+    const lastPath = isClassical ? getClassicalLastPageUrl() : getLastPageUrl();
     if (lastPath) {
       return appendLanguage(`${service.origin}/${storefront}/${lastPath}`, language);
     }
-    // fall through: no stored path yet, use 'new'
+    // fall through: no stored path yet, use the service default
   }
 
-  const pagePathMap: Record<string, string> = {
-    'home': 'home',
-    'new': 'new',
-    'radio': 'radio',
-    'all-playlists': 'library/all-playlists/',
-  };
-  const pagePath = pagePathMap[startPage] ?? pagePathMap['new'];
+  const pageEntry = service.startPages.find(p => p.id === startPage)
+    ?? service.startPages.find(p => p.id === service.defaultStartPage)
+    ?? service.startPages[0];
+  // The classical home entry has an empty path and must not gain a trailing slash.
+  const pagePath = pageEntry.path === '' ? '' : `/${pageEntry.path}`;
 
-  return appendLanguage(`${service.origin}/${storefront}/${pagePath}`, language);
+  return appendLanguage(`${service.origin}/${storefront}${pagePath}`, language);
 }
 
 export function buildItmsRouteURL(token: ItmsRouteToken): string {

--- a/src/storefront.ts
+++ b/src/storefront.ts
@@ -50,7 +50,8 @@ export function buildAppleMusicURL(): string {
       // fall through: no stored path yet, use default
     }
     const pageEntry = service.startPages.find(p => p.id === classicalStartPage)
-      ?? service.startPages.find(p => p.id === service.defaultStartPage)!;
+      ?? service.startPages.find(p => p.id === service.defaultStartPage)
+      ?? service.startPages[0];
     const pagePath = pageEntry.path;
     if (pagePath === '') {
       return appendLanguage(`${service.origin}/${storefront}`, language);
@@ -86,7 +87,8 @@ export function buildItmsRouteURL(token: ItmsRouteToken): string {
   }
   const language = getLanguage();
   const path = ITMS_ROUTE_PATHS[token];
-  return appendLanguage(`${getService(getMusicService()).origin}/${storefront}/${path}`, language);
+  // itms:// is permanently pinned to the music service; transformItmsUrl in src/itms.ts pins the host
+  return appendLanguage(`${getService('music').origin}/${storefront}/${path}`, language);
 }
 
 export function extractStorefrontFromURL(url: string): { storefront: string; language: string | null } | null {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -23,6 +23,10 @@ let themeCssKey: string | null = null;
 // No-op until initThemeCSS() assigns the real implementation.
 let applyThemeCSSInternal: (name: ThemeName) => Promise<void> = () => Promise.resolve();
 
+// Rebuild the tray menu after a custom.css change.
+// tray.ts imports theme.ts, so theme.ts cannot import rebuildTrayMenu back; main.ts supplies it.
+let rebuildTrayCallback: (() => void) | null = null;
+
 export function applyTheme(name: ThemeName): void {
   void applyThemeCSSInternal(name);
 }
@@ -32,7 +36,7 @@ export function customCssPath(): string {
 }
 
 export function hasCustomCss(): boolean {
-  return fs.existsSync(customCssPath());
+  return getThemeCss('custom') !== null;
 }
 
 function isThemeName(value: string): value is ThemeName {
@@ -126,6 +130,9 @@ export function initThemeCSS(win: BrowserWindow): void {
         } else if (getTheme() === 'custom') {
           void applyThemeCSSInternal('apple-music');
         }
+        // Unconditional: creating custom.css adds the tray Style entry and deleting it removes
+        // the entry, whichever theme is stored.
+        rebuildTrayCallback?.();
       }, THEME_RELOAD_DEBOUNCE_MS);
     });
     watcher.on('error', (error) => {
@@ -149,4 +156,8 @@ export function initThemeCSS(win: BrowserWindow): void {
 
 export function setThemeCssKey(key: string | null): void {
   themeCssKey = key;
+}
+
+export function setRebuildTrayCallback(callback: () => void): void {
+  rebuildTrayCallback = callback;
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -15,6 +15,15 @@ const customCssFilename = 'custom.css';
 const bundledThemesByName = new Map(BUNDLED_THEMES.map(theme => [theme.name, theme] as const));
 const bundledCssCache = new Map<BundledThemeName, string>();
 
+// custom.css is read on every tray rebuild, through both hasCustomCss() and
+// resolveTheme(), so its contents are cached and the fs.watch callback below
+// clears the cache. Nothing else would clear it, so a watcher that never starts
+// or dies switches caching off rather than leaving a cache that goes stale for
+// the life of the process.
+let customCssCache: string | null = null;
+let customCssCached = false;
+let customCssCacheEnabled = true;
+
 // Track injected theme CSS for live toggle
 let themeCssKey: string | null = null;
 
@@ -54,19 +63,40 @@ export function resolveTheme(): ThemeName {
   return theme;
 }
 
+function readCustomCss(): string | null {
+  try {
+    const css = fs.readFileSync(customCssPath(), 'utf-8');
+    return css.trim().length > 0 ? css : null;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code !== 'ENOENT') {
+      themeLog.warn('Failed to read custom.css from userData directory', error);
+    }
+    return null;
+  }
+}
+
+// Exported for the watcher below and for tests; nothing else needs it.
+export function invalidateCustomCssCache(): void {
+  customCssCache = null;
+  customCssCached = false;
+}
+
+function disableCustomCssCache(): void {
+  customCssCacheEnabled = false;
+  invalidateCustomCssCache();
+}
+
 export function getThemeCss(name: ThemeName): string | null {
   if (name === 'apple-music') return null;
   if (name === 'custom') {
-    try {
-      const css = fs.readFileSync(customCssPath(), 'utf-8');
-      return css.trim().length > 0 ? css : null;
-    } catch (error) {
-      const err = error as NodeJS.ErrnoException;
-      if (err.code !== 'ENOENT') {
-        themeLog.warn('Failed to read custom.css from userData directory', error);
-      }
-      return null;
+    if (customCssCached) return customCssCache;
+    const css = readCustomCss();
+    if (customCssCacheEnabled) {
+      customCssCache = css;
+      customCssCached = true;
     }
+    return css;
   }
 
   const cached = bundledCssCache.get(name);
@@ -120,6 +150,9 @@ export function initThemeCSS(win: BrowserWindow): void {
       // macOS may emit a null filename for directory-level change events.
       if (filename !== null && filename.toString() !== customCssFilename) return;
       themeLog.debug(`custom.css watcher event: ${eventType}`);
+      // Before the debounce, not inside it: a tray rebuild during the debounce
+      // window must not read the previous contents back out of the cache.
+      invalidateCustomCssCache();
       if (customCssTimer) clearTimeout(customCssTimer);
       customCssTimer = setTimeout(() => {
         customCssTimer = null;
@@ -137,9 +170,12 @@ export function initThemeCSS(win: BrowserWindow): void {
     });
     watcher.on('error', (error) => {
       themeLog.warn('custom.css watcher error', error);
+      // Node closes the watcher on error, so nothing is left to clear the cache.
+      disableCustomCssCache();
     });
   } catch (error) {
     themeLog.warn('Failed to initialise custom.css watcher', error);
+    disableCustomCssCache();
   }
 
   app.on('will-quit', () => {

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -746,6 +746,36 @@ export function rebuildTrayMenu(tray: Tray): void {
   tray.setContextMenu(buildContextMenu(tray));
 }
 
+// Playback, volume and now-playing events arrive in bursts: the hook polls
+// mk.volume every 250ms while the slider moves, and the renderer can emit far
+// faster than that. Each rebuild walks every submenu, reads custom.css and
+// resizes the artwork five times, so a burst is collapsed into one rebuild.
+const TRAY_REBUILD_COALESCE_MS = 250;
+
+let rebuildTimer: NodeJS.Timeout | null = null;
+let pendingRebuildTray: Tray | null = null;
+
+// A fixed window rather than a debounce: a debounce that restarts on every
+// event never expires under a sustained flood, so the menu would never rebuild.
+function scheduleTrayRebuild(tray: Tray): void {
+  pendingRebuildTray = tray;
+  if (rebuildTimer) return;
+  rebuildTimer = setTimeout(() => {
+    rebuildTimer = null;
+    const target = pendingRebuildTray;
+    pendingRebuildTray = null;
+    if (target) rebuildTrayMenu(target);
+  }, TRAY_REBUILD_COALESCE_MS);
+}
+
+export function cancelTrayRebuild(): void {
+  if (rebuildTimer) {
+    clearTimeout(rebuildTimer);
+    rebuildTimer = null;
+  }
+  pendingRebuildTray = null;
+}
+
 export function updateTrayTooltip(tray: Tray, payload: NowPlayingPayload | null): void {
   const fallback = getProductInfo().productName;
   const text = payload?.name
@@ -813,7 +843,7 @@ export function initTrayStateManager(player: Player, tray: Tray): () => void {
     currentPayload = null;
     currentArtworkPath = null;
     updateNowPlayingState(null, null, false, currentVolume);
-    rebuildTrayMenu(tray);
+    scheduleTrayRebuild(tray);
   };
 
   const trayPauseTimer = createPauseTimer(TRAY_PAUSE_TIMEOUT_MS, clearNowPlaying);
@@ -827,7 +857,7 @@ export function initTrayStateManager(player: Player, tray: Tray): () => void {
       currentArtworkPath = null;
       updateTrayTooltip(tray, null);
       updateNowPlayingState(null, null, false, currentVolume);
-      rebuildTrayMenu(tray);
+      scheduleTrayRebuild(tray);
       return;
     }
     trayLog.debug('nowPlayingItemDidChange (tray handler):', `"${payload.name}"`);
@@ -842,7 +872,7 @@ export function initTrayStateManager(player: Player, tray: Tray): () => void {
     currentArtworkPath = artworkPath;
     const { isPlaying } = player.playbackSnapshot();
     updateNowPlayingState(payload, artworkPath, isPlaying, currentVolume);
-    rebuildTrayMenu(tray);
+    scheduleTrayRebuild(tray);
   };
 
   const onPlaybackStateDidChange = (payload: { status: boolean; state: number } | null): void => {
@@ -854,7 +884,7 @@ export function initTrayStateManager(player: Player, tray: Tray): () => void {
       currentPayload = null;
       currentArtworkPath = null;
       updateNowPlayingState(null, null, false, currentVolume);
-      rebuildTrayMenu(tray);
+      scheduleTrayRebuild(tray);
       return;
     }
     const { isPlaying } = player.playbackSnapshot();
@@ -869,7 +899,7 @@ export function initTrayStateManager(player: Player, tray: Tray): () => void {
     previousPlaying = isPlaying;
 
     updateNowPlayingState(currentPayload, currentArtworkPath, isPlaying, currentVolume);
-    rebuildTrayMenu(tray);
+    scheduleTrayRebuild(tray);
   };
 
   const onVolumeDidChange = (volume: number | null): void => {
@@ -877,7 +907,7 @@ export function initTrayStateManager(player: Player, tray: Tray): () => void {
     currentVolume = volume;
     const { isPlaying } = player.playbackSnapshot();
     updateNowPlayingState(currentPayload, currentArtworkPath, isPlaying, currentVolume);
-    rebuildTrayMenu(tray);
+    scheduleTrayRebuild(tray);
   };
 
   player.on('nowPlayingItemDidChange', onNowPlayingItemDidChange);
@@ -886,6 +916,7 @@ export function initTrayStateManager(player: Player, tray: Tray): () => void {
 
   return () => {
     trayPauseTimer.destroy();
+    cancelTrayRebuild();
     player.off('nowPlayingItemDidChange', onNowPlayingItemDidChange);
     player.off('playbackStateDidChange', onPlaybackStateDidChange);
     player.off('volumeDidChange', onVolumeDidChange);

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -14,7 +14,7 @@ import { enable as enableDiscord, disable as disableDiscord } from './integratio
 import { enable as enableLastfm, disable as disableLastfm, startAuth as startLastfmAuth, disconnect as disconnectLastfm, isConfigured as isLastfmConfigured } from './integrations/lastfm';
 import { downloadArtwork } from './artwork';
 import { createPauseTimer } from './pauseTimer';
-import { allServices } from './musicService';
+import { allServices, getService } from './musicService';
 
 const trayLog = log.scope('tray');
 
@@ -166,7 +166,7 @@ interface SubmenuContext {
 function buildPlayerSubmenu(ctx: SubmenuContext): Electron.MenuItemConstructorOptions {
   const { strings, refresh } = ctx;
   const activeServiceId = getMusicService();
-  const activeService = allServices().find(s => s.id === activeServiceId)!;
+  const activeService = getService(activeServiceId);
   const parentLabel = `${strings.player}: ${activeService.displayName}`;
   return {
     label: parentLabel,

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -4,12 +4,12 @@ import log from 'electron-log/main';
 import { getTrayStrings, getUpdateStrings, getAutoUpdateStrings, type TrayStrings } from './i18n';
 import { getAssetPath, getProductInfo } from './paths';
 import { Player, PlaybackState, getShareUrl, type NowPlayingPayload } from './player';
-import { getNotificationsEnabled, setNotificationsEnabled, getDiscordEnabled, setDiscordEnabled, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername, setTheme, getStartPage, setStartPage, getZoomFactor, setZoomFactor, getCloseToTrayEnabled, setCloseToTrayEnabled, getMusicService, setMusicService, getClassicalStartPage, setClassicalStartPage } from './config';
+import { getNotificationsEnabled, setNotificationsEnabled, getDiscordEnabled, setDiscordEnabled, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername, getTheme, setTheme, getStartPage, setStartPage, getZoomFactor, setZoomFactor, getCloseToTrayEnabled, setCloseToTrayEnabled, getMusicService, setMusicService, getClassicalStartPage, setClassicalStartPage } from './config';
 import { showAboutWindow } from './aboutWindow';
 import { getUpdateInfo } from './update';
 import { quitAndInstall } from './autoUpdate';
 import { BUNDLED_THEMES, themeLabel } from './palettes';
-import { applyTheme, hasCustomCss, resolveTheme } from './theme';
+import { applyTheme, hasCustomCss, resolveTheme, type ThemeName } from './theme';
 import { enable as enableDiscord, disable as disableDiscord } from './integrations/discord-presence';
 import { enable as enableLastfm, disable as disableLastfm, startAuth as startLastfmAuth, disconnect as disconnectLastfm, isConfigured as isLastfmConfigured } from './integrations/lastfm';
 import { downloadArtwork } from './artwork';
@@ -411,10 +411,19 @@ function buildLastfmSubmenu(ctx: SubmenuContext): Electron.MenuItemConstructorOp
   };
 }
 
+// Classical injects no theme CSS but the stored choice is preserved, so the menu
+// reports what is stored rather than what resolveTheme() reduces it to
+function styleMenuTheme(isClassical: boolean): ThemeName {
+  if (!isClassical) return resolveTheme();
+  const stored = getTheme();
+  if (stored === 'custom' && !hasCustomCss()) return 'apple-music';
+  return stored;
+}
+
 function buildStyleSubmenu(ctx: SubmenuContext): Electron.MenuItemConstructorOptions {
   const { strings, refresh } = ctx;
   const isClassical = getMusicService() === 'classical';
-  const currentTheme = resolveTheme();
+  const currentTheme = styleMenuTheme(isClassical);
   const parentLabel = `${strings.style}: ${currentTheme === 'apple-music' ? strings.styleAppleMusic : themeLabel(currentTheme)}`;
   const icon = getMenuIcon('style');
   const items: Electron.MenuItemConstructorOptions[] = [

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -190,16 +190,17 @@ function buildStartPageSubmenu(ctx: SubmenuContext): Electron.MenuItemConstructo
   const icon = getMenuIcon('start-page');
 
   if (activeServiceId === 'classical') {
-    const currentPage = getClassicalStartPage();
+    const storedPage = getClassicalStartPage();
     const classicalPageLabelMap: Record<string, string> = {
       'home': strings.startPageHome,
       'browse': strings.startPageBrowse,
-      'library': strings.startPageLibrary,
       'playlists': strings.startPagePlaylists,
       'search': strings.startPageSearch,
       'last': strings.startPageLast,
     };
-    const parentLabel = `${strings.startPage}: ${classicalPageLabelMap[currentPage] ?? strings.startPageHome}`;
+    // A page id no longer offered resolves to home, matching buildAppleMusicURL's defaultStartPage fallback.
+    const currentPage = classicalPageLabelMap[storedPage] !== undefined ? storedPage : 'home';
+    const parentLabel = `${strings.startPage}: ${classicalPageLabelMap[currentPage]}`;
     return {
       label: parentLabel,
       ...(icon ? { icon } : {}),
@@ -215,12 +216,6 @@ function buildStartPageSubmenu(ctx: SubmenuContext): Electron.MenuItemConstructo
           type: 'radio',
           checked: currentPage === 'browse',
           click: () => { setClassicalStartPage('browse'); refresh(); },
-        },
-        {
-          label: strings.startPageLibrary,
-          type: 'radio',
-          checked: currentPage === 'library',
-          click: () => { setClassicalStartPage('library'); refresh(); },
         },
         {
           label: strings.startPagePlaylists,

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -4,7 +4,7 @@ import log from 'electron-log/main';
 import { getTrayStrings, getUpdateStrings, getAutoUpdateStrings, type TrayStrings } from './i18n';
 import { getAssetPath, getProductInfo } from './paths';
 import { Player, PlaybackState, getShareUrl, type NowPlayingPayload } from './player';
-import { getNotificationsEnabled, setNotificationsEnabled, getDiscordEnabled, setDiscordEnabled, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername, getTheme, setTheme, getStartPage, setStartPage, getZoomFactor, setZoomFactor, getCloseToTrayEnabled, setCloseToTrayEnabled, getMusicService, setMusicService, getClassicalStartPage, setClassicalStartPage } from './config';
+import { getNotificationsEnabled, setNotificationsEnabled, getDiscordEnabled, setDiscordEnabled, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername, getTheme, setTheme, getStartPage, setStartPage, getZoomFactor, setZoomFactor, getCloseToTrayEnabled, setCloseToTrayEnabled, getMusicService, getClassicalStartPage, setClassicalStartPage } from './config';
 import { showAboutWindow } from './aboutWindow';
 import { getUpdateInfo } from './update';
 import { quitAndInstall } from './autoUpdate';
@@ -14,7 +14,7 @@ import { enable as enableDiscord, disable as disableDiscord } from './integratio
 import { enable as enableLastfm, disable as disableLastfm, startAuth as startLastfmAuth, disconnect as disconnectLastfm, isConfigured as isLastfmConfigured } from './integrations/lastfm';
 import { downloadArtwork } from './artwork';
 import { createPauseTimer } from './pauseTimer';
-import { allServices, getService } from './musicService';
+import { allServices, getService, MUSIC_SERVICES, type AnyStartPageId, type MusicService, type MusicServiceId } from './musicService';
 
 const trayLog = log.scope('tray');
 
@@ -155,7 +155,7 @@ let nowPlayingState: NowPlayingState | null = null;
 let sendCommandCallback: ((channel: string, ...args: unknown[]) => void) | null = null;
 let applyZoomCallback: ((factor: number) => void) | null = null;
 let getMainWindowCallback: (() => BrowserWindow | null) | null = null;
-let switchServiceCallback: ((serviceId: string) => void) | null = null;
+let switchServiceCallback: ((serviceId: MusicServiceId) => void) | null = null;
 
 interface SubmenuContext {
   strings: TrayStrings;
@@ -164,7 +164,7 @@ interface SubmenuContext {
 }
 
 function buildPlayerSubmenu(ctx: SubmenuContext): Electron.MenuItemConstructorOptions {
-  const { strings, refresh } = ctx;
+  const { strings } = ctx;
   const activeServiceId = getMusicService();
   const activeService = getService(activeServiceId);
   const parentLabel = `${strings.player}: ${activeService.displayName}`;
@@ -174,116 +174,63 @@ function buildPlayerSubmenu(ctx: SubmenuContext): Electron.MenuItemConstructorOp
       label: svc.displayName,
       type: 'radio' as const,
       checked: activeServiceId === svc.id,
+      // switchService in ./serviceSwitch persists the new id and rebuilds this
+      // menu, so the click does neither itself.
       click: () => {
         if (activeServiceId === svc.id) return;
-        setMusicService(svc.id);
         if (switchServiceCallback) switchServiceCallback(svc.id);
-        refresh();
       },
     })),
   };
 }
 
-function buildStartPageSubmenu(ctx: SubmenuContext): Electron.MenuItemConstructorOptions {
-  const { strings, refresh } = ctx;
-  const activeServiceId = getMusicService();
-  const icon = getMenuIcon('start-page');
-
-  if (activeServiceId === 'classical') {
-    const storedPage = getClassicalStartPage();
-    const classicalPageLabelMap: Record<string, string> = {
-      'home': strings.startPageHome,
-      'browse': strings.startPageBrowse,
-      'playlists': strings.startPagePlaylists,
-      'search': strings.startPageSearch,
-      'last': strings.startPageLast,
-    };
-    // A page id no longer offered resolves to home, matching buildAppleMusicURL's defaultStartPage fallback.
-    const currentPage = classicalPageLabelMap[storedPage] !== undefined ? storedPage : 'home';
-    const parentLabel = `${strings.startPage}: ${classicalPageLabelMap[currentPage]}`;
-    return {
-      label: parentLabel,
-      ...(icon ? { icon } : {}),
-      submenu: [
-        {
-          label: strings.startPageHome,
-          type: 'radio',
-          checked: currentPage === 'home',
-          click: () => { setClassicalStartPage('home'); refresh(); },
-        },
-        {
-          label: strings.startPageBrowse,
-          type: 'radio',
-          checked: currentPage === 'browse',
-          click: () => { setClassicalStartPage('browse'); refresh(); },
-        },
-        {
-          label: strings.startPagePlaylists,
-          type: 'radio',
-          checked: currentPage === 'playlists',
-          click: () => { setClassicalStartPage('playlists'); refresh(); },
-        },
-        {
-          label: strings.startPageSearch,
-          type: 'radio',
-          checked: currentPage === 'search',
-          click: () => { setClassicalStartPage('search'); refresh(); },
-        },
-        {
-          label: strings.startPageLast,
-          type: 'radio',
-          checked: currentPage === 'last',
-          click: () => { setClassicalStartPage('last'); refresh(); },
-        },
-      ],
-    };
-  }
-
-  const currentStartPage = getStartPage();
-  const startPageLabelMap: Record<string, string> = {
+// Typed over every registry id, so adding a start page without a translation
+// fails tsc rather than rendering a blank menu entry.
+function startPageLabels(strings: TrayStrings): Record<AnyStartPageId | 'last', string> {
+  return {
     'home': strings.startPageHome,
     'new': strings.startPageNew,
     'radio': strings.startPageRadio,
     'all-playlists': strings.startPageAllPlaylists,
+    'browse': strings.startPageBrowse,
+    'playlists': strings.startPagePlaylists,
+    'search': strings.startPageSearch,
     'last': strings.startPageLast,
   };
-  const parentLabel = `${strings.startPage}: ${startPageLabelMap[currentStartPage]}`;
+}
+
+function buildStartPageSubmenuFor<PageId extends AnyStartPageId>(
+  service: MusicService<PageId>,
+  storedPage: PageId | 'last',
+  setPage: (page: PageId | 'last') => void,
+  ctx: SubmenuContext,
+): Electron.MenuItemConstructorOptions {
+  const { strings, refresh } = ctx;
+  const labels = startPageLabels(strings);
+  // 'last' is not a registry page: it is a stored-URL mode both services offer.
+  const pageIds: (PageId | 'last')[] = [...service.startPages.map(page => page.id), 'last'];
+  // A page id no longer offered resolves to the service's defaultStartPage, matching buildAppleMusicURL.
+  const currentPage = pageIds.includes(storedPage) ? storedPage : service.defaultStartPage;
+  const icon = getMenuIcon('start-page');
   return {
-    label: parentLabel,
+    label: `${strings.startPage}: ${labels[currentPage]}`,
     ...(icon ? { icon } : {}),
-    submenu: [
-      {
-        label: strings.startPageHome,
-        type: 'radio',
-        checked: currentStartPage === 'home',
-        click: () => { setStartPage('home'); refresh(); },
-      },
-      {
-        label: strings.startPageNew,
-        type: 'radio',
-        checked: currentStartPage === 'new',
-        click: () => { setStartPage('new'); refresh(); },
-      },
-      {
-        label: strings.startPageRadio,
-        type: 'radio',
-        checked: currentStartPage === 'radio',
-        click: () => { setStartPage('radio'); refresh(); },
-      },
-      {
-        label: strings.startPageAllPlaylists,
-        type: 'radio',
-        checked: currentStartPage === 'all-playlists',
-        click: () => { setStartPage('all-playlists'); refresh(); },
-      },
-      {
-        label: strings.startPageLast,
-        type: 'radio',
-        checked: currentStartPage === 'last',
-        click: () => { setStartPage('last'); refresh(); },
-      },
-    ],
+    submenu: pageIds.map(id => ({
+      label: labels[id],
+      type: 'radio' as const,
+      checked: currentPage === id,
+      click: () => { setPage(id); refresh(); },
+    })),
   };
+}
+
+// The registry entries are passed directly rather than through getService(), which
+// returns the widened MusicService and would lose each service's page id union.
+function buildStartPageSubmenu(ctx: SubmenuContext): Electron.MenuItemConstructorOptions {
+  if (getMusicService() === 'classical') {
+    return buildStartPageSubmenuFor(MUSIC_SERVICES.classical, getClassicalStartPage(), setClassicalStartPage, ctx);
+  }
+  return buildStartPageSubmenuFor(MUSIC_SERVICES.music, getStartPage(), setStartPage, ctx);
 }
 
 function buildNotificationsSubmenu(ctx: SubmenuContext): Electron.MenuItemConstructorOptions {
@@ -734,7 +681,7 @@ export function setGetMainWindowCallback(callback: () => BrowserWindow | null): 
   getMainWindowCallback = callback;
 }
 
-export function setSwitchServiceCallback(callback: (serviceId: string) => void): void {
+export function setSwitchServiceCallback(callback: (serviceId: MusicServiceId) => void): void {
   switchServiceCallback = callback;
 }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, expectTypeOf, vi, beforeEach } from 'vitest';
+import { describe, it, expect, expectTypeOf, vi, beforeAll, beforeEach } from 'vitest';
 import type { ThemeName } from '../src/theme';
 
 // Mock electron-conf at the config module level. config.ts imports
@@ -71,11 +71,11 @@ vi.mock('../src/config', async () => {
     },
     setMusicService: (id: MusicServiceId): void => { data.set('musicService', id); },
 
-    getClassicalStartPage: (): string => {
+    getClassicalStartPage: (): ClassicalStartPageId | 'last' => {
       if (!data.has('classical.startPage')) return 'home';
-      return data.get('classical.startPage') as string;
+      return data.get('classical.startPage') as ClassicalStartPageId | 'last';
     },
-    setClassicalStartPage: (page: string): void => { data.set('classical.startPage', page); },
+    setClassicalStartPage: (page: ClassicalStartPageId | 'last'): void => { data.set('classical.startPage', page); },
 
     getClassicalLastPageUrl: (): string | undefined => {
       if (!data.has('classical.lastPageUrl')) return undefined;
@@ -99,7 +99,9 @@ import {
   getClassicalStartPage, setClassicalStartPage,
   getClassicalLastPageUrl, setClassicalLastPageUrl,
 } from '../src/config';
-import type { MusicServiceId } from '../src/musicService';
+import { Conf } from 'electron-conf/main';
+import { DEFAULT_SERVICE_ID } from '../src/musicService';
+import type { ClassicalStartPageId, MusicServiceId } from '../src/musicService';
 
 // Type assertions verify that each getter return type matches its StoreSchema key type.
 // These are compile-time checks via expectTypeOf.
@@ -185,12 +187,12 @@ describe('Config store type assertions', () => {
     expectTypeOf(setMusicService).parameter(0).toEqualTypeOf<MusicServiceId>();
   });
 
-  it('getClassicalStartPage returns string', () => {
-    expectTypeOf(getClassicalStartPage).returns.toEqualTypeOf<string>();
+  it('getClassicalStartPage returns the Classical start page union', () => {
+    expectTypeOf(getClassicalStartPage).returns.toEqualTypeOf<ClassicalStartPageId | 'last'>();
   });
 
-  it('setClassicalStartPage accepts string', () => {
-    expectTypeOf(setClassicalStartPage).parameter(0).toEqualTypeOf<string>();
+  it('setClassicalStartPage accepts the Classical start page union', () => {
+    expectTypeOf(setClassicalStartPage).parameter(0).toEqualTypeOf<ClassicalStartPageId | 'last'>();
   });
 
   it('getClassicalLastPageUrl returns string | undefined', () => {
@@ -265,5 +267,49 @@ describe('Config store runtime behaviour', () => {
   it('setClassicalLastPageUrl persists value', () => {
     setClassicalLastPageUrl('browse/albums');
     expect(getClassicalLastPageUrl()).toBe('browse/albums');
+  });
+});
+
+// The blocks above run against the hand-written stand-in declared at the top of
+// this file. These run against the real src/config.ts, reached past that mock
+// with vi.importActual and backed by the electron-conf mock in test/setup.ts.
+describe('Config store real module', () => {
+  // The electron-conf mock backs every Conf instance with one module-level map
+  // and exposes it as a static for seeding. Shared process-wide within this file.
+  const store = (Conf as unknown as { _data: Map<string, unknown> })._data;
+  let config: typeof import('../src/config');
+
+  beforeAll(async () => {
+    config = await vi.importActual<typeof import('../src/config')>('../src/config');
+  });
+
+  beforeEach(() => {
+    store.clear();
+  });
+
+  it('getMusicService falls back when the persisted id is unregistered', () => {
+    store.set('musicService', 'jazz');
+    expect(config.getMusicService()).toBe(DEFAULT_SERVICE_ID);
+  });
+
+  it('getMusicService returns music when persisted', () => {
+    store.set('musicService', 'music');
+    expect(config.getMusicService()).toBe('music');
+  });
+
+  it('getMusicService returns classical when persisted', () => {
+    store.set('musicService', 'classical');
+    expect(config.getMusicService()).toBe('classical');
+  });
+
+  it('getMusicService falls back when nothing is persisted', () => {
+    expect(config.getMusicService()).toBe(DEFAULT_SERVICE_ID);
+  });
+
+  it('setClassicalStartPage rejects a music start page at compile time', () => {
+    // @ts-expect-error 'radio' is a music start page, not a Classical one
+    config.setClassicalStartPage('radio');
+    // The union is the only guard; the write itself is unchecked at runtime.
+    expect(store.get('classical.startPage')).toBe('radio');
   });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,95 +1,19 @@
-import { describe, it, expect, expectTypeOf, vi, beforeAll, beforeEach } from 'vitest';
+import { describe, it, expect, expectTypeOf, beforeEach } from 'vitest';
 import type { ThemeName } from '../src/theme';
 
-// Mock electron-conf at the config module level. config.ts imports
-// electron-conf/main at module scope. Mock the config module and pass through
-// to a manual implementation that mirrors the real store wrapper.
-const data = new Map<string, unknown>();
-
-vi.mock('../src/config', async () => {
-  // Provide a standalone implementation matching config.ts getter/setter
-  // signatures. This avoids loading the real config.ts (which triggers
-  // the electron-conf/main import that Vitest cannot intercept).
-  return {
-    getStorefront: (): string | undefined => {
-      if (!data.has('storefront')) return undefined;
-      return data.get('storefront') as string;
-    },
-    setStorefront: (code: string): void => { data.set('storefront', code); },
-
-    getLanguage: (): string | null | undefined => {
-      if (!data.has('language')) return undefined;
-      return data.get('language') as string | null;
-    },
-    setLanguage: (lang: string | null): void => { data.set('language', lang); },
-
-    getNotificationsEnabled: (): boolean => {
-      if (!data.has('notifications.enabled')) return true;
-      return data.get('notifications.enabled') as boolean;
-    },
-    setNotificationsEnabled: (enabled: boolean): void => { data.set('notifications.enabled', enabled); },
-
-    getDiscordEnabled: (): boolean => {
-      if (!data.has('discord.enabled')) return true;
-      return data.get('discord.enabled') as boolean;
-    },
-    setDiscordEnabled: (enabled: boolean): void => { data.set('discord.enabled', enabled); },
-
-    getTheme: (): ThemeName => {
-      if (!data.has('theme')) return 'apple-music';
-      return data.get('theme') as ThemeName;
-    },
-    setTheme: (name: ThemeName): void => { data.set('theme', name); },
-
-    getAutoUpdateEnabled: (): boolean => {
-      if (!data.has('autoUpdate.enabled')) return true;
-      return data.get('autoUpdate.enabled') as boolean;
-    },
-    setAutoUpdateEnabled: (enabled: boolean): void => { data.set('autoUpdate.enabled', enabled); },
-
-    getLastPageUrl: (): string | undefined => {
-      if (!data.has('lastPageUrl')) return undefined;
-      return data.get('lastPageUrl') as string;
-    },
-    setLastPageUrl: (url: string): void => { data.set('lastPageUrl', url); },
-
-    getStartPage: (): 'home' | 'new' | 'radio' | 'all-playlists' | 'last' => {
-      if (!data.has('startPage')) return 'new';
-      return data.get('startPage') as 'home' | 'new' | 'radio' | 'all-playlists' | 'last';
-    },
-    setStartPage: (page: 'home' | 'new' | 'radio' | 'all-playlists' | 'last'): void => { data.set('startPage', page); },
-
-    getZoomFactor: (): number => {
-      if (!data.has('zoomFactor')) return 1.0;
-      return data.get('zoomFactor') as number;
-    },
-    setZoomFactor: (factor: number): void => { data.set('zoomFactor', factor); },
-
-    getMusicService: (): MusicServiceId => {
-      if (!data.has('musicService')) return 'music';
-      return data.get('musicService') as MusicServiceId;
-    },
-    setMusicService: (id: MusicServiceId): void => { data.set('musicService', id); },
-
-    getClassicalStartPage: (): ClassicalStartPageId | 'last' => {
-      if (!data.has('classical.startPage')) return 'home';
-      return data.get('classical.startPage') as ClassicalStartPageId | 'last';
-    },
-    setClassicalStartPage: (page: ClassicalStartPageId | 'last'): void => { data.set('classical.startPage', page); },
-
-    getClassicalLastPageUrl: (): string | undefined => {
-      if (!data.has('classical.lastPageUrl')) return undefined;
-      return data.get('classical.lastPageUrl') as string;
-    },
-    setClassicalLastPageUrl: (url: string): void => { data.set('classical.lastPageUrl', url); },
-  };
-});
-
+// No mock of ../src/config here, deliberately. A hand-written stand-in used to sit
+// at this point in the file and every runtime assertion below read that stand-in's
+// own defaults back out, so real defects in src/config.ts passed. electron-conf/main
+// is mocked globally in test/setup.ts, so the real module loads and runs unmodified.
 import {
   getStorefront, setStorefront,
   getLanguage, setLanguage,
   getNotificationsEnabled, setNotificationsEnabled,
   getDiscordEnabled, setDiscordEnabled,
+  getCloseToTrayEnabled, setCloseToTrayEnabled,
+  getLastfmEnabled,
+  getLastfmSessionKey, getLastfmUsername,
+  setLastfmSession, clearLastfmSession,
   getTheme, setTheme,
   getAutoUpdateEnabled, setAutoUpdateEnabled,
   getLastPageUrl, setLastPageUrl,
@@ -205,8 +129,12 @@ describe('Config store type assertions', () => {
 });
 
 describe('Config store runtime behaviour', () => {
+  // The electron-conf mock backs every Conf instance with one module-level map
+  // and exposes it as a static for seeding. Shared process-wide within this file.
+  const store = (Conf as unknown as { _data: Map<string, unknown> })._data;
+
   beforeEach(() => {
-    data.clear();
+    store.clear();
   });
 
   it('getStorefront returns undefined when not set', () => {
@@ -222,8 +150,8 @@ describe('Config store runtime behaviour', () => {
     expect(getNotificationsEnabled()).toBe(true);
   });
 
-  it('getDiscordEnabled defaults to true', () => {
-    expect(getDiscordEnabled()).toBe(true);
+  it('getDiscordEnabled defaults to false', () => {
+    expect(getDiscordEnabled()).toBe(false);
   });
 
   it('getTheme defaults to apple-music', () => {
@@ -242,22 +170,51 @@ describe('Config store runtime behaviour', () => {
     expect(getZoomFactor()).toBe(1.0);
   });
 
-  it('getMusicService defaults to music', () => {
+  it('getMusicService falls back to music when nothing is persisted', () => {
     expect(getMusicService()).toBe('music');
+    expect(getMusicService()).toBe(DEFAULT_SERVICE_ID);
   });
 
   it('setMusicService persists value', () => {
-    setMusicService('music');
+    // Writes the non-default id, so a setter that never reached the store would fail here.
+    setMusicService('classical');
+    expect(getMusicService()).toBe('classical');
+  });
+
+  it('getMusicService falls back when the persisted id is unregistered', () => {
+    store.set('musicService', 'jazz');
+    expect(getMusicService()).toBe(DEFAULT_SERVICE_ID);
+  });
+
+  it('getMusicService returns music when persisted', () => {
+    store.set('musicService', 'music');
     expect(getMusicService()).toBe('music');
+  });
+
+  it('getMusicService returns classical when persisted', () => {
+    store.set('musicService', 'classical');
+    expect(getMusicService()).toBe('classical');
   });
 
   it('getClassicalStartPage defaults to home', () => {
     expect(getClassicalStartPage()).toBe('home');
   });
 
+  it('getClassicalStartPage returns the persisted value', () => {
+    store.set('classical.startPage', 'search');
+    expect(getClassicalStartPage()).toBe('search');
+  });
+
   it('setClassicalStartPage persists value', () => {
     setClassicalStartPage('browse');
     expect(getClassicalStartPage()).toBe('browse');
+  });
+
+  it('setClassicalStartPage rejects a music start page at compile time', () => {
+    // @ts-expect-error 'radio' is a music start page, not a Classical one
+    setClassicalStartPage('radio');
+    // The union is the only guard; the write itself is unchecked at runtime.
+    expect(store.get('classical.startPage')).toBe('radio');
   });
 
   it('getClassicalLastPageUrl returns undefined when not set', () => {
@@ -268,48 +225,93 @@ describe('Config store runtime behaviour', () => {
     setClassicalLastPageUrl('browse/albums');
     expect(getClassicalLastPageUrl()).toBe('browse/albums');
   });
-});
 
-// The blocks above run against the hand-written stand-in declared at the top of
-// this file. These run against the real src/config.ts, reached past that mock
-// with vi.importActual and backed by the electron-conf mock in test/setup.ts.
-describe('Config store real module', () => {
-  // The electron-conf mock backs every Conf instance with one module-level map
-  // and exposes it as a static for seeding. Shared process-wide within this file.
-  const store = (Conf as unknown as { _data: Map<string, unknown> })._data;
-  let config: typeof import('../src/config');
-
-  beforeAll(async () => {
-    config = await vi.importActual<typeof import('../src/config')>('../src/config');
+  it('each last page reader reads its own service key', () => {
+    // Different values on purpose: with both keys equal, a reader pointed at the
+    // wrong key still returns the right answer and the test proves nothing.
+    setLastPageUrl('https://music.apple.com/gb/new');
+    setClassicalLastPageUrl('https://classical.music.apple.com/gb/browse/catalog');
+    expect(getLastPageUrl()).toBe('https://music.apple.com/gb/new');
+    expect(getClassicalLastPageUrl()).toBe('https://classical.music.apple.com/gb/browse/catalog');
   });
 
-  beforeEach(() => {
-    store.clear();
+  it('language and storefront readers each read their own key', () => {
+    // Two different values on purpose: with both keys equal, a reader pointed at
+    // the other key still returns the right answer and proves nothing.
+    store.set('storefront', 'gb');
+    store.set('language', 'cy');
+    expect(getStorefront()).toBe('gb');
+    expect(getLanguage()).toBe('cy');
   });
 
-  it('getMusicService falls back when the persisted id is unregistered', () => {
-    store.set('musicService', 'jazz');
-    expect(config.getMusicService()).toBe(DEFAULT_SERVICE_ID);
+  it('setLanguage persists to the language key and leaves storefront alone', () => {
+    setLanguage('fr-CA');
+    expect(getLanguage()).toBe('fr-CA');
+    expect(getStorefront()).toBeUndefined();
   });
 
-  it('getMusicService returns music when persisted', () => {
-    store.set('musicService', 'music');
-    expect(config.getMusicService()).toBe('music');
+  it('setLanguage persists null and reads back as null', () => {
+    // The signature allows null, meaning "no override"; a stored null must stay
+    // distinguishable from a key that was never written.
+    setLanguage(null);
+    expect(getLanguage()).toBeNull();
   });
 
-  it('getMusicService returns classical when persisted', () => {
-    store.set('musicService', 'classical');
-    expect(config.getMusicService()).toBe('classical');
+  it('getCloseToTrayEnabled defaults to false', () => {
+    expect(getCloseToTrayEnabled()).toBe(false);
   });
 
-  it('getMusicService falls back when nothing is persisted', () => {
-    expect(config.getMusicService()).toBe(DEFAULT_SERVICE_ID);
+  it('close-to-tray and Discord readers each read their own key', () => {
+    // Opposite values, so a reader crossed onto the other key inverts its answer.
+    store.set('closeToTray.enabled', true);
+    store.set('discord.enabled', false);
+    expect(getCloseToTrayEnabled()).toBe(true);
+    expect(getDiscordEnabled()).toBe(false);
   });
 
-  it('setClassicalStartPage rejects a music start page at compile time', () => {
-    // @ts-expect-error 'radio' is a music start page, not a Classical one
-    config.setClassicalStartPage('radio');
-    // The union is the only guard; the write itself is unchecked at runtime.
-    expect(store.get('classical.startPage')).toBe('radio');
+  it('setCloseToTrayEnabled persists to the close-to-tray key only', () => {
+    setCloseToTrayEnabled(true);
+    expect(getCloseToTrayEnabled()).toBe(true);
+    expect(getDiscordEnabled()).toBe(false);
+  });
+
+  it('getLastfmEnabled defaults to false', () => {
+    expect(getLastfmEnabled()).toBe(false);
+  });
+
+  it('Last.fm session key and username readers each read their own key', () => {
+    store.set('lastfm.sessionKey', 'sk-0123456789abcdef');
+    store.set('lastfm.username', 'wimpysworld');
+    expect(getLastfmSessionKey()).toBe('sk-0123456789abcdef');
+    expect(getLastfmUsername()).toBe('wimpysworld');
+  });
+
+  it('setLastfmSession writes each argument to its own key', () => {
+    // Clearly different values, so swapping the two arguments fails here.
+    setLastfmSession('sk-0123456789abcdef', 'wimpysworld');
+    expect(getLastfmSessionKey()).toBe('sk-0123456789abcdef');
+    expect(getLastfmUsername()).toBe('wimpysworld');
+  });
+
+  it('clearLastfmSession sets both keys to null rather than removing them', () => {
+    setLastfmSession('sk-0123456789abcdef', 'wimpysworld');
+    clearLastfmSession();
+    // Null, not undefined: the readers use the has-check variant, so a cleared
+    // key and an absent key are different states. Asserting falsiness alone
+    // would pass against a clear that did nothing at all.
+    expect(getLastfmSessionKey()).toBeNull();
+    expect(getLastfmUsername()).toBeNull();
+  });
+
+  it('setStartPage persists to the music start page key, not the Classical one', () => {
+    setStartPage('radio');
+    expect(getStartPage()).toBe('radio');
+    expect(getClassicalStartPage()).toBe('home');
+  });
+
+  it('setZoomFactor persists to the zoom key and leaves the start page alone', () => {
+    setZoomFactor(1.25);
+    expect(getZoomFactor()).toBe(1.25);
+    expect(getStartPage()).toBe('new');
   });
 });

--- a/test/contentReady.test.ts
+++ b/test/contentReady.test.ts
@@ -15,16 +15,22 @@ describe('content readiness marker', () => {
     expect(contentReadyProbeScript()).not.toContain('navigation__header');
   });
 
-  it('embeds a custom selector when one is passed', () => {
-    const customSelector = '.my-custom-element[ready]';
-    const script = contentReadyProbeScript(customSelector);
-    expect(script).toContain(customSelector);
-    expect(script).toBe(`!!document.querySelector(${JSON.stringify(customSelector)})`);
-  });
+  it('embeds a caller-supplied selector as valid JavaScript', () => {
+    // The selector carries double quotes, so raw interpolation would end the string literal
+    // early and the probe would fail to parse inside executeJavaScript.
+    const customSelector = '[data-testid="app-container"] .my-custom-element[ready]';
+    const queried: string[] = [];
+    const fakeDocument = {
+      querySelector: (selector: string): null => {
+        queried.push(selector);
+        return null;
+      }
+    };
 
-  it('default selector matches CONTENT_READY_SELECTOR', () => {
-    const defaultScript = contentReadyProbeScript();
-    const explicitScript = contentReadyProbeScript(CONTENT_READY_SELECTOR);
-    expect(defaultScript).toBe(explicitScript);
+    const probe = new Function('document', `return ${contentReadyProbeScript(customSelector)};`);
+    const result: unknown = probe(fakeDocument);
+
+    expect(queried).toEqual([customSelector]);
+    expect(result).toBe(false);
   });
 });

--- a/test/mpris.test.ts
+++ b/test/mpris.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BrowserWindow } from 'electron';
+
+import { setMusicService } from '../src/config';
+import type { IntegrationContext } from '../src/player';
+import * as mpris from '../src/integrations/mpris';
+import { FakePlayer } from './mocks/player';
+
+interface DbusBus {
+  on: (event: string, listener: (err: Error) => void) => void;
+  export: (path: string, iface: object) => void;
+  requestName: (name: string, flags: number) => Promise<unknown>;
+}
+
+interface DbusModule {
+  sessionBus: () => DbusBus;
+}
+
+// src/integrations/mpris/index.ts pulls @holusion/dbus-next in with a bare
+// require, which vi.mock does not intercept. The module loads fine off a bus -
+// only sessionBus() opens a socket - so the real one is loaded and that single
+// entry point is stubbed.
+const dbus = require('@holusion/dbus-next') as DbusModule;
+
+const busStub = {
+  on: vi.fn(),
+  export: vi.fn<(path: string, iface: object) => void>(),
+  requestName: vi.fn(() => Promise.resolve()),
+};
+
+interface PlayerInterface {
+  OpenUri(uri: string): void;
+}
+
+describe('MPRIS OpenUri', () => {
+  let win: { loadURL: ReturnType<typeof vi.fn> };
+
+  /**
+   * init() exports the root interface first and the player interface second, so
+   * the live MediaPlayer2Player instance is the second argument of the second
+   * export. Driving the real method this way needs no production change.
+   */
+  function initPlayerInterface(): PlayerInterface {
+    const ctx: IntegrationContext = {
+      player: new FakePlayer(),
+      getMainWindow: () => win as unknown as BrowserWindow,
+    };
+    mpris.init(ctx);
+    expect(busStub.export).toHaveBeenCalledTimes(2);
+    return busStub.export.mock.calls[1][1] as PlayerInterface;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(dbus, 'sessionBus').mockReturnValue(busStub);
+    setMusicService('music');
+    // loadURL must return a promise: production attaches a .catch() to it.
+    win = { loadURL: vi.fn(() => Promise.resolve()) };
+  });
+
+  it('loads a music.apple.com URI', () => {
+    initPlayerInterface().OpenUri('https://music.apple.com/gb/album/foo');
+    expect(win.loadURL).toHaveBeenCalledWith('https://music.apple.com/gb/album/foo');
+  });
+
+  it('loads a classical.music.apple.com URI', () => {
+    initPlayerInterface().OpenUri('https://classical.music.apple.com/gb/album/foo');
+    expect(win.loadURL).toHaveBeenCalledWith('https://classical.music.apple.com/gb/album/foo');
+  });
+
+  // Every registered host is accepted whatever the active service is. The check
+  // once compared against the active service's host, so with Classical selected
+  // every music.apple.com URI an MPRIS client sent was dropped.
+  it('loads a music.apple.com URI while Classical is the active service', () => {
+    setMusicService('classical');
+    initPlayerInterface().OpenUri('https://music.apple.com/gb/album/foo');
+    expect(win.loadURL).toHaveBeenCalledWith('https://music.apple.com/gb/album/foo');
+  });
+
+  it('rejects an unregistered host', () => {
+    initPlayerInterface().OpenUri('https://example.com/gb/album/foo');
+    expect(win.loadURL).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-https URI', () => {
+    initPlayerInterface().OpenUri('http://music.apple.com/gb/album/foo');
+    expect(win.loadURL).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed URI without throwing', () => {
+    const playerIface = initPlayerInterface();
+    expect(() => playerIface.OpenUri('not a url')).not.toThrow();
+    expect(win.loadURL).not.toHaveBeenCalled();
+  });
+});

--- a/test/musicKitHook.test.ts
+++ b/test/musicKitHook.test.ts
@@ -124,7 +124,7 @@ describe('musicKitHook', () => {
   });
 
   it.each([0, undefined])(
-    'does not report media session position state when duration is %s',
+    'clears media session position state when duration is %s',
     (currentPlaybackDuration) => {
       const { mediaSession, musicKitListeners } = createHarness({
         musicKitOverrides: {
@@ -135,7 +135,7 @@ describe('musicKitHook', () => {
 
       expect(() => musicKitListeners.get('playbackTimeDidChange')?.()).not.toThrow();
 
-      expect(mediaSession.setPositionState).not.toHaveBeenCalled();
+      expect(mediaSession.setPositionState).toHaveBeenCalledWith();
     },
   );
 
@@ -150,5 +150,88 @@ describe('musicKitHook', () => {
 
     expect(() => musicKitListeners.get('playbackTimeDidChange')?.()).not.toThrow();
     expect(() => musicKitListeners.get('nowPlayingItemDidChange')?.({ item: null })).not.toThrow();
+  });
+
+  it('reports the item duration in seconds when the playback duration is unavailable', () => {
+    const { mediaSession, musicKitListeners } = createHarness({
+      musicKitOverrides: {
+        currentPlaybackDuration: undefined,
+        currentPlaybackTime: 42,
+        nowPlayingItem: { attributes: { durationInMillis: 180_000 } },
+      },
+    });
+
+    expect(() => musicKitListeners.get('playbackTimeDidChange')?.()).not.toThrow();
+
+    expect(mediaSession.setPositionState).toHaveBeenCalledWith({
+      duration: 180,
+      playbackRate: 1,
+      position: 42,
+    });
+  });
+
+  it('prefers the playback duration over the item duration when both are usable', () => {
+    const { mediaSession, musicKitListeners } = createHarness({
+      musicKitOverrides: {
+        currentPlaybackDuration: 180,
+        currentPlaybackTime: 42,
+        nowPlayingItem: { attributes: { durationInMillis: 999_000 } },
+      },
+    });
+
+    expect(() => musicKitListeners.get('playbackTimeDidChange')?.()).not.toThrow();
+
+    expect(mediaSession.setPositionState).toHaveBeenCalledWith({
+      duration: 180,
+      playbackRate: 1,
+      position: 42,
+    });
+  });
+
+  it('clamps a position that runs past the duration', () => {
+    const { mediaSession, musicKitListeners } = createHarness({
+      musicKitOverrides: {
+        currentPlaybackDuration: 180,
+        currentPlaybackTime: 200,
+      },
+    });
+
+    expect(() => musicKitListeners.get('playbackTimeDidChange')?.()).not.toThrow();
+
+    expect(mediaSession.setPositionState).toHaveBeenCalledWith({
+      duration: 180,
+      playbackRate: 1,
+      position: 180,
+    });
+  });
+
+  it('clears media session position state rather than reporting a negative position', () => {
+    const { mediaSession, musicKitListeners } = createHarness({
+      musicKitOverrides: {
+        currentPlaybackDuration: 180,
+        currentPlaybackTime: -5,
+      },
+    });
+
+    expect(() => musicKitListeners.get('playbackTimeDidChange')?.()).not.toThrow();
+
+    expect(mediaSession.setPositionState).toHaveBeenCalledWith();
+    expect(mediaSession.setPositionState).not.toHaveBeenCalledWith(
+      expect.objectContaining({ position: -5 }),
+    );
+  });
+
+  it('clears media session position state for a radio stream with no duration', () => {
+    const { mediaSession, musicKitListeners } = createHarness({
+      musicKitOverrides: {
+        currentPlaybackDuration: Number.POSITIVE_INFINITY,
+        currentPlaybackTime: 42,
+        nowPlayingItem: { attributes: {} },
+      },
+    });
+
+    expect(() => musicKitListeners.get('playbackTimeDidChange')?.()).not.toThrow();
+
+    expect(mediaSession.setPositionState).toHaveBeenCalledWith();
   });
 });

--- a/test/musicKitHook.test.ts
+++ b/test/musicKitHook.test.ts
@@ -183,8 +183,12 @@ describe('musicKitHook', () => {
     },
   );
 
-  it('does nothing when navigator.mediaSession is unavailable', () => {
-    const { musicKitListeners } = createHarness({
+  it('still forwards playback events over IPC when navigator.mediaSession is unavailable', () => {
+    // Position state is a bonus for OS media controls; the IPC forwarding is
+    // the hook's actual job. A guard that swallowed the whole listener would
+    // leave MPRIS and every integration blind, so assert the sends, not that
+    // the listener merely survived.
+    const { musicKitListeners, window } = createHarness({
       navigatorOverrides: {},
       musicKitOverrides: {
         currentPlaybackDuration: 180,
@@ -192,8 +196,43 @@ describe('musicKitHook', () => {
       },
     });
 
-    expect(() => musicKitListeners.get('playbackTimeDidChange')?.()).not.toThrow();
-    expect(() => musicKitListeners.get('nowPlayingItemDidChange')?.({ item: null })).not.toThrow();
+    musicKitListeners.get('playbackTimeDidChange')?.();
+    musicKitListeners.get('nowPlayingItemDidChange')?.({ item: null });
+
+    expect(window.AMWrapper.ipcRenderer.send).toHaveBeenCalledWith(
+      'playbackTimeDidChange',
+      42 * 1_000_000,
+    );
+    expect(window.AMWrapper.ipcRenderer.send).toHaveBeenCalledWith(
+      'nowPlayingItemDidChange',
+      null,
+    );
+  });
+
+  it('still forwards playback events over IPC when setPositionState is missing', () => {
+    // Safari exposes navigator.mediaSession without setPositionState, which is
+    // the arm the object-presence check alone would let through. Both calls sit
+    // in a try/catch, so an unguarded call would not surface as a throw - the
+    // IPC sends are the only observable proof the listeners ran to completion.
+    const { musicKitListeners, window } = createHarness({
+      navigatorOverrides: { mediaSession: {} },
+      musicKitOverrides: {
+        currentPlaybackDuration: 180,
+        currentPlaybackTime: 42,
+      },
+    });
+
+    musicKitListeners.get('playbackTimeDidChange')?.();
+    musicKitListeners.get('nowPlayingItemDidChange')?.({ item: null });
+
+    expect(window.AMWrapper.ipcRenderer.send).toHaveBeenCalledWith(
+      'playbackTimeDidChange',
+      42 * 1_000_000,
+    );
+    expect(window.AMWrapper.ipcRenderer.send).toHaveBeenCalledWith(
+      'nowPlayingItemDidChange',
+      null,
+    );
   });
 
   it('reports the item duration in seconds when the playback duration is unavailable', () => {

--- a/test/musicKitHook.test.ts
+++ b/test/musicKitHook.test.ts
@@ -10,10 +10,12 @@ const hookScript = fs.readFileSync(
 
 function createHarness({
   musicKitOverrides = {},
+  musicKitThrowsAtInjection = false,
   navigatorOverrides,
   repeatInjection = false,
 }: {
   musicKitOverrides?: Record<string, unknown>;
+  musicKitThrowsAtInjection?: boolean;
   navigatorOverrides?: Record<string, unknown>;
   repeatInjection?: boolean;
 } = {}) {
@@ -60,13 +62,26 @@ function createHarness({
     window,
   });
 
+  // MusicKit can be present but mid-initialisation when the script is injected,
+  // so getInstance() throws until it settles. Clearing the flag after the
+  // injection run models it settling before the 500ms poll first fires.
+  let getInstanceThrows = musicKitThrowsAtInjection;
+  const musicKitApi = {
+    getInstance: () => {
+      if (getInstanceThrows) throw new Error('MusicKit is re-initialising');
+      return musicKit;
+    },
+    PlaybackStates: { playing: 2 },
+  };
+  if (musicKitThrowsAtInjection) {
+    Object.assign(context, { MusicKit: musicKitApi });
+    Object.assign(window, { MusicKit: musicKitApi });
+  }
+
   vm.runInContext(hookScript, context);
   if (repeatInjection) vm.runInContext(hookScript, context);
 
-  const musicKitApi = {
-    getInstance: () => musicKit,
-    PlaybackStates: { playing: 2 },
-  };
+  getInstanceThrows = false;
   Object.assign(context, { MusicKit: musicKitApi });
   Object.assign(window, { MusicKit: musicKitApi });
   for (const callback of intervalCallbacks.slice()) callback();
@@ -77,6 +92,15 @@ function createHarness({
     musicKit,
     musicKitListeners,
     navigator,
+    // Runs the script again against the same window, then drains only the
+    // timers that second run added. The message listener is installed inside
+    // the waitForMK callback rather than the script body, so a re-run that
+    // slipped past the injection guard would go unnoticed without the drain.
+    reinject: () => {
+      const alreadyRun = intervalCallbacks.length;
+      vm.runInContext(hookScript, context);
+      for (const callback of intervalCallbacks.slice(alreadyRun)) callback();
+    },
     window,
   };
 }
@@ -96,6 +120,26 @@ describe('musicKitHook', () => {
     for (const listener of messageListeners) listener(event);
 
     expect(skipToNextItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when MusicKit.getInstance() throws during injection', () => {
+    expect(() => createHarness({ musicKitThrowsAtInjection: true })).not.toThrow();
+  });
+
+  it('still hooks MusicKit after a getInstance() that threw during injection', () => {
+    const { musicKitListeners } = createHarness({ musicKitThrowsAtInjection: true });
+
+    expect(musicKitListeners.has('playbackStateDidChange')).toBe(true);
+  });
+
+  it('installs no second message listener when the script is injected again', () => {
+    const { messageListeners, reinject } = createHarness();
+
+    expect(messageListeners).toHaveLength(1);
+
+    reinject();
+
+    expect(messageListeners).toHaveLength(1);
   });
 
   it('reports explicit media session position state on playback time changes', () => {

--- a/test/musicService.test.ts
+++ b/test/musicService.test.ts
@@ -48,73 +48,43 @@ describe('MusicService types', () => {
 });
 
 describe('MUSIC_SERVICES registry', () => {
-  it('contains the music entry', () => {
-    expect(MUSIC_SERVICES['music']).toBeDefined();
-  });
-
-  it('music entry has correct id', () => {
-    expect(MUSIC_SERVICES['music'].id).toBe('music');
-  });
-
-  it('music entry has correct host', () => {
-    expect(MUSIC_SERVICES['music'].host).toBe('music.apple.com');
-  });
-
-  it('music entry has correct origin', () => {
-    expect(MUSIC_SERVICES['music'].origin).toBe('https://music.apple.com');
-  });
-
-  it('music entry has correct displayName', () => {
-    expect(MUSIC_SERVICES['music'].displayName).toBe('Apple Music');
-  });
-
-  it('music entry has correct authFrameHosts', () => {
-    expect(MUSIC_SERVICES['music'].authFrameHosts).toContain('auth.music.apple.com');
-    expect(MUSIC_SERVICES['music'].authFrameHosts).toContain('idmsa.apple.com');
-  });
-
-  it('contains the classical entry', () => {
-    expect(MUSIC_SERVICES['classical']).toBeDefined();
-  });
-
-  it('classical entry has correct id', () => {
-    expect(MUSIC_SERVICES['classical'].id).toBe('classical');
-  });
-
-  it('classical entry has correct host', () => {
-    expect(MUSIC_SERVICES['classical'].host).toBe('classical.music.apple.com');
-  });
-
-  it('classical entry has correct origin', () => {
-    expect(MUSIC_SERVICES['classical'].origin).toBe('https://classical.music.apple.com');
-  });
-
-  it('classical entry has correct displayName', () => {
-    expect(MUSIC_SERVICES['classical'].displayName).toBe('Apple Music Classical');
-  });
-
-  it('classical entry has start pages', () => {
-    expect(MUSIC_SERVICES['classical'].startPages.length).toBeGreaterThan(0);
-    expect(MUSIC_SERVICES['classical'].startPages.map(p => p.id)).toContain('home');
-  });
-
-  it('classical entry declares exactly the reachable start pages', () => {
-    expect(MUSIC_SERVICES['classical'].startPages.map(p => p.id)).toEqual([
-      'home',
-      'browse',
-      'playlists',
-      'search',
-    ]);
-  });
-
-  it('classical browse start page points at browse/catalog', () => {
-    const browse = MUSIC_SERVICES['classical'].startPages.find(p => p.id === 'browse');
-    expect(browse).toBeDefined();
-    expect(browse!.path).toBe('browse/catalog');
-  });
-
-  it('classical entry has a defaultStartPage', () => {
-    expect(MUSIC_SERVICES['classical'].defaultStartPage).toBe('home');
+  // One whole-registry comparison rather than a field at a time: an added, renamed or dropped
+  // entry is caught as well, and a failure prints the whole diff instead of one stray value.
+  // Start page order is the tray submenu order, so the arrays are compared in order.
+  it('matches the expected registry shape', () => {
+    expect(MUSIC_SERVICES).toEqual({
+      music: {
+        id: 'music',
+        host: 'music.apple.com',
+        origin: 'https://music.apple.com',
+        displayName: 'Apple Music',
+        authFrameHosts: ['auth.music.apple.com', 'idmsa.apple.com'],
+        contentReadySelector: CONTENT_READY_SELECTOR,
+        startPages: [
+          { id: 'home', path: 'home' },
+          { id: 'new', path: 'new' },
+          { id: 'radio', path: 'radio' },
+          { id: 'all-playlists', path: 'library/all-playlists/' },
+        ],
+        defaultStartPage: 'new',
+      },
+      classical: {
+        id: 'classical',
+        host: 'classical.music.apple.com',
+        origin: 'https://classical.music.apple.com',
+        displayName: 'Apple Music Classical',
+        authFrameHosts: ['auth.music.apple.com', 'idmsa.apple.com'],
+        contentReadySelector: CONTENT_READY_SELECTOR,
+        startPages: [
+          { id: 'home', path: '' },
+          // Classical serves its catalogue under browse/, so both of these paths carry the prefix.
+          { id: 'browse', path: 'browse/catalog' },
+          { id: 'playlists', path: 'browse/playlists' },
+          { id: 'search', path: 'search' },
+        ],
+        defaultStartPage: 'home',
+      },
+    });
   });
 });
 
@@ -271,11 +241,6 @@ describe('isAllowedNavigationUrl', () => {
 
   it('rejects an empty string', () => {
     expect(isAllowedNavigationUrl('')).toBe(false);
-  });
-
-  it('does not throw on malformed input', () => {
-    expect(() => isAllowedNavigationUrl('not a url')).not.toThrow();
-    expect(() => isAllowedNavigationUrl('')).not.toThrow();
   });
 
   it('rejects an allowed host carried in the userinfo of a foreign host', () => {

--- a/test/musicService.test.ts
+++ b/test/musicService.test.ts
@@ -7,6 +7,7 @@ import {
   getService,
   getServiceByHost,
   allServices,
+  isMusicServiceId,
 } from '../src/musicService';
 import type { MusicServiceId, MusicService } from '../src/musicService';
 
@@ -131,6 +132,47 @@ describe('getServiceByHost', () => {
   it('returns undefined for an empty string', () => {
     expect(getServiceByHost('')).toBeUndefined();
   });
+});
+
+describe('isMusicServiceId', () => {
+  it('accepts every registered id', () => {
+    expect(isMusicServiceId('music')).toBe(true);
+    expect(isMusicServiceId('classical')).toBe(true);
+  });
+
+  it('rejects an unregistered id', () => {
+    expect(isMusicServiceId('jazz')).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    expect(isMusicServiceId('')).toBe(false);
+  });
+
+  // A prototype-walking check would accept these and hand main.ts an undefined service.
+  it('rejects inherited Object.prototype keys', () => {
+    expect(isMusicServiceId('toString')).toBe(false);
+    expect(isMusicServiceId('constructor')).toBe(false);
+  });
+
+  it('narrows a string to MusicServiceId', () => {
+    const persisted: string = 'classical';
+    if (isMusicServiceId(persisted)) {
+      expectTypeOf(persisted).toEqualTypeOf<MusicServiceId>();
+      expect(getService(persisted).id).toBe('classical');
+    }
+  });
+});
+
+describe('start page registry integrity', () => {
+  for (const service of allServices()) {
+    it(`${service.id} declares at least one start page`, () => {
+      expect(service.startPages.length).toBeGreaterThan(0);
+    });
+
+    it(`${service.id} defaultStartPage names one of its own start pages`, () => {
+      expect(service.startPages.map(p => p.id)).toContain(service.defaultStartPage);
+    });
+  }
 });
 
 describe('allServices', () => {

--- a/test/musicService.test.ts
+++ b/test/musicService.test.ts
@@ -8,6 +8,8 @@ import {
   getServiceByHost,
   allServices,
   isMusicServiceId,
+  ALLOWED_NAVIGATION_HOSTS,
+  isAllowedNavigationUrl,
 } from '../src/musicService';
 import type { MusicServiceId, MusicService } from '../src/musicService';
 
@@ -181,6 +183,72 @@ describe('allServices', () => {
     expect(svcs.length).toBe(2);
     expect(svcs.map(s => s.id)).toContain('music');
     expect(svcs.map(s => s.id)).toContain('classical');
+  });
+});
+
+describe('ALLOWED_NAVIGATION_HOSTS', () => {
+  it('holds exactly the hosts derived from the registry', () => {
+    const derived = allServices().flatMap(svc => [svc.host, ...svc.authFrameHosts]);
+    expect([...ALLOWED_NAVIGATION_HOSTS].sort()).toEqual([...new Set(derived)].sort());
+  });
+});
+
+describe('isAllowedNavigationUrl', () => {
+  for (const service of allServices()) {
+    it(`accepts an https URL on the ${service.id} host`, () => {
+      expect(isAllowedNavigationUrl(`https://${service.host}/`)).toBe(true);
+    });
+
+    for (const host of service.authFrameHosts) {
+      it(`accepts an https URL on the ${service.id} auth frame host ${host}`, () => {
+        expect(isAllowedNavigationUrl(`https://${host}/`)).toBe(true);
+      });
+    }
+  }
+
+  it('rejects a foreign host', () => {
+    expect(isAllowedNavigationUrl('https://evil.test/')).toBe(false);
+  });
+
+  // An endsWith comparison would accept this subdomain.
+  it('rejects a subdomain of an allowed host', () => {
+    expect(isAllowedNavigationUrl('https://evil.music.apple.com/')).toBe(false);
+  });
+
+  it('rejects a host ending with an allowed host as a suffix', () => {
+    expect(isAllowedNavigationUrl('https://evil.music.apple.com.attacker.test/')).toBe(false);
+  });
+
+  // An includes comparison would accept this hostname.
+  it('rejects a host that merely contains an allowed host', () => {
+    expect(isAllowedNavigationUrl('https://music.apple.com.attacker.test/')).toBe(false);
+  });
+
+  // An includes comparison against the whole URL would accept this query string.
+  it('rejects a foreign host carrying an allowed host in the query string', () => {
+    expect(isAllowedNavigationUrl('https://attacker.test/?x=music.apple.com')).toBe(false);
+  });
+
+  it('rejects a malformed URL', () => {
+    expect(isAllowedNavigationUrl('not a url')).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    expect(isAllowedNavigationUrl('')).toBe(false);
+  });
+
+  it('does not throw on malformed input', () => {
+    expect(() => isAllowedNavigationUrl('not a url')).not.toThrow();
+    expect(() => isAllowedNavigationUrl('')).not.toThrow();
+  });
+
+  it('rejects an allowed host carried in the userinfo of a foreign host', () => {
+    expect(isAllowedNavigationUrl('https://music.apple.com@evil.test/')).toBe(false);
+  });
+
+  // Pins the URL parser behaviour the predicate depends on.
+  it('reads the hostname after the userinfo, not the userinfo itself', () => {
+    expect(new URL('https://music.apple.com@evil.test/').hostname).toBe('evil.test');
   });
 });
 

--- a/test/musicService.test.ts
+++ b/test/musicService.test.ts
@@ -11,7 +11,14 @@ import {
   ALLOWED_NAVIGATION_HOSTS,
   isAllowedNavigationUrl,
 } from '../src/musicService';
-import type { MusicServiceId, MusicService } from '../src/musicService';
+import type {
+  MusicServiceId,
+  MusicService,
+  MusicStartPageId,
+  ClassicalStartPageId,
+  AnyStartPageId,
+} from '../src/musicService';
+import { CONTENT_READY_SELECTOR } from '../src/contentReady';
 
 describe('MusicService types', () => {
   it('DEFAULT_SERVICE_ID is MusicServiceId', () => {
@@ -20,6 +27,23 @@ describe('MusicService types', () => {
 
   it('getService returns MusicService', () => {
     expectTypeOf(getService).returns.toEqualTypeOf<MusicService>();
+  });
+
+  // Pins the derived unions: adding or renaming a registry start page must be a deliberate edit
+  // here too, because config keys and the tray label record are typed from these.
+  it('MusicStartPageId covers exactly the music start pages', () => {
+    expectTypeOf<MusicStartPageId>().toEqualTypeOf<'home' | 'new' | 'radio' | 'all-playlists'>();
+  });
+
+  it('ClassicalStartPageId covers exactly the classical start pages', () => {
+    expectTypeOf<ClassicalStartPageId>().toEqualTypeOf<'home' | 'browse' | 'playlists' | 'search'>();
+  });
+
+  it('AnyStartPageId is the union of both services', () => {
+    expectTypeOf<AnyStartPageId>().toEqualTypeOf<MusicStartPageId | ClassicalStartPageId>();
+    expectTypeOf<AnyStartPageId>().toEqualTypeOf<
+      'home' | 'new' | 'radio' | 'all-playlists' | 'browse' | 'playlists' | 'search'
+    >();
   });
 });
 
@@ -91,6 +115,18 @@ describe('MUSIC_SERVICES registry', () => {
 
   it('classical entry has a defaultStartPage', () => {
     expect(MUSIC_SERVICES['classical'].defaultStartPage).toBe('home');
+  });
+});
+
+// Both services probe readiness with the same selector; a second copy of the literal would
+// drift silently, so the registry must reference the one in contentReady.ts.
+describe('content ready selector', () => {
+  it('music entry uses CONTENT_READY_SELECTOR', () => {
+    expect(MUSIC_SERVICES['music'].contentReadySelector).toBe(CONTENT_READY_SELECTOR);
+  });
+
+  it('classical entry uses CONTENT_READY_SELECTOR', () => {
+    expect(MUSIC_SERVICES['classical'].contentReadySelector).toBe(CONTENT_READY_SELECTOR);
   });
 });
 

--- a/test/musicService.test.ts
+++ b/test/musicService.test.ts
@@ -71,6 +71,21 @@ describe('MUSIC_SERVICES registry', () => {
     expect(MUSIC_SERVICES['classical'].startPages.map(p => p.id)).toContain('home');
   });
 
+  it('classical entry declares exactly the reachable start pages', () => {
+    expect(MUSIC_SERVICES['classical'].startPages.map(p => p.id)).toEqual([
+      'home',
+      'browse',
+      'playlists',
+      'search',
+    ]);
+  });
+
+  it('classical browse start page points at browse/catalog', () => {
+    const browse = MUSIC_SERVICES['classical'].startPages.find(p => p.id === 'browse');
+    expect(browse).toBeDefined();
+    expect(browse!.path).toBe('browse/catalog');
+  });
+
   it('classical entry has a defaultStartPage', () => {
     expect(MUSIC_SERVICES['classical'].defaultStartPage).toBe('home');
   });

--- a/test/musicService.test.ts
+++ b/test/musicService.test.ts
@@ -247,6 +247,20 @@ describe('isAllowedNavigationUrl', () => {
     expect(isAllowedNavigationUrl('https://music.apple.com@evil.test/')).toBe(false);
   });
 
+  it('rejects http on an allowed host', () => {
+    expect(isAllowedNavigationUrl('http://music.apple.com/gb')).toBe(false);
+  });
+
+  // The parser reads an authority from any URL carrying '//', so a hostname-only
+  // check accepts these two despite neither being a web origin.
+  it('rejects a javascript URL carrying an allowed host as its authority', () => {
+    expect(isAllowedNavigationUrl('javascript://music.apple.com/%0aalert(1)')).toBe(false);
+  });
+
+  it('rejects a file URL carrying an allowed host as its authority', () => {
+    expect(isAllowedNavigationUrl('file://music.apple.com/etc/passwd')).toBe(false);
+  });
+
   // Pins the URL parser behaviour the predicate depends on.
   it('reads the hostname after the userinfo, not the userinfo itself', () => {
     expect(new URL('https://music.apple.com@evil.test/').hostname).toBe('evil.test');

--- a/test/navigationBar.test.ts
+++ b/test/navigationBar.test.ts
@@ -1,0 +1,163 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+
+const navBarScript = fs.readFileSync(
+  path.join(__dirname, '..', 'assets', 'navigationBar.js'),
+  'utf-8',
+);
+
+const ANCHOR_SELECTOR = '.navigation__header .logo';
+
+type StubListener = (this: StubElement) => void;
+
+class StubElement {
+  readonly tagName: string;
+  readonly namespaceURI: string | null;
+  readonly children: StubElement[] = [];
+  readonly style = { setProperty: vi.fn() };
+  id = '';
+
+  private readonly attributes = new Map<string, string>();
+  private readonly listeners = new Map<string, StubListener[]>();
+
+  constructor(tagName: string, namespaceURI: string | null = null) {
+    this.tagName = tagName;
+    this.namespaceURI = namespaceURI;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  appendChild<T extends StubElement>(child: T): T {
+    this.children.push(child);
+    return child;
+  }
+
+  addEventListener(type: string, listener: StubListener): void {
+    const existing = this.listeners.get(type);
+    if (existing) existing.push(listener);
+    else this.listeners.set(type, [listener]);
+  }
+
+  dispatch(type: string): void {
+    for (const listener of this.listeners.get(type) ?? []) listener.call(this);
+  }
+
+  // Only tag-name selectors are needed; the script queries its own 'svg' child.
+  querySelector(selector: string): StubElement | null {
+    return this.descendants().find((element) => element.tagName === selector) ?? null;
+  }
+
+  descendants(): StubElement[] {
+    return this.children.flatMap((child) => [child, ...child.descendants()]);
+  }
+}
+
+function createHarness({ withAnchor = true }: { withAnchor?: boolean } = {}) {
+  const root = new StubElement('body');
+  const anchor = withAnchor ? root.appendChild(new StubElement('div')) : null;
+  const send = vi.fn();
+  const warn = vi.fn();
+  const log = vi.fn();
+
+  const document = {
+    // Resolves against the live tree so the script's double-injection guard
+    // sees the container a previous run appended.
+    getElementById: (id: string): StubElement | null =>
+      root.descendants().find((element) => element.id === id) ?? null,
+    querySelector: (selector: string): StubElement | null =>
+      selector === ANCHOR_SELECTOR ? anchor : null,
+    createElement: (tagName: string): StubElement => new StubElement(tagName),
+    createElementNS: (namespaceURI: string, tagName: string): StubElement =>
+      new StubElement(tagName, namespaceURI),
+  };
+  const window = { AMWrapper: { ipcRenderer: { send } } };
+  const context = vm.createContext({ console: { log, warn }, document, window });
+
+  return {
+    anchor,
+    bar: (): StubElement | null =>
+      root.descendants().find((element) => element.id === 'sidra-nav-buttons') ?? null,
+    buttons: (): StubElement[] =>
+      root.descendants().filter((element) => element.tagName === 'button'),
+    root,
+    run: () => vm.runInContext(navBarScript, context),
+    send,
+    warn,
+  };
+}
+
+function labelsOf(elements: StubElement[]): Array<string | null> {
+  return elements.map((element) => element.getAttribute('aria-label'));
+}
+
+describe('navigationBar', () => {
+  it('appends the button container to the matched anchor', () => {
+    const { anchor, bar, run } = createHarness();
+
+    run();
+
+    expect(bar()).not.toBeNull();
+    expect(anchor?.children).toContain(bar());
+  });
+
+  it('builds Back, Forward and Reload buttons inside the container', () => {
+    const { bar, run } = createHarness();
+
+    run();
+
+    expect(labelsOf(bar()?.children ?? [])).toEqual(['Back', 'Forward', 'Reload']);
+  });
+
+  it('appends nothing and throws nothing when the anchor is missing', () => {
+    const { bar, root, run } = createHarness({ withAnchor: false });
+
+    expect(() => run()).not.toThrow();
+
+    expect(root.descendants()).toHaveLength(0);
+    expect(bar()).toBeNull();
+  });
+
+  it('warns when the anchor is missing', () => {
+    const { run, warn } = createHarness({ withAnchor: false });
+
+    run();
+
+    expect(warn).toHaveBeenCalledWith(`Sidra: ${ANCHOR_SELECTOR} not found`);
+  });
+
+  it('appends no duplicate buttons when the script runs again', () => {
+    const { anchor, buttons, run } = createHarness();
+
+    run();
+
+    expect(buttons()).toHaveLength(3);
+
+    run();
+
+    expect(buttons()).toHaveLength(3);
+    expect(anchor?.children).toHaveLength(1);
+  });
+
+  it.each([
+    ['Back', 'nav:back'],
+    ['Forward', 'nav:forward'],
+    ['Reload', 'nav:reload'],
+  ])('sends %s clicks on the %s channel', (label, channel) => {
+    const { buttons, run, send } = createHarness();
+
+    run();
+    const button = buttons().find((element) => element.getAttribute('aria-label') === label);
+    button?.dispatch('click');
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(channel);
+  });
+});

--- a/test/serviceSwitch.test.ts
+++ b/test/serviceSwitch.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, expectTypeOf, vi, beforeEach } from 'vitest';
+import { Tray } from 'electron';
+import type { MusicServiceId } from '../src/musicService';
+
+// One shared recorder: every mocked step appends its own name, so a dropped or
+// reordered step in switchService() shows up as a different array.
+const { calls, state } = vi.hoisted(() => ({
+  calls: [] as string[],
+  state: { service: 'music' as MusicServiceId },
+}));
+
+vi.mock('../src/wedgeDetector', () => ({
+  reset: vi.fn(() => { calls.push('resetWedgeDetector'); }),
+}));
+
+vi.mock('../src/config', () => ({
+  getMusicService: vi.fn(() => state.service),
+  setMusicService: vi.fn((id: MusicServiceId) => {
+    calls.push('setMusicService');
+    state.service = id;
+  }),
+}));
+
+vi.mock('../src/tray', () => ({
+  rebuildTrayMenu: vi.fn(() => { calls.push('rebuildTrayMenu'); }),
+}));
+
+vi.mock('../src/theme', () => ({
+  setThemeCssKey: vi.fn(() => { calls.push('setThemeCssKey'); }),
+}));
+
+// Returns the persisted service, so a URL built before setMusicService names the old one.
+vi.mock('../src/storefront', () => ({
+  buildAppleMusicURL: vi.fn(() => `https://example.test/${state.service}`),
+}));
+
+import { initServiceSwitch, routeToMusicService, switchService } from '../src/serviceSwitch';
+import { setMusicService } from '../src/config';
+import { rebuildTrayMenu } from '../src/tray';
+import { setThemeCssKey } from '../src/theme';
+import { buildAppleMusicURL } from '../src/storefront';
+
+describe('serviceSwitch', () => {
+  const tray = new Tray('/tmp/sidra-test/icon.png');
+  const loadURL = vi.fn((_url: string) => { calls.push('loadURL'); });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    calls.length = 0;
+    state.service = 'music';
+    initServiceSwitch({ getTray: () => tray, loadURL });
+  });
+
+  it('runs the five steps in the fixed order', () => {
+    switchService('classical');
+    expect(calls).toEqual([
+      'resetWedgeDetector',
+      'setMusicService',
+      'rebuildTrayMenu',
+      'setThemeCssKey',
+      'loadURL',
+    ]);
+  });
+
+  it('persists the requested service and rebuilds the supplied tray', () => {
+    switchService('classical');
+    expect(setMusicService).toHaveBeenCalledWith('classical');
+    expect(rebuildTrayMenu).toHaveBeenCalledWith(tray);
+  });
+
+  it('clears the tracked inserted-CSS key', () => {
+    switchService('classical');
+    expect(setThemeCssKey).toHaveBeenCalledWith(null);
+  });
+
+  it('builds the default URL after persisting the service', () => {
+    switchService('classical');
+    expect(loadURL).toHaveBeenCalledWith('https://example.test/classical');
+    expect(vi.mocked(buildAppleMusicURL).mock.invocationCallOrder[0])
+      .toBeGreaterThan(vi.mocked(setMusicService).mock.invocationCallOrder[0]);
+  });
+
+  it('passes an explicit target URL through unchanged', () => {
+    switchService('music', 'https://music.apple.com/gb/album/1');
+    expect(loadURL).toHaveBeenCalledWith('https://music.apple.com/gb/album/1');
+    expect(buildAppleMusicURL).not.toHaveBeenCalled();
+  });
+
+  it('completes the sequence when no tray exists', () => {
+    initServiceSwitch({ getTray: () => null, loadURL });
+    switchService('classical');
+    expect(calls).toEqual(['resetWedgeDetector', 'setMusicService', 'setThemeCssKey', 'loadURL']);
+    expect(rebuildTrayMenu).not.toHaveBeenCalled();
+  });
+
+  it('takes a service id, not a bare string', () => {
+    expectTypeOf(switchService).parameter(0).toEqualTypeOf<MusicServiceId>();
+    expectTypeOf(switchService).parameter(1).toEqualTypeOf<string | undefined>();
+  });
+});
+
+// The itms:// path in main.ts is this function plus a URL. main.ts runs app.whenReady()
+// at import and cannot be loaded here, so the branch it used to hold lives in the module
+// under test and is driven directly.
+describe('routeToMusicService', () => {
+  const tray = new Tray('/tmp/sidra-test/icon.png');
+  const loadURL = vi.fn((_url: string) => { calls.push('loadURL'); });
+  const deepLink = 'https://music.apple.com/gb/album/1234';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    calls.length = 0;
+    initServiceSwitch({ getTray: () => tray, loadURL });
+  });
+
+  it('runs the same sequence as the tray path when classical is active', () => {
+    state.service = 'classical';
+    routeToMusicService(deepLink);
+    expect(calls).toEqual([
+      'resetWedgeDetector',
+      'setMusicService',
+      'rebuildTrayMenu',
+      'setThemeCssKey',
+      'loadURL',
+    ]);
+    expect(setMusicService).toHaveBeenCalledWith('music');
+    expect(setThemeCssKey).toHaveBeenCalledWith(null);
+  });
+
+  it('navigates once, to the link rather than the start page', () => {
+    state.service = 'classical';
+    routeToMusicService(deepLink);
+    expect(loadURL).toHaveBeenCalledTimes(1);
+    expect(loadURL).toHaveBeenCalledWith(deepLink);
+    expect(buildAppleMusicURL).not.toHaveBeenCalled();
+  });
+
+  it('loads the link without switching when music is already active', () => {
+    state.service = 'music';
+    routeToMusicService(deepLink);
+    expect(calls).toEqual(['loadURL']);
+    expect(loadURL).toHaveBeenCalledWith(deepLink);
+    expect(setMusicService).not.toHaveBeenCalled();
+  });
+});

--- a/test/storefront.test.ts
+++ b/test/storefront.test.ts
@@ -231,6 +231,36 @@ describe('buildAppleMusicURL - classical service', () => {
   });
 });
 
+describe('buildAppleMusicURL - registry-driven page paths', () => {
+  // Adding a start page to MUSIC_SERVICES must need no edit in storefront.ts.
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetStorefront.mockReturnValue('gb');
+    mockedGetLanguage.mockReturnValue(null);
+  });
+
+  it('resolves every music start page from the registry', () => {
+    mockedGetMusicService.mockReturnValue('music');
+    for (const page of MUSIC_SERVICES.music.startPages) {
+      mockedGetStartPage.mockReturnValue(page.id);
+      expect(buildAppleMusicURL()).toBe(`${MUSIC_SERVICES.music.origin}/gb/${page.path}`);
+    }
+    expect(mockedGetLastPageUrl).not.toHaveBeenCalled();
+  });
+
+  it('resolves every classical start page from the registry', () => {
+    mockedGetMusicService.mockReturnValue('classical');
+    for (const page of MUSIC_SERVICES.classical.startPages) {
+      mockedGetClassicalStartPage.mockReturnValue(page.id);
+      const expected = page.path === ''
+        ? `${MUSIC_SERVICES.classical.origin}/gb`
+        : `${MUSIC_SERVICES.classical.origin}/gb/${page.path}`;
+      expect(buildAppleMusicURL()).toBe(expected);
+    }
+    expect(mockedGetClassicalLastPageUrl).not.toHaveBeenCalled();
+  });
+});
+
 describe('buildItmsRouteURL', () => {
   // The Record type fails to compile if an ItmsRouteToken is missed.
   const routePaths: Record<ItmsRouteToken, string> = {

--- a/test/storefront.test.ts
+++ b/test/storefront.test.ts
@@ -2,9 +2,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import './mocks/storefront-deps';
 
-import { handleStorefrontNavigation, buildAppleMusicURL, extractStorefrontFromURL, handleLastPageNavigation } from '../src/storefront';
+import { handleStorefrontNavigation, buildAppleMusicURL, buildItmsRouteURL, extractStorefrontFromURL, handleLastPageNavigation, type ItmsRouteToken } from '../src/storefront';
 import { getStorefront, setStorefront, getLanguage, setLanguage, getMusicService, getStartPage, getLastPageUrl, getClassicalStartPage, getClassicalLastPageUrl, setLastPageUrl, setClassicalLastPageUrl } from '../src/config';
-import { MUSIC_SERVICES } from '../src/musicService';
+import { MUSIC_SERVICES, type ClassicalStartPageId } from '../src/musicService';
 
 const mockedGetStorefront = vi.mocked(getStorefront);
 const mockedSetStorefront = vi.mocked(setStorefront);
@@ -178,7 +178,9 @@ describe('buildAppleMusicURL - classical service', () => {
   });
 
   it('falls back to home when a removed library start page is still persisted', () => {
-    mockedGetClassicalStartPage.mockReturnValue('library');
+    // 'library' was persisted before WW-92 dropped the page: the type no longer admits it,
+    // the store still holds it.
+    mockedGetClassicalStartPage.mockReturnValue('library' as ClassicalStartPageId);
     const url = buildAppleMusicURL();
     expect(url).toBe('https://classical.music.apple.com/gb');
   });
@@ -227,6 +229,42 @@ describe('buildAppleMusicURL - classical service', () => {
     // falls through to default (home), which has empty path
     expect(url).toBe('https://classical.music.apple.com/gb');
   });
+});
+
+describe('buildItmsRouteURL', () => {
+  // The Record type fails to compile if an ItmsRouteToken is missed.
+  const routePaths: Record<ItmsRouteToken, string> = {
+    library: 'library',
+    browse: 'browse',
+    radio: 'radio',
+    listenNow: 'listen-now',
+    subscribe: 'subscribe',
+  };
+  const tokens = Object.keys(routePaths) as ItmsRouteToken[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetStorefront.mockReturnValue('gb');
+    mockedGetLanguage.mockReturnValue(null);
+  });
+
+  // itms:// is pinned to the music host and ITMS_ROUTE_PATHS holds music-only paths,
+  // so the active service must not reach the origin.
+  for (const service of ['classical', 'music'] as const) {
+    describe(`with the ${service} service active`, () => {
+      beforeEach(() => {
+        mockedGetMusicService.mockReturnValue(service);
+      });
+
+      for (const token of tokens) {
+        it(`builds ${token} against the music host`, () => {
+          const url = buildItmsRouteURL(token);
+          expect(url).toBe(`${MUSIC_SERVICES.music.origin}/gb/${routePaths[token]}`);
+          expect(new URL(url).origin).toBe(MUSIC_SERVICES.music.origin);
+        });
+      }
+    });
+  }
 });
 
 describe('handleLastPageNavigation', () => {

--- a/test/storefront.test.ts
+++ b/test/storefront.test.ts
@@ -4,6 +4,7 @@ import './mocks/storefront-deps';
 
 import { handleStorefrontNavigation, buildAppleMusicURL, extractStorefrontFromURL, handleLastPageNavigation } from '../src/storefront';
 import { getStorefront, setStorefront, getLanguage, setLanguage, getMusicService, getStartPage, getLastPageUrl, getClassicalStartPage, getClassicalLastPageUrl, setLastPageUrl, setClassicalLastPageUrl } from '../src/config';
+import { MUSIC_SERVICES } from '../src/musicService';
 
 const mockedGetStorefront = vi.mocked(getStorefront);
 const mockedSetStorefront = vi.mocked(setStorefront);
@@ -173,13 +174,31 @@ describe('buildAppleMusicURL - classical service', () => {
   it('builds classical browse URL', () => {
     mockedGetClassicalStartPage.mockReturnValue('browse');
     const url = buildAppleMusicURL();
-    expect(url).toBe('https://classical.music.apple.com/gb/browse');
+    expect(url).toBe('https://classical.music.apple.com/gb/browse/catalog');
   });
 
-  it('builds classical library URL', () => {
+  it('falls back to home when a removed library start page is still persisted', () => {
     mockedGetClassicalStartPage.mockReturnValue('library');
     const url = buildAppleMusicURL();
-    expect(url).toBe('https://classical.music.apple.com/gb/library');
+    expect(url).toBe('https://classical.music.apple.com/gb');
+  });
+
+  it('builds a probed URL for every declared classical start page id', () => {
+    // Every URL here returned 200 unauthenticated; a new id must be probed before it is added.
+    const expected: Record<string, string> = {
+      'home': 'https://classical.music.apple.com/gb',
+      'browse': 'https://classical.music.apple.com/gb/browse/catalog',
+      'playlists': 'https://classical.music.apple.com/gb/browse/playlists',
+      'search': 'https://classical.music.apple.com/gb/search',
+    };
+    const ids = MUSIC_SERVICES.classical.startPages.map(p => p.id);
+    expect(ids).toEqual(Object.keys(expected));
+    for (const id of ids) {
+      mockedGetClassicalStartPage.mockReturnValue(id);
+      const url = buildAppleMusicURL();
+      expect(url).toBe(expected[id]);
+      expect(new URL(url).pathname.split('/').filter(Boolean)).not.toContain('library');
+    }
   });
 
   it('builds classical playlists URL', () => {

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -60,15 +60,20 @@ describe('theme helpers', () => {
 
   // Fake timers plus a captured fs.watch listener, so a test can drive the
   // watcher and step past the 150ms debounce.
-  function watcherHarness(options: { isDestroyed?: boolean } = {}) {
+  // init defaults to the statically imported module; the cache-disable tests
+  // pass a freshly loaded copy so the flag they flip stays out of other tests.
+  function watcherHarness(options: { isDestroyed?: boolean; init?: typeof initThemeCSS } = {}) {
     vi.useFakeTimers();
     const removeInsertedCSS = vi.fn().mockResolvedValue(undefined);
     const insertCSS = vi.fn().mockResolvedValue('unused');
     let watchHandler: fs.WatchListener<string | Buffer> | undefined;
+    const watcherListeners = new Map<string, (error: Error) => void>();
     vi.mocked(fs.watch as unknown as WatchWithOptions).mockImplementation((_filename, _options, listener) => {
       watchHandler = listener;
       return {
-        on: vi.fn(),
+        on: vi.fn((event: string, handler: (error: Error) => void) => {
+          watcherListeners.set(event, handler);
+        }),
         close: vi.fn(),
       } as unknown as fs.FSWatcher;
     });
@@ -81,7 +86,11 @@ describe('theme helpers', () => {
       insertCSS,
       removeInsertedCSS,
       win,
-      start: () => { initThemeCSS(win); },
+      start: () => { (options.init ?? initThemeCSS)(win); },
+      // Fire the watcher's own error event, which Node follows by closing it.
+      fireError(error: Error = new Error('EBADF: bad file descriptor')) {
+        watcherListeners.get('error')?.(error);
+      },
       // Fire a watcher event without running the debounce.
       fire(eventType: 'rename' | 'change', filename = 'custom.css') {
         watchHandler?.(eventType, filename);
@@ -272,6 +281,60 @@ describe('theme helpers', () => {
     expect(theme.getThemeCss('custom')).toBe('body { color: red; }');
     vi.mocked(fs.readFileSync).mockReturnValue('body { color: blue; }');
     expect(theme.getThemeCss('custom')).toBe('body { color: blue; }');
+  });
+
+  it('reads custom.css on every call once the watcher has failed to start', async () => {
+    // Two reads, two filesystem calls: the cache is off, not merely cleared.
+    vi.resetModules();
+    vi.mocked(fs.watch).mockImplementation(() => { throw new Error('EMFILE: too many open files'); });
+    const theme = await import('../src/theme');
+    const win = {
+      isDestroyed: vi.fn().mockReturnValue(false),
+      webContents: { removeInsertedCSS: vi.fn(), insertCSS: vi.fn() },
+    } as unknown as Parameters<typeof initThemeCSS>[0];
+    theme.initThemeCSS(win);
+
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    expect(theme.getThemeCss('custom')).toBe('body { color: red; }');
+    expect(theme.getThemeCss('custom')).toBe('body { color: red; }');
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops the warm custom.css cache when the watcher reports an error', async () => {
+    // Node closes the watcher on error, so the cache it warmed is now stale
+    // with nothing left to clear it.
+    vi.resetModules();
+    const theme = await import('../src/theme');
+    const harness = watcherHarness({ init: theme.initThemeCSS });
+    harness.start();
+
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    expect(theme.getThemeCss('custom')).toBe('body { color: red; }');
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+
+    harness.fireError();
+
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: blue; }');
+    expect(theme.getThemeCss('custom')).toBe('body { color: blue; }');
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('reads custom.css on every call after a watcher error', async () => {
+    vi.resetModules();
+    const theme = await import('../src/theme');
+    const harness = watcherHarness({ init: theme.initThemeCSS });
+    harness.start();
+
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    expect(theme.getThemeCss('custom')).toBe('body { color: red; }');
+    harness.fireError();
+
+    // Two reads after the error, two filesystem calls: caching stays off rather
+    // than warming again on the next read.
+    vi.mocked(fs.readFileSync).mockClear();
+    expect(theme.getThemeCss('custom')).toBe('body { color: red; }');
+    expect(theme.getThemeCss('custom')).toBe('body { color: red; }');
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
   });
 
   it('renders bundled theme CSS', () => {

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -20,7 +20,7 @@ const fsMock = vi.hoisted(() => ({
 
 vi.mock('fs', () => ({ default: fsMock, ...fsMock }));
 
-import { getTheme } from '../src/config';
+import { getMusicService, getTheme } from '../src/config';
 import {
   customCssPath,
   getThemeCss,
@@ -35,6 +35,8 @@ import {
 describe('theme helpers', () => {
   beforeEach(() => {
     vi.mocked(getTheme).mockReturnValue('apple-music');
+    // Reset per test, so a switch to classical cannot leak into the next one.
+    vi.mocked(getMusicService).mockReturnValue('music');
     vi.mocked(fs.existsSync).mockReturnValue(false);
     vi.mocked(fs.readFileSync).mockReturnValue('');
     vi.mocked(fs.readFileSync).mockClear();
@@ -151,6 +153,43 @@ describe('theme helpers', () => {
     vi.mocked(getTheme).mockReturnValue('custom');
     vi.mocked(fs.readFileSync).mockReturnValue('\n  \n');
     expect(resolveTheme()).toBe('apple-music');
+  });
+
+  it('forces apple-music on classical for a bundled theme', () => {
+    // Bundled theme CSS targets the music.apple.com DOM, so classical gets none.
+    vi.mocked(getTheme).mockReturnValue('catppuccin');
+    vi.mocked(getMusicService).mockReturnValue('classical');
+    expect(resolveTheme()).toBe('apple-music');
+  });
+
+  it('forces apple-music on classical even with populated custom.css', () => {
+    vi.mocked(getTheme).mockReturnValue('custom');
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    vi.mocked(getMusicService).mockReturnValue('classical');
+    expect(resolveTheme()).toBe('apple-music');
+  });
+
+  it('restores the stored theme when the service switches back from classical', () => {
+    // The gate suppresses the theme; it never rewrites the stored value.
+    vi.mocked(getTheme).mockReturnValue('catppuccin');
+    expect(resolveTheme()).toBe('catppuccin');
+
+    vi.mocked(getMusicService).mockReturnValue('classical');
+    expect(resolveTheme()).toBe('apple-music');
+    expect(getTheme()).toBe('catppuccin');
+
+    vi.mocked(getMusicService).mockReturnValue('music');
+    expect(resolveTheme()).toBe('catppuccin');
+  });
+
+  it('returns null for apple-music even with populated custom.css', () => {
+    // apple-music means "inject no override CSS", so it must never pick up the
+    // custom.css a fall-through past the guard would reach.
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    expect(getThemeCss('apple-music')).toBeNull();
+    expect(fs.readFileSync).not.toHaveBeenCalled();
   });
 
   it('returns null for missing custom.css', () => {

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { app } from 'electron';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../src/config', () => ({
   getTheme: vi.fn(),
@@ -22,7 +22,15 @@ vi.mock('fs', () => ({
 }));
 
 import { getTheme } from '../src/config';
-import { customCssPath, getThemeCss, hasCustomCss, initThemeCSS, resolveTheme, setThemeCssKey } from '../src/theme';
+import {
+  customCssPath,
+  getThemeCss,
+  hasCustomCss,
+  initThemeCSS,
+  resolveTheme,
+  setRebuildTrayCallback,
+  setThemeCssKey,
+} from '../src/theme';
 
 describe('theme helpers', () => {
   beforeEach(() => {
@@ -31,13 +39,86 @@ describe('theme helpers', () => {
     vi.mocked(fs.readFileSync).mockReturnValue('');
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // vi.mocked() resolves fs.watch to its two-argument overload, so the mock is
+  // typed against the three-argument form initThemeCSS() actually calls.
+  type WatchWithOptions = (
+    filename: fs.PathLike,
+    options: fs.WatchOptions,
+    listener: fs.WatchListener<string | Buffer>,
+  ) => fs.FSWatcher;
+
+  // Fake timers plus a captured fs.watch listener, so a test can drive the
+  // watcher and step past the 150ms debounce.
+  function watcherHarness(options: { isDestroyed?: boolean } = {}) {
+    vi.useFakeTimers();
+    const removeInsertedCSS = vi.fn().mockResolvedValue(undefined);
+    const insertCSS = vi.fn().mockResolvedValue('unused');
+    let watchHandler: fs.WatchListener<string | Buffer> | undefined;
+    vi.mocked(fs.watch as unknown as WatchWithOptions).mockImplementation((_filename, _options, listener) => {
+      watchHandler = listener;
+      return {
+        on: vi.fn(),
+        close: vi.fn(),
+      } as unknown as fs.FSWatcher;
+    });
+    const win = {
+      isDestroyed: vi.fn().mockReturnValue(options.isDestroyed ?? false),
+      webContents: { removeInsertedCSS, insertCSS },
+    } as unknown as Parameters<typeof initThemeCSS>[0];
+
+    return {
+      insertCSS,
+      removeInsertedCSS,
+      win,
+      start: () => { initThemeCSS(win); },
+      // Fire a watcher event, then run the debounce and the CSS promise chain.
+      async emit(eventType: 'rename' | 'change') {
+        watchHandler?.(eventType, 'custom.css');
+        vi.advanceTimersByTime(151);
+        await Promise.resolve();
+        await Promise.resolve();
+      },
+    };
+  }
+
+  function throwEnoent(): void {
+    const enoent: NodeJS.ErrnoException = new Error('ENOENT: no such file or directory');
+    enoent.code = 'ENOENT';
+    vi.mocked(fs.readFileSync).mockImplementation(() => { throw enoent; });
+  }
+
   it('builds the custom.css path from userData', () => {
     expect(customCssPath()).toBe(path.join(app.getPath('userData'), 'custom.css'));
   });
 
-  it('reports custom.css presence from disk', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
+  it('reports custom.css presence from file content', () => {
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
     expect(hasCustomCss()).toBe(true);
+  });
+
+  it('reports no custom.css when the file is missing', () => {
+    throwEnoent();
+    expect(hasCustomCss()).toBe(false);
+  });
+
+  it('agrees with resolveTheme for whitespace-only custom.css', () => {
+    vi.mocked(getTheme).mockReturnValue('custom');
+    // The file is on disk, so an existence check would call it present.
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('   \n');
+    expect(hasCustomCss()).toBe(false);
+    expect(resolveTheme()).toBe('apple-music');
+  });
+
+  it('agrees with resolveTheme for populated custom.css', () => {
+    vi.mocked(getTheme).mockReturnValue('custom');
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    expect(hasCustomCss()).toBe(true);
+    expect(resolveTheme()).toBe('custom');
   });
 
   it('falls back to apple-music for unknown stored themes', () => {
@@ -64,9 +145,7 @@ describe('theme helpers', () => {
   });
 
   it('returns null for missing custom.css', () => {
-    const enoent: NodeJS.ErrnoException = new Error('ENOENT: no such file or directory');
-    enoent.code = 'ENOENT';
-    vi.mocked(fs.readFileSync).mockImplementation(() => { throw enoent; });
+    throwEnoent();
     expect(getThemeCss('custom')).toBeNull();
   });
 
@@ -88,31 +167,67 @@ describe('theme helpers', () => {
   });
 
   it('removes injected css when custom.css disappears for stored custom theme', async () => {
-    vi.useFakeTimers();
-    const removeInsertedCSS = vi.fn().mockResolvedValue(undefined);
-    const insertCSS = vi.fn().mockResolvedValue('unused');
-    let watchHandler: ((eventType: string, filename: string | Buffer | null) => void) | undefined;
-    vi.mocked(fs.watch).mockImplementation((_, __, listener) => {
-      watchHandler = listener;
-      return {
-        on: vi.fn(),
-        close: vi.fn(),
-      } as unknown as fs.FSWatcher;
-    });
-    const win = {
-      isDestroyed: vi.fn().mockReturnValue(false),
-      webContents: { removeInsertedCSS, insertCSS },
-    } as unknown as Parameters<typeof initThemeCSS>[0];
+    const harness = watcherHarness();
     vi.mocked(getTheme).mockReturnValue('custom');
     vi.mocked(fs.existsSync).mockReturnValue(false);
     setThemeCssKey('stale-theme-css-key');
-    initThemeCSS(win);
-    watchHandler?.('change', 'custom.css');
-    vi.advanceTimersByTime(151);
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(removeInsertedCSS).toHaveBeenCalledWith('stale-theme-css-key');
-    expect(insertCSS).not.toHaveBeenCalled();
-    vi.useRealTimers();
+    harness.start();
+    await harness.emit('change');
+    expect(harness.removeInsertedCSS).toHaveBeenCalledWith('stale-theme-css-key');
+    expect(harness.insertCSS).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds the tray menu after create, write and delete events', async () => {
+    const rebuildTray = vi.fn();
+    setRebuildTrayCallback(rebuildTray);
+    const harness = watcherHarness();
+    vi.mocked(getTheme).mockReturnValue('custom');
+    setThemeCssKey(null);
+    harness.start();
+
+    // Create: the file appears with content.
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    await harness.emit('rename');
+    expect(rebuildTray).toHaveBeenCalledTimes(1);
+
+    // Write: the content changes.
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: blue; }');
+    await harness.emit('change');
+    expect(rebuildTray).toHaveBeenCalledTimes(2);
+
+    // Delete: the file is gone.
+    throwEnoent();
+    await harness.emit('rename');
+    expect(rebuildTray).toHaveBeenCalledTimes(3);
+  });
+
+  it('rebuilds the tray menu when the stored theme is not custom', async () => {
+    const rebuildTray = vi.fn();
+    setRebuildTrayCallback(rebuildTray);
+    const harness = watcherHarness();
+    vi.mocked(getTheme).mockReturnValue('catppuccin');
+    setThemeCssKey(null);
+    harness.start();
+
+    // custom.css appears while a bundled theme is active: no CSS work, but the
+    // tray still needs the new Style entry.
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    await harness.emit('rename');
+    expect(rebuildTray).toHaveBeenCalledTimes(1);
+    expect(harness.insertCSS).not.toHaveBeenCalled();
+    expect(harness.removeInsertedCSS).not.toHaveBeenCalled();
+  });
+
+  it('does not rebuild the tray menu when the window is destroyed', async () => {
+    const rebuildTray = vi.fn();
+    setRebuildTrayCallback(rebuildTray);
+    const harness = watcherHarness({ isDestroyed: true });
+    vi.mocked(getTheme).mockReturnValue('custom');
+    setThemeCssKey(null);
+    harness.start();
+
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    await harness.emit('change');
+    expect(rebuildTray).not.toHaveBeenCalled();
   });
 });

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -8,18 +8,17 @@ vi.mock('../src/config', () => ({
   getMusicService: vi.fn(() => 'music'),
 }));
 
-vi.mock('fs', () => ({
-  default: {
-    readFileSync: vi.fn(),
-    existsSync: vi.fn(),
-    watch: vi.fn(),
-    mkdirSync: vi.fn(),
-  },
+// Hoisted so the same mock functions survive vi.resetModules(): the
+// watcher-failure test loads a second copy of src/theme.ts and has to drive the
+// same fs.
+const fsMock = vi.hoisted(() => ({
   readFileSync: vi.fn(),
   existsSync: vi.fn(),
   watch: vi.fn(),
   mkdirSync: vi.fn(),
 }));
+
+vi.mock('fs', () => ({ default: fsMock, ...fsMock }));
 
 import { getTheme } from '../src/config';
 import {
@@ -27,6 +26,7 @@ import {
   getThemeCss,
   hasCustomCss,
   initThemeCSS,
+  invalidateCustomCssCache,
   resolveTheme,
   setRebuildTrayCallback,
   setThemeCssKey,
@@ -37,6 +37,11 @@ describe('theme helpers', () => {
     vi.mocked(getTheme).mockReturnValue('apple-music');
     vi.mocked(fs.existsSync).mockReturnValue(false);
     vi.mocked(fs.readFileSync).mockReturnValue('');
+    vi.mocked(fs.readFileSync).mockClear();
+    vi.mocked(fs.watch).mockReset();
+    // custom.css contents are cached for the life of the process, so each test
+    // starts from a cold cache.
+    invalidateCustomCssCache();
   });
 
   afterEach(() => {
@@ -75,6 +80,10 @@ describe('theme helpers', () => {
       removeInsertedCSS,
       win,
       start: () => { initThemeCSS(win); },
+      // Fire a watcher event without running the debounce.
+      fire(eventType: 'rename' | 'change', filename = 'custom.css') {
+        watchHandler?.(eventType, filename);
+      },
       // Fire a watcher event, then run the debounce and the CSS promise chain.
       async emit(eventType: 'rename' | 'change') {
         watchHandler?.(eventType, 'custom.css');
@@ -157,6 +166,73 @@ describe('theme helpers', () => {
   it('returns custom.css content when present', () => {
     vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
     expect(getThemeCss('custom')).toBe('body { color: red; }');
+  });
+
+  it('reads custom.css once across repeated resolveTheme calls', () => {
+    vi.mocked(getTheme).mockReturnValue('custom');
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    expect(resolveTheme()).toBe('custom');
+    expect(resolveTheme()).toBe('custom');
+    expect(resolveTheme()).toBe('custom');
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves hasCustomCss and getThemeCss from the same cached read', () => {
+    vi.mocked(getTheme).mockReturnValue('custom');
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    expect(hasCustomCss()).toBe(true);
+    expect(getThemeCss('custom')).toBe('body { color: red; }');
+    expect(resolveTheme()).toBe('custom');
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches the absence of custom.css rather than retrying the read', () => {
+    throwEnoent();
+    expect(hasCustomCss()).toBe(false);
+    expect(hasCustomCss()).toBe(false);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-reads custom.css as soon as the watcher fires, before the debounce', () => {
+    const harness = watcherHarness();
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    harness.start();
+    expect(getThemeCss('custom')).toBe('body { color: red; }');
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: blue; }');
+    harness.fire('change');
+    expect(getThemeCss('custom')).toBe('body { color: blue; }');
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the cache when the watcher event names another file', () => {
+    const harness = watcherHarness();
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    harness.start();
+    expect(getThemeCss('custom')).toBe('body { color: red; }');
+
+    harness.fire('change', 'config.json');
+    expect(getThemeCss('custom')).toBe('body { color: red; }');
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops caching when the watcher cannot start', async () => {
+    // Nothing would clear a cache the watcher never populates events for, so a
+    // failed watcher has to fall back to reading on every call.
+    vi.resetModules();
+    vi.mocked(fs.watch).mockImplementation(() => { throw new Error('EMFILE: too many open files'); });
+    const theme = await import('../src/theme');
+    const win = {
+      isDestroyed: vi.fn().mockReturnValue(false),
+      webContents: { removeInsertedCSS: vi.fn(), insertCSS: vi.fn() },
+    } as unknown as Parameters<typeof initThemeCSS>[0];
+    theme.initThemeCSS(win);
+
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
+    expect(theme.getThemeCss('custom')).toBe('body { color: red; }');
+    vi.mocked(fs.readFileSync).mockReturnValue('body { color: blue; }');
+    expect(theme.getThemeCss('custom')).toBe('body { color: blue; }');
   });
 
   it('renders bundled theme CSS', () => {

--- a/test/themes.test.ts
+++ b/test/themes.test.ts
@@ -15,6 +15,74 @@ function mediaBlock(css: string, query: string): string {
 }
 
 const HEX_RE = /^#[0-9a-f]{6}$/;
+const CSS_HEX_RE = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/;
+const CSS_RGBA_RE = /^rgba\((\d+),(\d+),(\d+),([0-9.]+)\)$/;
+
+/** WCAG 2.x AA floor for body text. */
+const CONTRAST_FLOOR = 4.5;
+
+// Catppuccin Latte ships subtext0 at #6c6f85, which lands at 4.37:1. Latte is
+// the one palette that was checked on screen, and WW-101 leaves every
+// Catppuccin value untouched, so it holds its shipped ratio.
+const SECONDARY_FLOORS: Record<string, number> = {
+  'catppuccin light': 4.37,
+};
+
+type Rgb = [number, number, number];
+
+/** Reads one custom property out of a generated scheme block. */
+function cssVar(block: string, name: string): string {
+  const match = new RegExp(`--${name}: ([^;]+) !important;`).exec(block);
+  if (match === null) {
+    throw new Error(`--${name} is missing from the generated block`);
+  }
+  return match[1];
+}
+
+function parseHex(value: string): Rgb {
+  const match = CSS_HEX_RE.exec(value);
+  if (match === null) {
+    throw new Error(`${value} is not a six-digit hex colour`);
+  }
+  return [parseInt(match[1], 16), parseInt(match[2], 16), parseInt(match[3], 16)];
+}
+
+function parseRgba(value: string): { rgb: Rgb; alpha: number } {
+  const match = CSS_RGBA_RE.exec(value);
+  if (match === null) {
+    throw new Error(`${value} is not an rgba() colour`);
+  }
+  return {
+    rgb: [Number(match[1]), Number(match[2]), Number(match[3])],
+    alpha: Number(match[4]),
+  };
+}
+
+/** Paints a translucent colour over an opaque one. */
+function composite(fg: Rgb, alpha: number, bg: Rgb): Rgb {
+  return [
+    fg[0] * alpha + bg[0] * (1 - alpha),
+    fg[1] * alpha + bg[1] * (1 - alpha),
+    fg[2] * alpha + bg[2] * (1 - alpha),
+  ];
+}
+
+function relativeLuminance([r, g, b]: Rgb): number {
+  const channel = (value: number): number => {
+    const c = value / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+/** WCAG 2.x contrast ratio, rounded to the two decimals the failures report. */
+function contrastRatio(a: Rgb, b: Rgb): number {
+  const lighter = Math.max(relativeLuminance(a), relativeLuminance(b));
+  const darker = Math.min(relativeLuminance(a), relativeLuminance(b));
+  return Number(((lighter + 0.05) / (darker + 0.05)).toFixed(2));
+}
+
+const SCHEMES = ['dark', 'light'] as const;
 
 describe('palettes', () => {
   it('has unique kebab-case names and unique labels', () => {
@@ -43,6 +111,53 @@ describe('palettes', () => {
     expect(themeLabel('custom')).toBe('Custom');
     expect(themeLabel('apple-music')).toBe('Apple Music');
     expect(themeLabel('no-such-theme')).toBe('Apple Music');
+  });
+});
+
+describe('palette ladders and text contrast', () => {
+  it('gives each background and foreground slot its own hex', () => {
+    for (const theme of BUNDLED_THEMES) {
+      for (const scheme of SCHEMES) {
+        const c = theme[scheme];
+        expect(
+          c.overlay,
+          `${theme.name} ${scheme}: overlay and subtext0 both use ${c.overlay}`,
+        ).not.toBe(c.subtext0);
+        expect(
+          c.crust,
+          `${theme.name} ${scheme}: crust and surface0 both use ${c.crust}`,
+        ).not.toBe(c.surface0);
+      }
+    }
+  });
+
+  // Read from the generated CSS, not the palette, so the alpha values come from
+  // the template itself and cannot drift out of sync with this test.
+  // --systemSecondary sits below the floor in every scheme by design, so it is
+  // not asserted here.
+  it('keeps primary and secondary text at or above the WCAG floor', () => {
+    for (const theme of BUNDLED_THEMES) {
+      const css = buildThemeCss(theme);
+      for (const scheme of SCHEMES) {
+        const block = mediaBlock(css, `prefers-color-scheme: ${scheme}`);
+        const pageBG = parseHex(cssVar(block, 'pageBG'));
+
+        const primary = parseRgba(cssVar(block, 'systemPrimary'));
+        const primaryRatio = contrastRatio(composite(primary.rgb, primary.alpha, pageBG), pageBG);
+        expect(
+          primaryRatio,
+          `${theme.name} ${scheme}: --systemPrimary is ${primaryRatio.toFixed(2)}:1`,
+        ).toBeGreaterThanOrEqual(CONTRAST_FLOOR);
+
+        const secondary = parseHex(cssVar(block, 'systemSecondary-vibrant'));
+        const secondaryRatio = contrastRatio(secondary, pageBG);
+        const floor = SECONDARY_FLOORS[`${theme.name} ${scheme}`] ?? CONTRAST_FLOOR;
+        expect(
+          secondaryRatio,
+          `${theme.name} ${scheme}: --systemSecondary-vibrant is ${secondaryRatio.toFixed(2)}:1`,
+        ).toBeGreaterThanOrEqual(floor);
+      }
+    }
   });
 });
 

--- a/test/tray.test.ts
+++ b/test/tray.test.ts
@@ -508,11 +508,20 @@ describe('createTray - menu template inspection', () => {
       const startPageItem = findItem(template, 'Start Page');
       const submenu = startPageItem!.submenu as Electron.MenuItemConstructorOptions[];
       const labels = submenu.map(item => item.label);
-      expect(labels).toContain('Home');
-      expect(labels).toContain('Browse');
-      expect(labels).toContain('Library');
+      expect(labels).toEqual(['Home', 'Browse', 'Playlists', 'Search', 'Last']);
       expect(labels).not.toContain('New');
       expect(labels).not.toContain('Radio');
+    });
+
+    it('falls back to Home when a stored library page is no longer offered', () => {
+      vi.mocked(getClassicalStartPage).mockReturnValue('library');
+      createTray();
+      const template = getLastTemplate();
+      const startPageItem = findItem(template, 'Start Page');
+      expect(startPageItem!.label).toBe('Start Page: Home');
+      const submenu = startPageItem!.submenu as Electron.MenuItemConstructorOptions[];
+      const ticked = submenu.filter(item => item.checked === true).map(item => item.label);
+      expect(ticked).toEqual(['Home']);
     });
   });
 

--- a/test/tray.test.ts
+++ b/test/tray.test.ts
@@ -108,7 +108,7 @@ vi.mock('../src/paths', () => ({
 import { BrowserWindow, Menu, Tray, nativeImage, nativeTheme } from 'electron';
 import { getUpdateInfo } from '../src/update';
 import { truncateMenuLabel, sanitiseLinuxLabel, createTray, getMenuIcon, updateNowPlayingState, updateTrayTooltip, rebuildTrayMenu, initTrayStateManager, setGetMainWindowCallback } from '../src/tray';
-import { getCloseToTrayEnabled, setTheme, getMusicService, getClassicalStartPage, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername } from '../src/config';
+import { getCloseToTrayEnabled, getTheme, setTheme, getMusicService, getClassicalStartPage, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername } from '../src/config';
 import { downloadArtwork } from '../src/artwork';
 import { PlaybackState } from '../src/player';
 import type { NowPlayingPayload, PlayerEvents } from '../src/player';
@@ -547,6 +547,68 @@ describe('createTray - menu template inspection', () => {
       const template = getLastTemplate();
       const styleItem = findItem(template, 'Style');
       expect(styleItem!.enabled).toBe(true);
+    });
+  });
+
+  describe('Style submenu theme on Classical', () => {
+    // Classical injects no override CSS, so resolveTheme() reduces the stored
+    // choice to 'apple-music'. The menu must still report what is stored.
+    beforeEach(() => {
+      setPlatform('linux');
+      vi.mocked(getMusicService).mockReturnValue('classical');
+      vi.mocked(getTheme).mockReturnValue('dracula');
+      vi.mocked(resolveTheme).mockReturnValue('apple-music');
+      vi.mocked(hasCustomCss).mockReturnValue(false);
+    });
+
+    // Mocks are not reset between tests, so hand back the state the rest of the
+    // file builds the menu in.
+    afterEach(() => {
+      vi.mocked(getMusicService).mockReturnValue('music');
+      vi.mocked(getTheme).mockReturnValue('apple-music');
+      vi.mocked(resolveTheme).mockReturnValue('apple-music');
+      vi.mocked(hasCustomCss).mockReturnValue(false);
+    });
+
+    it('names the stored theme in the parent label', () => {
+      createTray();
+      const styleItem = findItem(getLastTemplate(), 'Style');
+      expect(styleItem!.label).toBe('Style: Dracula');
+    });
+
+    it('ticks the stored theme and nothing else', () => {
+      createTray();
+      const styleItem = findItem(getLastTemplate(), 'Style');
+      const submenu = styleItem!.submenu as Electron.MenuItemConstructorOptions[];
+      const ticked = submenu.filter(item => item.checked === true).map(item => item.label);
+      expect(ticked).toEqual(['Dracula']);
+    });
+
+    it('stays disabled with a stored theme other than Apple Music', () => {
+      createTray();
+      const styleItem = findItem(getLastTemplate(), 'Style');
+      expect(styleItem!.enabled).toBe(false);
+    });
+
+    it('falls back to Apple Music when the stored custom.css is gone', () => {
+      vi.mocked(getTheme).mockReturnValue('custom');
+      createTray();
+      const styleItem = findItem(getLastTemplate(), 'Style');
+      expect(styleItem!.label).toBe('Style: Apple Music');
+      const submenu = styleItem!.submenu as Electron.MenuItemConstructorOptions[];
+      const ticked = submenu.filter(item => item.checked === true).map(item => item.label);
+      expect(ticked).toEqual(['Apple Music']);
+    });
+
+    it('follows resolveTheme rather than the stored theme on the music service', () => {
+      vi.mocked(getMusicService).mockReturnValue('music');
+      vi.mocked(resolveTheme).mockReturnValue('rose-pine');
+      createTray();
+      const styleItem = findItem(getLastTemplate(), 'Style');
+      expect(styleItem!.label).toBe('Style: Rosé Pine');
+      const submenu = styleItem!.submenu as Electron.MenuItemConstructorOptions[];
+      const ticked = submenu.filter(item => item.checked === true).map(item => item.label);
+      expect(ticked).toEqual(['Rosé Pine']);
     });
   });
 

--- a/test/tray.test.ts
+++ b/test/tray.test.ts
@@ -107,7 +107,7 @@ vi.mock('../src/paths', () => ({
 
 import { BrowserWindow, Menu, Tray, nativeImage, nativeTheme } from 'electron';
 import { getUpdateInfo } from '../src/update';
-import { truncateMenuLabel, sanitiseLinuxLabel, createTray, getMenuIcon, updateNowPlayingState, updateTrayTooltip, rebuildTrayMenu, initTrayStateManager, setGetMainWindowCallback } from '../src/tray';
+import { truncateMenuLabel, sanitiseLinuxLabel, cancelTrayRebuild, createTray, getMenuIcon, updateNowPlayingState, updateTrayTooltip, rebuildTrayMenu, initTrayStateManager, setGetMainWindowCallback } from '../src/tray';
 import { getCloseToTrayEnabled, getTheme, setTheme, getMusicService, getClassicalStartPage, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername } from '../src/config';
 import { downloadArtwork } from '../src/artwork';
 import { PlaybackState } from '../src/player';
@@ -1410,6 +1410,11 @@ describe('initTrayStateManager', () => {
   let player: FakePlayer;
   let mockTray: InstanceType<typeof Tray>;
 
+  // The state manager coalesces rebuilds behind a 250ms window, so every test
+  // in this block runs on fake timers and steps past the window to see the
+  // rebuild land.
+  const COALESCE_MS = 250;
+
   /**
    * The handler the state manager registered for `event`. Taking it from the
    * emitter rather than emitting keeps the async handlers awaitable, and lets a
@@ -1422,11 +1427,21 @@ describe('initTrayStateManager', () => {
   }
 
   beforeEach(() => {
+    vi.useFakeTimers();
+    // The coalescing timer is module state, and switching timer modes discards
+    // the pending callback without clearing the handle it was stored under.
+    cancelTrayRebuild();
     player = new FakePlayer();
     mockTray = new Tray('test-icon.png');
     vi.mocked(Menu.buildFromTemplate).mockClear();
     vi.mocked(downloadArtwork).mockReset();
     vi.mocked(downloadArtwork).mockResolvedValue('/tmp/downloaded-artwork.png');
+    vi.mocked(resolveTheme).mockReturnValue('apple-music');
+    vi.mocked(hasCustomCss).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('event subscription', () => {
@@ -1447,125 +1462,116 @@ describe('initTrayStateManager', () => {
     });
 
     it('clears the pause timer when called during an active pause timeout', () => {
-      vi.useFakeTimers();
-      try {
-        const cleanup = initTrayStateManager(player, mockTray);
+      const cleanup = initTrayStateManager(player, mockTray);
 
-        // Simulate playing then pausing to start the pause timer
-        player.setPlaybackState(PlaybackState.Playing);
-        handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Playing });
+      // Simulate playing then pausing to start the pause timer
+      player.setPlaybackState(PlaybackState.Playing);
+      handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Playing });
 
-        player.setPlaybackState(PlaybackState.Paused);
-        handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Paused });
+      player.setPlaybackState(PlaybackState.Paused);
+      handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Paused });
 
-        // Timer is now pending. Cleanup should clear it.
-        cleanup();
+      // Timer is now pending. Cleanup should clear it.
+      cleanup();
 
-        // Advance past the 30s timeout - should not trigger any state clearing
-        vi.mocked(Menu.buildFromTemplate).mockClear();
-        vi.advanceTimersByTime(35_000);
+      // Advance past the 30s timeout - should not trigger any state clearing
+      vi.mocked(Menu.buildFromTemplate).mockClear();
+      vi.advanceTimersByTime(35_000);
 
-        // No additional menu rebuild from the timer callback
-        expect(vi.mocked(Menu.buildFromTemplate)).not.toHaveBeenCalled();
-      } finally {
-        vi.useRealTimers();
-      }
+      // No additional menu rebuild from the timer callback
+      expect(vi.mocked(Menu.buildFromTemplate)).not.toHaveBeenCalled();
+    });
+
+    it('drops a rebuild still inside the coalescing window', () => {
+      const cleanup = initTrayStateManager(player, mockTray);
+      player.setPlaybackState(PlaybackState.Playing);
+
+      handlerFor('volumeDidChange')(0.5);
+      cleanup();
+
+      vi.advanceTimersByTime(COALESCE_MS);
+      expect(vi.mocked(Menu.buildFromTemplate)).not.toHaveBeenCalled();
     });
   });
 
   describe('pause timeout', () => {
     it('clears Now Playing after 30s of inactivity when paused', () => {
-      vi.useFakeTimers();
-      try {
-        initTrayStateManager(player, mockTray);
+      initTrayStateManager(player, mockTray);
 
-        // Transition to playing first (sets previousPlaying = true)
-        player.setPlaybackState(PlaybackState.Playing);
-        handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Playing });
+      // Transition to playing first (sets previousPlaying = true)
+      player.setPlaybackState(PlaybackState.Playing);
+      handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Playing });
 
-        // Transition to paused
-        player.setPlaybackState(PlaybackState.Paused);
-        handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Paused });
+      // Transition to paused
+      player.setPlaybackState(PlaybackState.Paused);
+      handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Paused });
 
-        // Advance 29s - should not have cleared yet
-        vi.mocked(Menu.buildFromTemplate).mockClear();
-        const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
-        setToolTipFn.mockClear();
+      // Advance 29s - should not have cleared yet
+      vi.mocked(Menu.buildFromTemplate).mockClear();
+      const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
+      setToolTipFn.mockClear();
 
-        vi.advanceTimersByTime(29_000);
-        // The tooltip should not have been cleared to the product name yet
-        expect(setToolTipFn).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(29_000);
+      // The tooltip should not have been cleared to the product name yet
+      expect(setToolTipFn).not.toHaveBeenCalled();
 
-        // Advance past 30s
-        vi.advanceTimersByTime(2_000);
+      // Advance past 30s, then past the rebuild window
+      vi.advanceTimersByTime(2_000);
 
-        // Now the tooltip should be reset (updateTrayTooltip(tray, null) sets product name)
-        expect(setToolTipFn).toHaveBeenCalled();
-        // And the menu should be rebuilt
-        expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalled();
-      } finally {
-        vi.useRealTimers();
-      }
+      // Now the tooltip should be reset (updateTrayTooltip(tray, null) sets product name)
+      expect(setToolTipFn).toHaveBeenCalled();
+      // And the menu should be rebuilt
+      expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalled();
     });
 
     it('cancels the pause timer when playback resumes', () => {
-      vi.useFakeTimers();
-      try {
-        initTrayStateManager(player, mockTray);
+      initTrayStateManager(player, mockTray);
 
-        // Play -> Pause (start timer)
-        player.setPlaybackState(PlaybackState.Playing);
-        handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Playing });
+      // Play -> Pause (start timer)
+      player.setPlaybackState(PlaybackState.Playing);
+      handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Playing });
 
-        player.setPlaybackState(PlaybackState.Paused);
-        handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Paused });
+      player.setPlaybackState(PlaybackState.Paused);
+      handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Paused });
 
-        // Resume playing before timeout
-        vi.advanceTimersByTime(10_000);
-        player.setPlaybackState(PlaybackState.Playing);
-        handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Playing });
+      // Resume playing before timeout
+      vi.advanceTimersByTime(10_000);
+      player.setPlaybackState(PlaybackState.Playing);
+      handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Playing });
 
-        // Advance past original timeout - should not clear
-        vi.mocked(Menu.buildFromTemplate).mockClear();
-        const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
-        setToolTipFn.mockClear();
-        vi.advanceTimersByTime(25_000);
+      // Advance past original timeout - should not clear
+      vi.mocked(Menu.buildFromTemplate).mockClear();
+      const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
+      setToolTipFn.mockClear();
+      vi.advanceTimersByTime(25_000);
 
-        expect(setToolTipFn).not.toHaveBeenCalled();
-      } finally {
-        vi.useRealTimers();
-      }
+      expect(setToolTipFn).not.toHaveBeenCalled();
     });
 
     it('cancels the pause timer on track change', async () => {
-      vi.useFakeTimers();
-      try {
-        initTrayStateManager(player, mockTray);
+      initTrayStateManager(player, mockTray);
 
-        // Play -> Pause (start timer)
-        player.setPlaybackState(PlaybackState.Playing);
-        handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Playing });
+      // Play -> Pause (start timer)
+      player.setPlaybackState(PlaybackState.Playing);
+      handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Playing });
 
-        player.setPlaybackState(PlaybackState.Paused);
-        handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Paused });
+      player.setPlaybackState(PlaybackState.Paused);
+      handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Paused });
 
-        // New track arrives - should cancel timer
-        const payload: NowPlayingPayload = { name: 'New Track', artistName: 'Artist' };
-        vi.mocked(downloadArtwork).mockResolvedValue(null);
-        player.setPlaybackState(PlaybackState.Playing);
-        await handlerFor('nowPlayingItemDidChange')(payload);
+      // New track arrives - should cancel timer
+      const payload: NowPlayingPayload = { name: 'New Track', artistName: 'Artist' };
+      vi.mocked(downloadArtwork).mockResolvedValue(null);
+      player.setPlaybackState(PlaybackState.Playing);
+      await handlerFor('nowPlayingItemDidChange')(payload);
 
-        // Advance past original timeout - should not clear
-        vi.mocked(Menu.buildFromTemplate).mockClear();
-        const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
-        setToolTipFn.mockClear();
-        vi.advanceTimersByTime(35_000);
+      // Advance past original timeout - should not clear
+      vi.mocked(Menu.buildFromTemplate).mockClear();
+      const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
+      setToolTipFn.mockClear();
+      vi.advanceTimersByTime(35_000);
 
-        // No timeout-triggered tooltip reset
-        expect(setToolTipFn).not.toHaveBeenCalled();
-      } finally {
-        vi.useRealTimers();
-      }
+      // No timeout-triggered tooltip reset
+      expect(setToolTipFn).not.toHaveBeenCalled();
     });
   });
 
@@ -1577,6 +1583,7 @@ describe('initTrayStateManager', () => {
       player.setPlaybackState(PlaybackState.Playing);
 
       await handlerFor('nowPlayingItemDidChange')(payload);
+      vi.advanceTimersByTime(COALESCE_MS);
 
       const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
       expect(setToolTipFn).toHaveBeenCalled();
@@ -1587,6 +1594,7 @@ describe('initTrayStateManager', () => {
       initTrayStateManager(player, mockTray);
 
       await handlerFor('nowPlayingItemDidChange')(null);
+      vi.advanceTimersByTime(COALESCE_MS);
 
       const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
       expect(setToolTipFn).toHaveBeenCalled();
@@ -1624,11 +1632,13 @@ describe('initTrayStateManager', () => {
       await handlerFor('nowPlayingItemDidChange')(payload2);
 
       // Clear the mock calls from the second track handler
+      vi.advanceTimersByTime(COALESCE_MS);
       vi.mocked(Menu.buildFromTemplate).mockClear();
 
       // Resolve first artwork download - should be discarded (stale)
       resolveFirst!('/tmp/art1.png');
       await firstPromise;
+      vi.advanceTimersByTime(COALESCE_MS);
 
       // No additional menu rebuild from the stale first track
       expect(vi.mocked(Menu.buildFromTemplate)).not.toHaveBeenCalled();
@@ -1642,6 +1652,7 @@ describe('initTrayStateManager', () => {
       for (const state of [PlaybackState.None, PlaybackState.Stopped, PlaybackState.Ended, PlaybackState.Completed]) {
         vi.mocked(Menu.buildFromTemplate).mockClear();
         handlerFor('playbackStateDidChange')({ status: true, state });
+        vi.advanceTimersByTime(COALESCE_MS);
         expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalled();
       }
     });
@@ -1652,6 +1663,7 @@ describe('initTrayStateManager', () => {
 
       vi.mocked(Menu.buildFromTemplate).mockClear();
       handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Playing });
+      vi.advanceTimersByTime(COALESCE_MS);
 
       expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalled();
     });
@@ -1664,6 +1676,7 @@ describe('initTrayStateManager', () => {
 
       vi.mocked(Menu.buildFromTemplate).mockClear();
       handlerFor('volumeDidChange')(0.5);
+      vi.advanceTimersByTime(COALESCE_MS);
 
       expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalled();
     });
@@ -1673,8 +1686,91 @@ describe('initTrayStateManager', () => {
 
       vi.mocked(Menu.buildFromTemplate).mockClear();
       handlerFor('volumeDidChange')(null);
+      vi.advanceTimersByTime(COALESCE_MS);
 
       expect(vi.mocked(Menu.buildFromTemplate)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rebuild coalescing', () => {
+    // The hook polls mk.volume every 250ms while the slider moves, and a page
+    // in the renderer can emit far faster than that. Each rebuild walks every
+    // submenu, reads custom.css and resizes the artwork five times.
+    it('collapses a burst of volume events into a single rebuild', () => {
+      initTrayStateManager(player, mockTray);
+      player.setPlaybackState(PlaybackState.Playing);
+      vi.mocked(Menu.buildFromTemplate).mockClear();
+
+      const onVolume = handlerFor('volumeDidChange');
+      for (let i = 1; i <= 20; i++) onVolume(i / 20);
+
+      expect(vi.mocked(Menu.buildFromTemplate)).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(COALESCE_MS);
+      expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalledTimes(1);
+    });
+
+    it('collapses a mixed burst of playback and volume events', () => {
+      initTrayStateManager(player, mockTray);
+      player.setPlaybackState(PlaybackState.Playing);
+      vi.mocked(Menu.buildFromTemplate).mockClear();
+
+      for (let i = 0; i < 10; i++) {
+        handlerFor('volumeDidChange')(0.5);
+        handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Playing });
+      }
+
+      vi.advanceTimersByTime(COALESCE_MS);
+      expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows the volume from the end of the burst', async () => {
+      initTrayStateManager(player, mockTray);
+      player.setPlaybackState(PlaybackState.Playing);
+      vi.mocked(downloadArtwork).mockResolvedValue(null);
+      await handlerFor('nowPlayingItemDidChange')({ name: 'Track', artistName: 'Artist' });
+      vi.advanceTimersByTime(COALESCE_MS);
+
+      const onVolume = handlerFor('volumeDidChange');
+      onVolume(0.25);
+      onVolume(0.5);
+      onVolume(0.75);
+      vi.mocked(Menu.buildFromTemplate).mockClear();
+      vi.advanceTimersByTime(COALESCE_MS);
+
+      const volumeItem = findItem(getLastTemplate(), 'Volume');
+      expect(volumeItem!.label).toBe('Volume: 75%');
+    });
+
+    it('rebuilds again for events that arrive after the window closes', () => {
+      initTrayStateManager(player, mockTray);
+      player.setPlaybackState(PlaybackState.Playing);
+      vi.mocked(Menu.buildFromTemplate).mockClear();
+
+      const onVolume = handlerFor('volumeDidChange');
+      onVolume(0.25);
+      onVolume(0.5);
+      vi.advanceTimersByTime(COALESCE_MS);
+      expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalledTimes(1);
+
+      onVolume(0.75);
+      vi.advanceTimersByTime(COALESCE_MS);
+      expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps rebuilding under a flood that never pauses', () => {
+      // A debounce restarted by every event would never expire here, leaving
+      // the menu frozen. The window has to close on schedule regardless.
+      initTrayStateManager(player, mockTray);
+      player.setPlaybackState(PlaybackState.Playing);
+      vi.mocked(Menu.buildFromTemplate).mockClear();
+
+      const onVolume = handlerFor('volumeDidChange');
+      for (let tick = 0; tick < 40; tick++) {
+        onVolume(tick % 2 === 0 ? 0.4 : 0.6);
+        vi.advanceTimersByTime(25);
+      }
+
+      expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/test/tray.test.ts
+++ b/test/tray.test.ts
@@ -115,6 +115,7 @@ import type { NowPlayingPayload, PlayerEvents } from '../src/player';
 import { applyTheme, hasCustomCss, resolveTheme } from '../src/theme';
 import { startAuth as startLastfmAuth, disconnect as disconnectLastfm, isConfigured as isLastfmConfigured } from '../src/integrations/lastfm';
 import { FakePlayer } from './mocks/player';
+import type { ClassicalStartPageId, MusicServiceId } from '../src/musicService';
 
 // Helper: extract the template array from the last Menu.buildFromTemplate call
 function getLastTemplate(): Electron.MenuItemConstructorOptions[] {
@@ -493,6 +494,48 @@ describe('createTray - menu template inspection', () => {
     });
   });
 
+  describe('Player submenu with an unregistered service id', () => {
+    // Stands in for a hand-edited config file, or for a downgrade past a future
+    // release that adds a third service id.
+    const UNREGISTERED_SERVICE_ID = 'jazz' as string as MusicServiceId;
+
+    beforeEach(() => {
+      setPlatform('linux');
+      vi.mocked(getMusicService).mockReturnValue(UNREGISTERED_SERVICE_ID);
+      vi.mocked(getTheme).mockReturnValue('apple-music');
+      vi.mocked(resolveTheme).mockReturnValue('apple-music');
+      vi.mocked(hasCustomCss).mockReturnValue(false);
+    });
+
+    // Mocks are not reset between tests, so hand back the state the rest of the
+    // file builds the menu in.
+    afterEach(() => {
+      vi.mocked(getMusicService).mockReturnValue('music');
+      vi.mocked(getTheme).mockReturnValue('apple-music');
+      vi.mocked(resolveTheme).mockReturnValue('apple-music');
+      vi.mocked(hasCustomCss).mockReturnValue(false);
+    });
+
+    it('builds a menu rather than leaving the tray without one', () => {
+      expect(() => createTray()).not.toThrow();
+      expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalled();
+      expect(getLastTemplate().length).toBeGreaterThan(0);
+    });
+
+    it('names the default service in the Player parent label', () => {
+      createTray();
+      const playerItem = findItem(getLastTemplate(), 'Player');
+      expect(playerItem!.label).toBe('Player: Apple Music');
+    });
+
+    it('still lists every registered service', () => {
+      createTray();
+      const playerItem = findItem(getLastTemplate(), 'Player');
+      const submenu = playerItem!.submenu as Electron.MenuItemConstructorOptions[];
+      expect(submenu.map(item => item.label)).toEqual(['Apple Music', 'Apple Music Classical']);
+    });
+  });
+
   describe('Start Page submenu with classical service', () => {
     beforeEach(() => {
       setPlatform('linux');
@@ -514,7 +557,9 @@ describe('createTray - menu template inspection', () => {
     });
 
     it('falls back to Home when a stored library page is no longer offered', () => {
-      vi.mocked(getClassicalStartPage).mockReturnValue('library');
+      // 'library' was persisted before WW-92 dropped the page; the store can still
+      // hold it, the type no longer admits it.
+      vi.mocked(getClassicalStartPage).mockReturnValue('library' as string as ClassicalStartPageId);
       createTray();
       const template = getLastTemplate();
       const startPageItem = findItem(template, 'Start Page');

--- a/test/tray.test.ts
+++ b/test/tray.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, expectTypeOf, vi, beforeEach, afterEach } from 'vitest';
 import type { TrayStrings } from '../src/i18n';
 
 // Mock modules that import electron-conf/main at import time.
@@ -67,6 +67,18 @@ const mockTrayStrings: TrayStrings = {
   closeToTray: 'Close to tray',
 };
 
+// Expected menu label per registry page id. Typed over the union, so a new page
+// with no expectation here fails tsc rather than going untested.
+const TEST_START_PAGE_LABELS: Record<AnyStartPageId, string> = {
+  'home': mockTrayStrings.startPageHome,
+  'new': mockTrayStrings.startPageNew,
+  'radio': mockTrayStrings.startPageRadio,
+  'all-playlists': mockTrayStrings.startPageAllPlaylists,
+  'browse': mockTrayStrings.startPageBrowse,
+  'playlists': mockTrayStrings.startPagePlaylists,
+  'search': mockTrayStrings.startPageSearch,
+};
+
 vi.mock('../src/i18n', () => ({
   getTrayStrings: () => mockTrayStrings,
   getAboutStrings: () => ({ close: 'Close', versionPrefix: 'Version', copyrightSuffix: 'All rights reserved', licensePrefix: 'License' }),
@@ -107,15 +119,15 @@ vi.mock('../src/paths', () => ({
 
 import { BrowserWindow, Menu, Tray, nativeImage, nativeTheme } from 'electron';
 import { getUpdateInfo } from '../src/update';
-import { truncateMenuLabel, sanitiseLinuxLabel, cancelTrayRebuild, createTray, getMenuIcon, updateNowPlayingState, updateTrayTooltip, rebuildTrayMenu, initTrayStateManager, setGetMainWindowCallback } from '../src/tray';
-import { getCloseToTrayEnabled, getTheme, setTheme, getMusicService, getClassicalStartPage, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername } from '../src/config';
+import { truncateMenuLabel, sanitiseLinuxLabel, cancelTrayRebuild, createTray, getMenuIcon, updateNowPlayingState, updateTrayTooltip, rebuildTrayMenu, initTrayStateManager, setGetMainWindowCallback, setSwitchServiceCallback } from '../src/tray';
+import { getCloseToTrayEnabled, getTheme, setTheme, getMusicService, setMusicService, getClassicalStartPage, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername } from '../src/config';
 import { downloadArtwork } from '../src/artwork';
 import { PlaybackState } from '../src/player';
 import type { NowPlayingPayload, PlayerEvents } from '../src/player';
 import { applyTheme, hasCustomCss, resolveTheme } from '../src/theme';
 import { startAuth as startLastfmAuth, disconnect as disconnectLastfm, isConfigured as isLastfmConfigured } from '../src/integrations/lastfm';
 import { FakePlayer } from './mocks/player';
-import type { ClassicalStartPageId, MusicServiceId } from '../src/musicService';
+import { MUSIC_SERVICES, type AnyStartPageId, type ClassicalStartPageId, type MusicServiceId } from '../src/musicService';
 
 // Helper: extract the template array from the last Menu.buildFromTemplate call
 function getLastTemplate(): Electron.MenuItemConstructorOptions[] {
@@ -494,6 +506,55 @@ describe('createTray - menu template inspection', () => {
     });
   });
 
+  describe('Player submenu service switch', () => {
+    const onSwitch = vi.fn();
+
+    beforeEach(() => {
+      setPlatform('linux');
+      vi.mocked(getMusicService).mockReturnValue('music');
+      vi.mocked(resolveTheme).mockReturnValue('apple-music');
+      vi.mocked(hasCustomCss).mockReturnValue(false);
+      vi.mocked(setMusicService).mockClear();
+      onSwitch.mockClear();
+      setSwitchServiceCallback(onSwitch);
+    });
+
+    // Mocks are not reset between tests, so hand back the state the rest of the
+    // file builds the menu in.
+    afterEach(() => {
+      setSwitchServiceCallback(() => {});
+      vi.mocked(getMusicService).mockReturnValue('music');
+    });
+
+    function playerSubmenu(): Electron.MenuItemConstructorOptions[] {
+      createTray();
+      const playerItem = findItem(getLastTemplate(), 'Player');
+      expect(playerItem).toBeDefined();
+      return playerItem!.submenu as Electron.MenuItemConstructorOptions[];
+    }
+
+    it('hands the clicked service id to the wired callback', () => {
+      const classicalItem = playerSubmenu().find(item => item.label === 'Apple Music Classical');
+      expect(classicalItem).toBeDefined();
+      (classicalItem!.click as Function)();
+      expect(onSwitch).toHaveBeenCalledTimes(1);
+      expect(onSwitch).toHaveBeenCalledWith('classical');
+    });
+
+    it('does nothing when the active service is clicked', () => {
+      const musicItem = playerSubmenu().find(item => item.label === 'Apple Music');
+      expect(musicItem).toBeDefined();
+      (musicItem!.click as Function)();
+      expect(onSwitch).not.toHaveBeenCalled();
+      expect(vi.mocked(setMusicService)).not.toHaveBeenCalled();
+    });
+
+    it('takes a service id rather than any string', () => {
+      expectTypeOf(setSwitchServiceCallback).parameter(0).parameter(0).toEqualTypeOf<MusicServiceId>();
+      expectTypeOf(setSwitchServiceCallback).parameter(0).parameter(0).not.toEqualTypeOf<string>();
+    });
+  });
+
   describe('Player submenu with an unregistered service id', () => {
     // Stands in for a hand-edited config file, or for a downgrade past a future
     // release that adds a third service id.
@@ -567,6 +628,48 @@ describe('createTray - menu template inspection', () => {
       const submenu = startPageItem!.submenu as Electron.MenuItemConstructorOptions[];
       const ticked = submenu.filter(item => item.checked === true).map(item => item.label);
       expect(ticked).toEqual(['Home']);
+    });
+  });
+
+  describe('Start Page submenu covers the registry', () => {
+    beforeEach(() => {
+      setPlatform('linux');
+      vi.mocked(resolveTheme).mockReturnValue('apple-music');
+      vi.mocked(hasCustomCss).mockReturnValue(false);
+    });
+
+    // Mocks are not reset between tests, so hand back the state the rest of the
+    // file builds the menu in.
+    afterEach(() => {
+      vi.mocked(getMusicService).mockReturnValue('music');
+      vi.mocked(getClassicalStartPage).mockReturnValue('home');
+    });
+
+    function startPageSubmenu(): Electron.MenuItemConstructorOptions[] {
+      createTray();
+      const startPageItem = findItem(getLastTemplate(), 'Start Page');
+      expect(startPageItem).toBeDefined();
+      return startPageItem!.submenu as Electron.MenuItemConstructorOptions[];
+    }
+
+    it('offers a radio entry for every music start page in the registry', () => {
+      vi.mocked(getMusicService).mockReturnValue('music');
+      const submenu = startPageSubmenu();
+      for (const page of MUSIC_SERVICES.music.startPages) {
+        const entry = submenu.find(item => item.label === TEST_START_PAGE_LABELS[page.id]);
+        expect(entry, `${page.id} should have a menu entry`).toBeDefined();
+        expect(entry!.type).toBe('radio');
+      }
+    });
+
+    it('offers a radio entry for every classical start page in the registry', () => {
+      vi.mocked(getMusicService).mockReturnValue('classical');
+      const submenu = startPageSubmenu();
+      for (const page of MUSIC_SERVICES.classical.startPages) {
+        const entry = submenu.find(item => item.label === TEST_START_PAGE_LABELS[page.id]);
+        expect(entry, `${page.id} should have a menu entry`).toBeDefined();
+        expect(entry!.type).toBe('radio');
+      }
     });
   });
 

--- a/test/tray.test.ts
+++ b/test/tray.test.ts
@@ -953,6 +953,38 @@ describe('createTray - menu template inspection', () => {
       expect(mockWin.focus).toHaveBeenCalled();
     });
 
+    it('tray click rebuilds the menu after showing a hidden window', () => {
+      mockWin.isVisible.mockReturnValue(false);
+      // Showing the window flips visibility, so the rebuilt menu is built against the new state.
+      mockWin.show.mockImplementation(() => { mockWin.isVisible.mockReturnValue(true); });
+      const tray = createTray();
+      const setContextMenu = tray.setContextMenu as ReturnType<typeof vi.fn>;
+      // Delta, never an absolute count: createTray() sets the menu once on its own.
+      const before = setContextMenu.mock.calls.length;
+      const onFn = tray.on as ReturnType<typeof vi.fn>;
+      const clickCall = onFn.mock.calls.find(([event]: [string]) => event === 'click');
+      expect(clickCall).toBeDefined();
+      (clickCall![1] as () => void)();
+      expect(setContextMenu.mock.calls.length).toBe(before + 1);
+      // Without the rebuild the menu still offers Show Sidra for a window that is now visible.
+      const template = getLastTemplate();
+      expect(findItem(template, 'Hide Sidra')).toBeDefined();
+      expect(findItem(template, 'Show Sidra')).toBeUndefined();
+    });
+
+    it('tray click focuses a visible window without rebuilding the menu', () => {
+      const tray = createTray();
+      const setContextMenu = tray.setContextMenu as ReturnType<typeof vi.fn>;
+      const before = setContextMenu.mock.calls.length;
+      const onFn = tray.on as ReturnType<typeof vi.fn>;
+      const clickCall = onFn.mock.calls.find(([event]: [string]) => event === 'click');
+      expect(clickCall).toBeDefined();
+      (clickCall![1] as () => void)();
+      expect(mockWin.focus).toHaveBeenCalled();
+      expect(mockWin.show).not.toHaveBeenCalled();
+      expect(setContextMenu.mock.calls.length).toBe(before);
+    });
+
     it('tray click is a no-op when close-to-tray is disabled', () => {
       mockWin.isVisible.mockReturnValue(false);
       vi.mocked(getCloseToTrayEnabled).mockReturnValue(false);


### PR DESCRIPTION
These six Copilot pull requests were structurally sound but defective at every
edge the agent had not exercised. This branch closes WW-91's fourteen child
issues, each as its own commit.

Apple Music Classical gets four fixes: the Start Page offered a Library route
that 404s (50216df), Classical had no Back, Forward, or Reload (4027704), the
tray Style label now shows correctly when Classical is active (514e544), and
service switching no longer trusts the persisted service id as the active
host (02dbfb1).

Theming gets two: `custom.css` was documented at a path that does not exist on
Linux, now fixed alongside presence-check and tray-refresh handling (2573758),
and palette contrast fixes raise low-contrast text and remove duplicate ladder
rungs (16690ea).

The MusicKit hook gets two: stale media-session position on unresolved
duration (dbb4e35), and a dead injection guard that could throw before the
splash screen dismissed (95c471c).

Two further fixes stand alone: correcting the Sidra userData path casing in
README and justfile (4f8de8c), and blocking top-frame navigation to non-Apple
hosts (4916675). Tray rebuilds are now coalesced and `custom.css` reads
cached (3855499).

The remaining three commits are cleanup: unifying the service-switch sequence
and its duplicated maps (4226cc9), a test suite pass driven by mutation
testing that closed 26 killed-mutation gaps and dropped 16 weak tests, taking
the suite from 585 tests across 21 files to 706 across 24 (015da55) - the gap
mattered because `test/config.test.ts` mocked the very module it was meant to
cover - and documentation corrections across AGENTS.md, README and
SPECIFICATION (b775777).

One behaviour change worth a reviewer's attention: the navigation-allowlist
fix (4916675) blocks same-tab navigation to a non-Apple host with a log line
and nothing else, so a legitimate outbound link now does nothing visible.
`setWindowOpenHandler` still opens `target="_blank"` links externally as
before. Routing blocked navigations to `shell.openExternal` instead would
close that gap; the fix as specified does not.

Three things still need a human. The twelve colour schemes have not been
viewed running in light and dark; Solarized changed most, with primary text
raised a full upstream rung in both variants to clear 4.5:1 contrast, so
Solarized Dark body text moves from `#93a1a1` to `#eee8d5`. The Classical
navigation bar was proven to attach by a live DOM probe against the real
site, but not from a packaged build with `musicService` set to `classical`.
The `custom.css` create and delete checks, and starting a radio station
after a track, both need a running Sidra.

This closes the WW-91 cohort. Two further issues, WW-106 and WW-107, came out
of testing this branch and are deliberately left for separate work.
