### PR TITLE
feat(theme): apply bundled themes and custom.css on Classical

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,9 +142,11 @@ When adding a language, add an entry to every record in every JSON file:
 
 `routeToMusicService(url)` in the same module handles `itms://` links, which always target the music service. It calls `switchService('music', url)` when Classical is active and navigates directly otherwise, so the switch costs one navigation.
 
-### Theme gating
+### Themes on both services
 
-`resolveTheme()` in `src/theme.ts` forces `'apple-music'` when the classical service is active, so no override CSS is injected. The stored `theme` value is left unchanged, so switching back to the music service restores the user's preferred theme. The Style submenu in the tray is disabled (`enabled: false`) when Classical is active.
+Bundled themes and `custom.css` apply to both services. `resolveTheme()` in `src/theme.ts` never branches on the active service, `injectContent()` in `src/main.ts` calls `injectThemeCss()` from `src/theme.ts` on every load, and the tray Style submenu is enabled on both.
+
+Do not reintroduce a service gate. `music.apple.com` and `classical.music.apple.com` are separate builds of one Svelte design system and share an identical `:root` custom property block, so every colour token `src/themeTemplate.ts` overrides exists on Classical with the same value. A visual gap in Classical's own player chrome is a missing selector, not a reason to stop injecting.
 
 ### postMessage target origin
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ As an unsupported escape hatch, you can place a `custom.css` file in Sidra's use
 
 The **Custom** menu entry only appears when that file exists.
 
-Themes apply to Apple Music only. Sidra keeps your choice while Apple Music Classical is active and restores it when you switch back.
+Your chosen theme applies to both Apple Music and Apple Music Classical.
 
 ---
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -112,7 +112,7 @@ sidra/
 │   ├── types/
 │   │   ├── electron.d.ts          - module augmentations for CastLabs type gaps
 │   │   └── hook.d.ts              - hook-preload contract: SidraHook, AMWrapperBridge, SendChannel, ReceiveChannel, SidraCommandMessage, Window augmentations
-│   ├── theme.ts                   - theme lifecycle: ThemeName, resolveTheme(), getThemeCss(), applyTheme(), initThemeCSS()
+│   ├── theme.ts                   - theme lifecycle: ThemeName, resolveTheme(), getThemeCss(), applyTheme(), injectThemeCss(), initThemeCSS()
 │   ├── palettes.ts                - bundled theme registry (BUNDLED_THEMES), BundledThemeName, themeLabel()
 │   ├── themeTemplate.ts           - pure palette→CSS renderer (buildThemeCss())
 │   ├── artwork.ts                 - downloadArtwork(), cleanArtworkCache(); UUID-based multi-file cache
@@ -574,9 +574,9 @@ Each service keeps its own start page and last page. `classical.startPage` and `
 
 `buildItmsRouteURL()` is pinned to `getService('music').origin`. `itms://` links always target Apple Music, and `transformItmsUrl()` in `src/itms.ts` pins the host on the parsing side.
 
-### Theme gate
+### Themes across services
 
-`resolveTheme()` returns `'apple-music'` for Classical before it reads the stored value, so no override CSS is injected. Bundled themes target the `music.apple.com` DOM and do not apply. The tray Style submenu renders with `enabled: false` under Classical, and `styleMenuTheme()` labels it from `getTheme()` rather than `resolveTheme()` so the user's stored choice stays visible.
+Themes are service-agnostic. `resolveTheme()` does not branch on the active service, `injectThemeCss()` runs on every page load, and the tray Style submenu is enabled under both services. Both sites are separate builds of one Svelte design system and share an identical `:root` custom property block, so every token `src/themeTemplate.ts` overrides carries the same value on Classical.
 
 ### Switching
 
@@ -634,7 +634,7 @@ The default colour scheme is Apple Music's own (`'apple-music'`). Bundled themes
 
 Theme preference is stored in `electron-conf` as `theme` (`ThemeName`: `'apple-music'` | `BundledThemeName` | `'custom'`). `resolveTheme()` guards startup/runtime behaviour:
 
-- Apple Music Classical returns `'apple-music'` before the stored value is read, so no override CSS is injected. The stored theme is left untouched and returns on the switch back
+- The active music service is not consulted; the same theme resolves on Apple Music and Apple Music Classical
 - Unknown stored values fall back to `'apple-music'`
 - `'custom'` falls back to `'apple-music'` when `custom.css` holds no usable CSS
 - Bundled values pass through directly

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import { Player, IntegrationContext } from './player';
 import { buildAppleMusicURL, buildItmsRouteURL, handleStorefrontNavigation, handleLastPageNavigation } from './storefront';
 import { extractItmsUrlFromArgv, type ItmsTarget } from './itms';
 import { initServiceSwitch, routeToMusicService, switchService } from './serviceSwitch';
-import { getThemeCss, initThemeCSS, resolveTheme, setRebuildTrayCallback, setThemeCssKey } from './theme';
+import { initThemeCSS, injectThemeCss, setRebuildTrayCallback } from './theme';
 import { createTray, getMenuIcon, initTrayStateManager, rebuildTrayMenu, setApplyZoomCallback, setSendCommandCallback, setGetMainWindowCallback, setSwitchServiceCallback } from './tray';
 import { showAboutWindow } from './aboutWindow';
 import { checkForUpdates } from './update';
@@ -578,21 +578,7 @@ function setupContentHandlers(win: BrowserWindow, player: Player, markCssReady: 
     win.webContents.setZoomFactor(getZoomFactor());
     await win.webContents.insertCSS(assets.STYLE_FIX_CSS);
     mainLog.debug('CSS fixes injected');
-    const activeService = getMusicService();
-    if (activeService === 'music') {
-      const theme = resolveTheme();
-      if (theme !== 'apple-music') {
-        const css = getThemeCss(theme);
-        if (css !== null) {
-          setThemeCssKey(await win.webContents.insertCSS(css));
-          mainLog.debug(`Theme CSS injected: ${theme}`);
-        } else {
-          mainLog.warn(`Theme CSS unavailable: ${theme}`);
-        }
-      }
-    } else {
-      setThemeCssKey(null);
-    }
+    await injectThemeCss(win.webContents);
     const currentUrl = win.webContents.getURL();
     if (isAllowedNavigationUrl(currentUrl)) {
       await win.webContents.executeJavaScript(assets.hookScript);

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import { app, BrowserWindow, nativeTheme } from 'electron';
+import { app, BrowserWindow, nativeTheme, type WebContents } from 'electron';
 import log from 'electron-log/main';
 import { BUNDLED_THEMES, type BundledThemeName } from './palettes';
 import { buildThemeCss } from './themeTemplate';
-import { getTheme, getMusicService } from './config';
+import { getTheme } from './config';
 
 export type ThemeName = 'apple-music' | BundledThemeName | 'custom';
 
@@ -55,8 +55,6 @@ function isThemeName(value: string): value is ThemeName {
 }
 
 export function resolveTheme(): ThemeName {
-  // Classical does not support bundled theme CSS (targets music.apple.com DOM)
-  if (getMusicService() === 'classical') return 'apple-music';
   const theme = getTheme();
   if (!isThemeName(theme)) return 'apple-music';
   if (theme === 'custom' && getThemeCss('custom') === null) return 'apple-music';
@@ -106,6 +104,19 @@ export function getThemeCss(name: ThemeName): string | null {
   const css = buildThemeCss(theme);
   bundledCssCache.set(name, css);
   return css;
+}
+
+// Inject the resolved theme CSS after a page load. main.ts calls this on every load.
+export async function injectThemeCss(contents: WebContents): Promise<void> {
+  const theme = resolveTheme();
+  if (theme === 'apple-music') return;
+  const css = getThemeCss(theme);
+  if (css === null) {
+    themeLog.warn(`Theme CSS unavailable: ${theme}`);
+    return;
+  }
+  setThemeCssKey(await contents.insertCSS(css));
+  themeLog.debug(`Theme CSS injected: ${theme}`);
 }
 
 export function initThemeCSS(win: BrowserWindow): void {

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -4,12 +4,12 @@ import log from 'electron-log/main';
 import { getTrayStrings, getUpdateStrings, getAutoUpdateStrings, type TrayStrings } from './i18n';
 import { getAssetPath, getProductInfo } from './paths';
 import { Player, PlaybackState, getShareUrl, type NowPlayingPayload } from './player';
-import { getNotificationsEnabled, setNotificationsEnabled, getDiscordEnabled, setDiscordEnabled, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername, getTheme, setTheme, getStartPage, setStartPage, getZoomFactor, setZoomFactor, getCloseToTrayEnabled, setCloseToTrayEnabled, getMusicService, getClassicalStartPage, setClassicalStartPage } from './config';
+import { getNotificationsEnabled, setNotificationsEnabled, getDiscordEnabled, setDiscordEnabled, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername, setTheme, getStartPage, setStartPage, getZoomFactor, setZoomFactor, getCloseToTrayEnabled, setCloseToTrayEnabled, getMusicService, getClassicalStartPage, setClassicalStartPage } from './config';
 import { showAboutWindow } from './aboutWindow';
 import { getUpdateInfo } from './update';
 import { quitAndInstall } from './autoUpdate';
 import { BUNDLED_THEMES, themeLabel } from './palettes';
-import { applyTheme, hasCustomCss, resolveTheme, type ThemeName } from './theme';
+import { applyTheme, hasCustomCss, resolveTheme } from './theme';
 import { enable as enableDiscord, disable as disableDiscord } from './integrations/discord-presence';
 import { enable as enableLastfm, disable as disableLastfm, startAuth as startLastfmAuth, disconnect as disconnectLastfm, isConfigured as isLastfmConfigured } from './integrations/lastfm';
 import { downloadArtwork } from './artwork';
@@ -364,19 +364,9 @@ function buildLastfmSubmenu(ctx: SubmenuContext): Electron.MenuItemConstructorOp
   };
 }
 
-// Classical injects no theme CSS but the stored choice is preserved, so the menu
-// reports what is stored rather than what resolveTheme() reduces it to
-function styleMenuTheme(isClassical: boolean): ThemeName {
-  if (!isClassical) return resolveTheme();
-  const stored = getTheme();
-  if (stored === 'custom' && !hasCustomCss()) return 'apple-music';
-  return stored;
-}
-
 function buildStyleSubmenu(ctx: SubmenuContext): Electron.MenuItemConstructorOptions {
   const { strings, refresh } = ctx;
-  const isClassical = getMusicService() === 'classical';
-  const currentTheme = styleMenuTheme(isClassical);
+  const currentTheme = resolveTheme();
   const parentLabel = `${strings.style}: ${currentTheme === 'apple-music' ? strings.styleAppleMusic : themeLabel(currentTheme)}`;
   const icon = getMenuIcon('style');
   const items: Electron.MenuItemConstructorOptions[] = [
@@ -404,7 +394,6 @@ function buildStyleSubmenu(ctx: SubmenuContext): Electron.MenuItemConstructorOpt
   return {
     label: parentLabel,
     ...(icon ? { icon } : {}),
-    enabled: !isClassical,
     submenu: items,
   };
 }

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { app } from 'electron';
+import { app, type WebContents } from 'electron';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../src/config', () => ({
@@ -26,6 +26,7 @@ import {
   getThemeCss,
   hasCustomCss,
   initThemeCSS,
+  injectThemeCss,
   invalidateCustomCssCache,
   resolveTheme,
   setRebuildTrayCallback,
@@ -164,32 +165,66 @@ describe('theme helpers', () => {
     expect(resolveTheme()).toBe('apple-music');
   });
 
-  it('forces apple-music on classical for a bundled theme', () => {
-    // Bundled theme CSS targets the music.apple.com DOM, so classical gets none.
+  it('keeps a bundled theme on classical', () => {
     vi.mocked(getTheme).mockReturnValue('catppuccin');
     vi.mocked(getMusicService).mockReturnValue('classical');
-    expect(resolveTheme()).toBe('apple-music');
+    expect(resolveTheme()).toBe('catppuccin');
   });
 
-  it('forces apple-music on classical even with populated custom.css', () => {
+  it('keeps custom on classical with populated custom.css', () => {
     vi.mocked(getTheme).mockReturnValue('custom');
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue('body { color: red; }');
     vi.mocked(getMusicService).mockReturnValue('classical');
-    expect(resolveTheme()).toBe('apple-music');
+    expect(resolveTheme()).toBe('custom');
   });
 
-  it('restores the stored theme when the service switches back from classical', () => {
-    // The gate suppresses the theme; it never rewrites the stored value.
+  it('resolves the same theme across a music to classical to music switch', () => {
+    // The active service is not an input to resolveTheme().
     vi.mocked(getTheme).mockReturnValue('catppuccin');
     expect(resolveTheme()).toBe('catppuccin');
 
     vi.mocked(getMusicService).mockReturnValue('classical');
-    expect(resolveTheme()).toBe('apple-music');
-    expect(getTheme()).toBe('catppuccin');
+    expect(resolveTheme()).toBe('catppuccin');
 
     vi.mocked(getMusicService).mockReturnValue('music');
     expect(resolveTheme()).toBe('catppuccin');
+  });
+
+  // main.ts calls injectThemeCss() from injectContent() on every page load, and
+  // src/main.ts cannot be imported under Vitest, so this is where that path is
+  // covered.
+  describe('injectThemeCss', () => {
+    beforeEach(() => {
+      // The key outlives the module, so each test starts with none injected.
+      setThemeCssKey(null);
+    });
+
+    function fakeContents() {
+      const insertCSS = vi.fn().mockResolvedValue('key');
+      return { insertCSS, contents: { insertCSS } as unknown as WebContents };
+    }
+
+    it('injects bundled theme CSS while classical is active', async () => {
+      vi.mocked(getTheme).mockReturnValue('catppuccin');
+      vi.mocked(getMusicService).mockReturnValue('classical');
+      const { insertCSS, contents } = fakeContents();
+
+      await injectThemeCss(contents);
+
+      expect(insertCSS).toHaveBeenCalledTimes(1);
+      const [css] = insertCSS.mock.calls[0] as [string];
+      expect(css).toContain('--pageBG');
+    });
+
+    it('injects nothing for the apple-music theme', async () => {
+      vi.mocked(getTheme).mockReturnValue('apple-music');
+      const { insertCSS, contents } = fakeContents();
+
+      await injectThemeCss(contents);
+
+      expect(insertCSS).not.toHaveBeenCalled();
+    });
   });
 
   it('returns null for apple-music even with populated custom.css', () => {

--- a/test/tray.test.ts
+++ b/test/tray.test.ts
@@ -13,7 +13,6 @@ vi.mock('../src/config', () => ({
   getLastfmUsername: vi.fn(() => null),
   setLastfmSession: vi.fn(),
   clearLastfmSession: vi.fn(),
-  getTheme: vi.fn(() => 'apple-music'),
   setTheme: vi.fn(),
   getStartPage: () => 'new',
   setStartPage: vi.fn(),
@@ -120,7 +119,7 @@ vi.mock('../src/paths', () => ({
 import { BrowserWindow, Menu, Tray, nativeImage, nativeTheme } from 'electron';
 import { getUpdateInfo } from '../src/update';
 import { truncateMenuLabel, sanitiseLinuxLabel, cancelTrayRebuild, createTray, getMenuIcon, updateNowPlayingState, updateTrayTooltip, rebuildTrayMenu, initTrayStateManager, setGetMainWindowCallback, setSwitchServiceCallback } from '../src/tray';
-import { getCloseToTrayEnabled, getTheme, setTheme, getMusicService, setMusicService, getClassicalStartPage, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername } from '../src/config';
+import { getCloseToTrayEnabled, setTheme, getMusicService, setMusicService, getClassicalStartPage, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername } from '../src/config';
 import { downloadArtwork } from '../src/artwork';
 import { PlaybackState } from '../src/player';
 import type { NowPlayingPayload, PlayerEvents } from '../src/player';
@@ -600,7 +599,6 @@ describe('createTray - menu template inspection', () => {
     beforeEach(() => {
       setPlatform('linux');
       vi.mocked(getMusicService).mockReturnValue(UNREGISTERED_SERVICE_ID);
-      vi.mocked(getTheme).mockReturnValue('apple-music');
       vi.mocked(resolveTheme).mockReturnValue('apple-music');
       vi.mocked(hasCustomCss).mockReturnValue(false);
     });
@@ -609,7 +607,6 @@ describe('createTray - menu template inspection', () => {
     // file builds the menu in.
     afterEach(() => {
       vi.mocked(getMusicService).mockReturnValue('music');
-      vi.mocked(getTheme).mockReturnValue('apple-music');
       vi.mocked(resolveTheme).mockReturnValue('apple-music');
       vi.mocked(hasCustomCss).mockReturnValue(false);
     });
@@ -710,39 +707,64 @@ describe('createTray - menu template inspection', () => {
     });
   });
 
-  describe('Style submenu disabled on Classical', () => {
+  describe('Style submenu usable on both services', () => {
+    // The item carries no `enabled` key, so `not.toBe(false)` is the assertion:
+    // a restored gate sets it to false and fails here whatever the default is.
     beforeEach(() => {
       setPlatform('linux');
       vi.mocked(getMusicService).mockReturnValue('classical');
       vi.mocked(resolveTheme).mockReturnValue('apple-music');
       vi.mocked(hasCustomCss).mockReturnValue(false);
+      vi.mocked(setTheme).mockClear();
+      vi.mocked(applyTheme).mockClear();
     });
 
-    it('Style submenu is disabled when classical is active', () => {
-      createTray();
-      const template = getLastTemplate();
-      const styleItem = findItem(template, 'Style');
-      expect(styleItem).toBeDefined();
-      expect(styleItem!.enabled).toBe(false);
-    });
-
-    it('Style submenu is enabled when music service is active', () => {
+    // Mocks are not reset between tests, so hand back the state the rest of the
+    // file builds the menu in.
+    afterEach(() => {
       vi.mocked(getMusicService).mockReturnValue('music');
+    });
+
+    function styleItemFor(service: MusicServiceId): Electron.MenuItemConstructorOptions {
+      vi.mocked(getMusicService).mockReturnValue(service);
       createTray();
-      const template = getLastTemplate();
-      const styleItem = findItem(template, 'Style');
-      expect(styleItem!.enabled).toBe(true);
+      const item = findItem(getLastTemplate(), 'Style');
+      expect(item).toBeDefined();
+      return item!;
+    }
+
+    it('leaves the Style item selectable when classical is active', () => {
+      expect(styleItemFor('classical').enabled).not.toBe(false);
+    });
+
+    it('leaves the Style item selectable when the music service is active', () => {
+      expect(styleItemFor('music').enabled).not.toBe(false);
+    });
+
+    it('offers every theme entry on Classical', () => {
+      const submenu = styleItemFor('classical').submenu as Electron.MenuItemConstructorOptions[];
+      expect(submenu.map(item => item.label)).toEqual(['Apple Music', 'Catppuccin', 'Dracula', 'Gruvbox', 'Nord', 'Rosé Pine', 'Solarized']);
+      expect(submenu.every(item => item.enabled !== false)).toBe(true);
+    });
+
+    it('stores and applies a theme clicked on Classical', () => {
+      const submenu = styleItemFor('classical').submenu as Electron.MenuItemConstructorOptions[];
+      const nordItem = submenu.find(item => item.label === 'Nord');
+      expect(nordItem).toBeDefined();
+      (nordItem!.click as Function)();
+      expect(vi.mocked(setTheme)).toHaveBeenCalledWith('nord');
+      expect(vi.mocked(applyTheme)).toHaveBeenCalledWith('nord');
     });
   });
 
-  describe('Style submenu theme on Classical', () => {
-    // Classical injects no override CSS, so resolveTheme() reduces the stored
-    // choice to 'apple-music'. The menu must still report what is stored.
+  describe('Style submenu reflects the resolved theme', () => {
+    // The menu reads resolveTheme() on both services, so the label and the tick
+    // name the theme that will be injected. Exactly one entry is ever ticked:
+    // two ticks mean a radio group that no longer maps to a single choice.
     beforeEach(() => {
       setPlatform('linux');
       vi.mocked(getMusicService).mockReturnValue('classical');
-      vi.mocked(getTheme).mockReturnValue('dracula');
-      vi.mocked(resolveTheme).mockReturnValue('apple-music');
+      vi.mocked(resolveTheme).mockReturnValue('dracula');
       vi.mocked(hasCustomCss).mockReturnValue(false);
     });
 
@@ -750,50 +772,56 @@ describe('createTray - menu template inspection', () => {
     // file builds the menu in.
     afterEach(() => {
       vi.mocked(getMusicService).mockReturnValue('music');
-      vi.mocked(getTheme).mockReturnValue('apple-music');
       vi.mocked(resolveTheme).mockReturnValue('apple-music');
       vi.mocked(hasCustomCss).mockReturnValue(false);
     });
 
-    it('names the stored theme in the parent label', () => {
+    function tickedLabels(): (string | undefined)[] {
+      const styleItem = findItem(getLastTemplate(), 'Style');
+      const submenu = styleItem!.submenu as Electron.MenuItemConstructorOptions[];
+      return submenu.filter(item => item.checked === true).map(item => item.label);
+    }
+
+    it('names the resolved theme in the parent label on Classical', () => {
       createTray();
       const styleItem = findItem(getLastTemplate(), 'Style');
       expect(styleItem!.label).toBe('Style: Dracula');
     });
 
-    it('ticks the stored theme and nothing else', () => {
+    it('ticks the resolved theme and nothing else on Classical', () => {
       createTray();
-      const styleItem = findItem(getLastTemplate(), 'Style');
-      const submenu = styleItem!.submenu as Electron.MenuItemConstructorOptions[];
-      const ticked = submenu.filter(item => item.checked === true).map(item => item.label);
-      expect(ticked).toEqual(['Dracula']);
+      expect(tickedLabels()).toEqual(['Dracula']);
     });
 
-    it('stays disabled with a stored theme other than Apple Music', () => {
-      createTray();
-      const styleItem = findItem(getLastTemplate(), 'Style');
-      expect(styleItem!.enabled).toBe(false);
-    });
-
-    it('falls back to Apple Music when the stored custom.css is gone', () => {
-      vi.mocked(getTheme).mockReturnValue('custom');
-      createTray();
-      const styleItem = findItem(getLastTemplate(), 'Style');
-      expect(styleItem!.label).toBe('Style: Apple Music');
-      const submenu = styleItem!.submenu as Electron.MenuItemConstructorOptions[];
-      const ticked = submenu.filter(item => item.checked === true).map(item => item.label);
-      expect(ticked).toEqual(['Apple Music']);
-    });
-
-    it('follows resolveTheme rather than the stored theme on the music service', () => {
+    it('names and ticks the resolved theme on the music service', () => {
       vi.mocked(getMusicService).mockReturnValue('music');
       vi.mocked(resolveTheme).mockReturnValue('rose-pine');
       createTray();
       const styleItem = findItem(getLastTemplate(), 'Style');
       expect(styleItem!.label).toBe('Style: Rosé Pine');
+      expect(tickedLabels()).toEqual(['Rosé Pine']);
+    });
+
+    it('ticks Custom when custom.css is present and resolves to it', () => {
+      vi.mocked(resolveTheme).mockReturnValue('custom');
+      vi.mocked(hasCustomCss).mockReturnValue(true);
+      createTray();
+      const styleItem = findItem(getLastTemplate(), 'Style');
+      expect(styleItem!.label).toBe('Style: Custom');
+      expect(tickedLabels()).toEqual(['Custom']);
+    });
+
+    it('offers no Custom entry and ticks Apple Music when custom.css is gone', () => {
+      // resolveTheme() reduces a stored 'custom' to 'apple-music' once the file
+      // is unreadable, so a Custom entry here would tick nothing at all.
+      vi.mocked(resolveTheme).mockReturnValue('apple-music');
+      vi.mocked(hasCustomCss).mockReturnValue(false);
+      createTray();
+      const styleItem = findItem(getLastTemplate(), 'Style');
+      expect(styleItem!.label).toBe('Style: Apple Music');
       const submenu = styleItem!.submenu as Electron.MenuItemConstructorOptions[];
-      const ticked = submenu.filter(item => item.checked === true).map(item => item.label);
-      expect(ticked).toEqual(['Rosé Pine']);
+      expect(submenu.some(item => item.label === 'Custom')).toBe(false);
+      expect(tickedLabels()).toEqual(['Apple Music']);
     });
   });
 


### PR DESCRIPTION
Sidra forced the 'apple-music' theme (no override CSS) whenever Apple Music
Classical was active and disabled the tray Style submenu there. That gate
rested on an untested comment claiming bundled theme CSS targets the
music.apple.com DOM specifically. Both services turn out to be separate
builds of the same Svelte design system sharing a byte-identical :root
custom property block, so every token themeTemplate.ts overrides carries the
same value on Classical. This removes the gate: the six bundled themes and a
user custom.css now apply on both services, and the tray Style submenu is
enabled for Classical too.

Theme injection also moves out of injectContent() in main.ts into a new
exported injectThemeCss(contents) in theme.ts. main.ts calls
app.whenReady() at import time and cannot load under Vitest, so the move is
what makes the injection testable; behaviour is unchanged, and the two log
lines it used to emit under the main scope now emit under theme instead.

Classical's own player bar chrome stays Apple grey after this change,
because it does not consume the --player* custom properties Sidra sets.
That needs a live DOM probe and will be filed as its own follow-up; it was a
stated non-goal here.

just lint and just test (743 passed, 27 files) are clean, and a manual check
on Apple Music Classical confirmed the page background and sidebar pick up
the theme.

Refs: WW-115
