### PR TITLE
refactor(theme): drop the dead dt-footer selector from styleFix.css

### DIFF
--- a/assets/styleFix.css
+++ b/assets/styleFix.css
@@ -24,8 +24,3 @@
   [class*="upsell-banner"] {
     display: none !important;
   }
-
-  /* Footer (not needed in desktop app) */
-  footer.dt-footer {
-    display: none !important;
-  }


### PR DESCRIPTION
`footer.dt-footer { display: none !important }` never matched anything. The class is absent from both the signed-out music.apple.com/gb HTML and the app JS bundle, while neighbouring rules in the same file target classes that do appear there (upsell-banner, native-cta), so the selector was simply wrong, not stale from a page since redesigned. Apple's footer carries footer-wrapper, footer-contents, footer-secondary-slot and footer--full-width instead.

Because the rule never applied, the footer has always rendered, and src/themeTemplate.ts already themes it. Removing the dead rule changes nothing on screen; it just drops the file that claimed to hide an element the other file was colouring. A dt-footer reference stays in test/themes.test.ts on purpose, asserting the selector stays out of generated theme CSS.

This closes a run of four footer and theme cleanups: WW-115 removed the Classical theme gate, WW-116 dropped other dead selectors and properties, WW-117 themed the player bar and LCD. Verified with `just lint` and `just test` (767 passed, 27 files), and the footer checked by eye on both services.

Refs: WW-118
