### PR TITLE
fix(theme): match the player bar and LCD to the active theme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,9 +169,11 @@ Most Apple Music styling responds to `:root` custom property overrides. These el
 | Side panels (Lyrics/Up Next) | `.side-panel`, `.side-panel-header-wrapper` | Direct `background-color` |
 | Page footer | `.scrollable-page footer` | Direct `background-color` |
 | Accent-coloured buttons | `.button.primary button.click-action` | Direct `background-color: rgb(214, 0, 23)` ignores `--keyColor` |
-| Accent CSS variables (`--keyColor` and variants) | `*` | Shadow DOM of `amp-*` elements does not inherit from `:root` |
+| Accent CSS variables (`--keyColor` and variants), `--chromePlayerBGFill`, `--lcd-bg-color` | `*` | Shadow DOM of `amp-*` elements does not inherit from `:root`, and Apple declares `--lcd-bg-color` on `.lcd` itself, where an inherited value loses |
 
-Sidra styles neither the player bar nor the LCD box; both read a property it does not set. Every other row has an override in `src/themeTemplate.ts`.
+Every row has an override in `src/themeTemplate.ts`. The player bar needs two: `--chromePlayerBGFill` in the `*` block, and a direct `.chrome-player::before` rule setting `background-color` and `background-image: none`. The direct rule is what covers music, which re-declares `--glassMaterialBackground` on the pseudo itself under `.is-light-theme` and `.is-dark-theme`, where a `*` block never reaches. Do not override `--glassMaterialBackground` instead: the music bundle also reads it on the navigation bar, the mini-player, and the cloud-buttons platter. The `background-image: none` drops Classical's white gloss gradient, a fixed overlay tuned to Apple's grey that no palette can derive; Apple already drops it in dark mode.
+
+`--playerMissingArtworkBg` and `--playerMissingArtworkIcon` theme the missing-artwork placeholder from `:root`, where Apple declares them. The LCD artwork hover scrim (`--lcd-artworkHoverBGColor`) stays as Apple ships it: it carries a `#fff` icon over arbitrary artwork, so a light theme colour there would make that icon unreadable.
 
 **Pattern:** when a `:root` variable override has no visible effect, the element either (a) uses a shadow-DOM-scoped custom property (set the variable on the host element), or (b) paints its own background via `::before` or a direct property (use a direct selector with `!important`).
 

--- a/src/themeTemplate.ts
+++ b/src/themeTemplate.ts
@@ -58,6 +58,7 @@ function rgbaSpaced(hex: string, alpha: number): string {
 }
 
 function schemeBlock(c: SchemeColours): string {
+  const playerBG = rgba(c.mantle, 0.88);
   return `  :root {
     /* Background & Structure */
     --pageBG: ${c.base} !important;
@@ -92,9 +93,11 @@ function schemeBlock(c: SchemeColours): string {
     --vibrantDivider: ${rgba(c.surface2, 0.25)} !important;
 
     /* Player */
-    --playerBackground: ${rgba(c.mantle, 0.88)} !important;
+    --playerBackground: ${playerBG} !important;
     --playerBackgroundFallback: ${rgba(c.mantle, 0.97)} !important;
     --playerLCDBGFill: ${c.surface0} !important;
+    --playerMissingArtworkBg: ${c.surface1} !important;
+    --playerMissingArtworkIcon: ${c.surface2} !important;
     --playerScrubberFill: ${c.accent} !important;
     --playerScrubberTrack: ${rgba(c.surface1, 0.2)} !important;
     --playerPlatterButtonBGFill: ${c.accent} !important;
@@ -136,7 +139,8 @@ function schemeBlock(c: SchemeColours): string {
     background-color: ${c.mantle} !important;
   }
 
-  /* Force variables into shadow-DOM-scoped elements */
+  /* Force variables into shadow-DOM-scoped elements, and variables Apple
+     re-declares on the element itself */
   * {
     --keyColor: ${c.accent} !important;
     --keyColor-rgb: ${rgbTriplet(c.accent)} !important;
@@ -147,6 +151,16 @@ function schemeBlock(c: SchemeColours): string {
     --musicKeyColor: ${c.accent} !important;
     --musicBrandBG: ${c.accent} !important;
     --selectionColor: ${c.accent} !important;
+    --chromePlayerBGFill: ${playerBG} !important;
+    --lcd-bg-color: ${c.surface0} !important;
+  }
+
+  /* Player bar: the bar is transparent and its ::before paints it. Classical
+     declares the gradient on that pseudo and music re-declares its fill there,
+     so neither is reachable from the * block. */
+  .chrome-player::before {
+    background-color: ${playerBG} !important;
+    background-image: none !important;
   }
 
   /* Side panels (Lyrics + Up Next): not covered by :root variables */

--- a/test/themes.test.ts
+++ b/test/themes.test.ts
@@ -39,6 +39,15 @@ function cssVar(block: string, name: string): string {
   return match[1];
 }
 
+/** Reads the background-color of the .chrome-player::before rule. */
+function chromePlayerFill(block: string): string {
+  const match = /\.chrome-player::before \{\s*background-color: ([^;]+) !important;/.exec(block);
+  if (match === null) {
+    throw new Error('.chrome-player::before is missing its background-color');
+  }
+  return match[1];
+}
+
 function parseHex(value: string): Rgb {
   const match = CSS_HEX_RE.exec(value);
   if (match === null) {
@@ -193,8 +202,32 @@ describe('buildThemeCss', () => {
         expect(css).toContain('background-color: var(--keyColor) !important;');
       });
 
+      it('themes the player bar and the Classical LCD in both variants', () => {
+        for (const block of [darkCss, lightCss]) {
+          expect(block).toContain('.chrome-player::before');
+          expect(block).toContain('background-image: none !important;');
+          expect(block).toContain('--chromePlayerBGFill:');
+          expect(block).toContain('--lcd-bg-color:');
+          expect(block).toContain('--playerMissingArtworkBg:');
+          expect(block).toContain('--playerMissingArtworkIcon:');
+        }
+      });
+
+      it('paints the player bar with the player background value', () => {
+        for (const block of [darkCss, lightCss]) {
+          expect(chromePlayerFill(block)).toBe(cssVar(block, 'playerBackground'));
+          expect(cssVar(block, 'chromePlayerBGFill')).toBe(cssVar(block, 'playerBackground'));
+          expect(cssVar(block, 'lcd-bg-color')).toBe(cssVar(block, 'playerLCDBGFill'));
+        }
+      });
+
+      it('emits no Svelte scope hash', () => {
+        expect(css).not.toMatch(/svelte-[a-z0-9]/);
+      });
+
       it('keeps old player structural selectors out', () => {
         expect(css).not.toContain('.wrapper amp-chrome-player::before');
+        expect(css).not.toContain('amp-chrome-player');
         expect(css).not.toContain('.player-bar');
         expect(css).not.toContain('.chrome-player.chrome-player__music');
         expect(css).not.toContain('amp-lcd');


### PR DESCRIPTION
The player bar and its LCD box stayed Apple's grey while the rest of the page
picked up the theme. The bar itself is transparent; its `::before` pseudo
paints the visible fill, and Classical reads that fill from
`var(--chromePlayerBGFill)` while music reads it from
`var(--glassMaterialBackground)`. Classical also declares a white gloss
gradient on the same pseudo, and music re-declares its own fill on the
pseudo under both light and dark theme classes, so neither is reachable from
the universal `*` block alone. Fixing it needs both a `*` block entry and a
direct rule: `--chromePlayerBGFill` and `--lcd-bg-color` go into the `*`
block, and a direct `.chrome-player::before` rule sets `background-color`
and clears `background-image`. `--playerMissingArtworkBg` and
`--playerMissingArtworkIcon` go into `:root` for the missing-artwork
placeholder. All five property names were confirmed present and consumed in
Apple's live CSS bundles before this landed, which matters because the
immediately preceding PR removed seven properties that were dead.

Two things are deliberately left alone. `--glassMaterialBackground` is not
overridden, because music also reads it on the navigation bar, the
mini-player and the cloud-buttons platter, so the direct rule on
`.chrome-player::before` is the narrower fix. `--lcd-artworkHoverBGColor` is
left as Apple ships it, because it carries a white icon over arbitrary
artwork and a theme override would fight that.

AGENTS.md records this reasoning in the "Elements outside the `:root`
cascade" section. test/themes.test.ts gains three assertions per bundled
theme: the new selectors and properties are emitted in both variants, the
bar fill matches `--playerBackground` and the LCD matches
`--playerLCDBGFill`, and no Svelte scope hash reaches the output.

This is the third of three: WW-115 removed the Classical theme gate, WW-116
dropped the dead selectors and properties, and this completes the run.

`just lint` is clean and `just test` passes 767 tests across 27 files, up
from 749. Verified at a display: the bar and LCD on both services in both
OS colour schemes, and no change to music's modals, navigation bar,
mini-player or cloud-buttons platter.

Refs: WW-117
