### PR TITLE
refactor(theme): drop dead selectors and properties, correct docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,17 +164,20 @@ Most Apple Music styling responds to `:root` custom property overrides. These el
 
 | Element | Selector | Reason |
 |---------|----------|--------|
-| Player bar background | `.wrapper amp-chrome-player::before` | `::before` pseudo paints the bar |
+| Player bar background | `.chrome-player::before` | The bar is transparent and the pseudo paints it, but the two services read different properties: music uses `var(--glassMaterialBackground)`, Classical uses `var(--chromePlayerBGFill)` under a `--playerGradientTop` to `--playerGradientBottom` gradient. Neither property has a consumer in the other service's bundle, so one `var()` override cannot cover both, and theming the bar means handling the fill and the gradient |
+| Player LCD box (Classical only) | `.lcd` | Paints `var(--lcd-bg-color, var(--playerLCDBGFill))`, and Classical declares `--lcd-bg-color: #4d4d4d`, so the fallback never applies |
 | Side panels (Lyrics/Up Next) | `.side-panel`, `.side-panel-header-wrapper` | Direct `background-color` |
-| Page footer | `.scrollable-page > footer` | Direct `background-color` |
+| Page footer | `.scrollable-page footer` | Direct `background-color` |
 | Accent-coloured buttons | `.button.primary button.click-action` | Direct `background-color: rgb(214, 0, 23)` ignores `--keyColor` |
 | Accent CSS variables (`--keyColor` and variants) | `*` | Shadow DOM of `amp-*` elements does not inherit from `:root` |
+
+Sidra styles neither the player bar nor the LCD box; both read a property it does not set. Every other row has an override in `src/themeTemplate.ts`.
 
 **Pattern:** when a `:root` variable override has no visible effect, the element either (a) uses a shadow-DOM-scoped custom property (set the variable on the host element), or (b) paints its own background via `::before` or a direct property (use a direct selector with `!important`).
 
 ### CSS variable audit
 
-Active Apple Music userstyle repositories provide reliable cross-referenced variable lists: PitchBlack (`sprince0031/PitchBlack-UserStyle-themes`), Native AM (`dantelin2009`), AppleMusic-Tui. Search with `mcp__exa__get_code_context_exa` using `"apple music userstyle css variables site:github.com"`.
+Active Apple Music userstyle repositories provide reliable cross-referenced variable lists: PitchBlack (`sprince0031/PitchBlack-UserStyle-themes`) and AppleMusic-Tui. Search with `mcp__exa__get_code_context_exa` using `"apple music userstyle css variables site:github.com"`.
 
 ### Asset packaging
 

--- a/src/themeTemplate.ts
+++ b/src/themeTemplate.ts
@@ -24,9 +24,9 @@ export interface SchemeColours {
   text: string;
   /** Secondary text */
   subtext1: string;
-  /** Vibrant secondary text and scrubber playhead */
+  /** Emphasised secondary text */
   subtext0: string;
-  /** Key colour: buttons, scrubber, volume, selection, loved */
+  /** Key colour: brand, selection, scrubber fill, platter buttons */
   accent: string;
   /** Accent rollover and pressed states */
   accentHover: string;
@@ -51,9 +51,8 @@ function rgba(hex: string, alpha: number): string {
   return `rgba(${rgbTriplet(hex)},${alpha})`;
 }
 
-// The original stylesheet used spaced rgba() in the shadow-DOM and
-// side-panel blocks; preserved for byte compatibility with the previous
-// catppuccin.css asset.
+// The original stylesheet used spaced rgba() in the side-panel block;
+// preserved for byte compatibility with the previous catppuccin.css asset.
 function rgbaSpaced(hex: string, alpha: number): string {
   return `rgba(${rgbTriplet(hex).split(',').join(', ')}, ${alpha})`;
 }
@@ -76,10 +75,8 @@ function schemeBlock(c: SchemeColours): string {
     --keyColor-deepPressed: ${c.accentHover} !important;
     --keyColor-disabled: ${rgba(c.accent, 0.35)} !important;
     --musicKeyColor: ${c.accent} !important;
-    --systemAccentBG: ${c.accent} !important;
     --musicBrandBG: ${c.accent} !important;
     --selectionColor: ${c.accent} !important;
-    --lovedBGColor: ${c.accent} !important;
 
     /* Text */
     --systemPrimary: ${rgba(c.text, 0.85)} !important;
@@ -100,10 +97,6 @@ function schemeBlock(c: SchemeColours): string {
     --playerLCDBGFill: ${c.surface0} !important;
     --playerScrubberFill: ${c.accent} !important;
     --playerScrubberTrack: ${rgba(c.surface1, 0.2)} !important;
-    --playerScrubberPlayhead: ${c.subtext0} !important;
-    --playerVolumeFill: ${c.accent} !important;
-    --playerVolumeTrack: ${rgba(c.surface1, 0.2)} !important;
-    --playerVolumeIconFill: ${rgba(c.subtext1, 0.5)} !important;
     --playerPlatterButtonBGFill: ${c.accent} !important;
     --playerPlatterButtonIconFill: ${c.base} !important;
     --playerDropShadow2: ${rgba(c.crust, 0.1)} !important;
@@ -145,7 +138,6 @@ function schemeBlock(c: SchemeColours): string {
 
   /* Force variables into shadow-DOM-scoped elements */
   * {
-    --playerBGFill: ${rgbaSpaced(c.mantle, 0.88)} !important;
     --keyColor: ${c.accent} !important;
     --keyColor-rgb: ${rgbTriplet(c.accent)} !important;
     --keyColor-rollover: ${c.accentHover} !important;
@@ -153,10 +145,8 @@ function schemeBlock(c: SchemeColours): string {
     --keyColor-deepPressed: ${c.accentHover} !important;
     --keyColor-disabled: ${rgba(c.accent, 0.35)} !important;
     --musicKeyColor: ${c.accent} !important;
-    --systemAccentBG: ${c.accent} !important;
     --musicBrandBG: ${c.accent} !important;
     --selectionColor: ${c.accent} !important;
-    --lovedBGColor: ${c.accent} !important;
   }
 
   /* Side panels (Lyrics + Up Next): not covered by :root variables */
@@ -173,9 +163,7 @@ function schemeBlock(c: SchemeColours): string {
   /* Footer */
   :is(
     footer,
-    .scrollable-page footer,
-    .dt-footer,
-    [class*="page-footer"]
+    .scrollable-page footer
   ) {
     background: ${c.crust} !important;
     background-color: ${c.crust} !important;
@@ -185,8 +173,7 @@ function schemeBlock(c: SchemeColours): string {
 
   :is(
     footer,
-    .scrollable-page footer,
-    .dt-footer
+    .scrollable-page footer
   ) :is(a, button, select, [role="button"], [class*="dropdown"]) {
     background-color: ${c.mantle} !important;
     border-color: ${rgba(c.surface2, 0.25)} !important;

--- a/test/themes.test.ts
+++ b/test/themes.test.ts
@@ -188,7 +188,6 @@ describe('buildThemeCss', () => {
 
       it('retains player variables and the accent button override', () => {
         expect(darkCss).toContain('--playerBackground:');
-        expect(darkCss).toContain('--playerBGFill:');
         expect(darkCss).toContain('--keyColor:');
         expect(css).toContain('.button.primary button.click-action');
         expect(css).toContain('background-color: var(--keyColor) !important;');
@@ -199,6 +198,18 @@ describe('buildThemeCss', () => {
         expect(css).not.toContain('.player-bar');
         expect(css).not.toContain('.chrome-player.chrome-player__music');
         expect(css).not.toContain('amp-lcd');
+      });
+
+      it('keeps selectors and properties Apple no longer ships out', () => {
+        expect(css).not.toContain('dt-footer');
+        expect(css).not.toContain('page-footer');
+        expect(css).not.toContain('--lovedBGColor');
+        expect(css).not.toContain('--playerBGFill');
+        expect(css).not.toContain('--playerScrubberPlayhead');
+        expect(css).not.toContain('--playerVolumeFill');
+        expect(css).not.toContain('--playerVolumeIconFill');
+        expect(css).not.toContain('--playerVolumeTrack');
+        expect(css).not.toContain('--systemAccentBG');
       });
 
       it('keeps country/location banner control styling on Apple Music defaults', () => {
@@ -232,7 +243,6 @@ describe('catppuccin regression against the retired static asset', () => {
     expect(darkCss).toContain('--keyColor-disabled: rgba(243,139,168,0.35) !important;');
     expect(darkCss).toContain('--systemPrimary: rgba(205,214,244,0.85) !important;');
     expect(darkCss).toContain('--playerBackground: rgba(24,24,37,0.88) !important;');
-    expect(darkCss).toContain('--playerBGFill: rgba(24, 24, 37, 0.88) !important;');
     expect(darkCss).toContain('scrollbar-color: #45475a #181825 !important;');
     expect(darkCss).toContain('background: #11111b !important;');
     expect(darkCss).toContain('background-color: #181825 !important;');
@@ -243,7 +253,6 @@ describe('catppuccin regression against the retired static asset', () => {
     expect(lightCss).toContain('--pageBG: #eff1f5 !important;');
     expect(lightCss).toContain('--keyColor: #d20f39 !important;');
     expect(lightCss).toContain('--playerBackground: rgba(230,233,239,0.88) !important;');
-    expect(lightCss).toContain('--playerBGFill: rgba(230, 233, 239, 0.88) !important;');
     expect(lightCss).toContain('scrollbar-color: #bcc0cc #e6e9ef !important;');
     expect(lightCss).toContain('background: #dce0e8 !important;');
     expect(lightCss).toContain('background-color: #e6e9ef !important;');


### PR DESCRIPTION
Removes generated CSS that matches nothing Apple ships: the `.dt-footer` and `[class*="page-footer"]` selectors from both footer groups in `src/themeTemplate.ts`, and seven custom properties with zero declarations and zero consumers on either service (`--lovedBGColor`, `--playerBGFill`, `--playerScrubberPlayhead`, `--playerVolumeFill`, `--playerVolumeIconFill`, `--playerVolumeTrack`, `--systemAccentBG`). A static audit of both live CSS bundles could not see shadow DOM, which is why the issue held these deletions back; a live CDP probe of classical.music.apple.com walked all four shadow roots and confirmed zero consumers, closing that gap.

AGENTS.md's "Elements outside the :root cascade" table named `.wrapper amp-chrome-player::before`, which Apple retired. It now names `.chrome-player::before` and records that the two services read different properties for it (music `var(--glassMaterialBackground)`, Classical `var(--chromePlayerBGFill)` under a gradient), plus a new row for Classical's `.lcd` box. The PitchBlack userstyle owner is corrected to sprince0031, and the dead dantelin2009 reference is dropped.

`test/themes.test.ts` drops the two `--playerBGFill` pins and adds a check that the removed selectors and properties stay out, across all six bundled themes.

`just lint` is clean and `just test` passes 749 tests across 27 files (up from 743). The footer was checked visually on both services and renders correctly themed on each. Follow-up work is filed separately: WW-118 for the dead `footer.dt-footer` rule still in `assets/styleFix.css`, and WW-117 for theming the player bar chrome.

Refs: WW-116
