### PR TITLE
docs: polish comments across the tree

### DIFF
--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -1,8 +1,8 @@
 (function () {
   // This flag persists for the page lifetime and is never cleared. Re-injection
   // must not re-run the IIFE: the 5-second monitor inside the hook already
-  // handles MusicKit instance replacement, and re-running would install
-  // duplicate message listeners (the bug fixed in #154 / issue #153).
+  // handles MusicKit instance replacement, and re-running would install a
+  // duplicate set of message and wheel listeners.
   if (window.__sidraHookInjected) return;
   window.__sidraHookInjected = true;
 
@@ -18,9 +18,9 @@
      *
      * window.AMWrapper is installed by the preload script. It is normally there
      * before this runs, but the hook is injected into a page it does not
-     * control and cannot assume it. A throw from the eager send in
-     * attachToInstance() used to escape before the instance marker was
-     * assigned, which put the 5-second monitor into an endless re-attach loop.
+     * control and cannot assume it. The eager volume send in attachToInstance()
+     * is the most likely thrower, and every send goes through here so no path
+     * can throw on an absent bridge.
      *
      * @param {string} channel - IPC channel name
      * @param {unknown} [payload] - Channel payload
@@ -42,15 +42,15 @@
      * @returns {void}
      */
     function attachToInstance(mk) {
-      // Claimed before anything below can throw, not after. The 5-second
-      // monitor re-attaches whenever this marker does not match the live
-      // instance, so assigning it last meant any throw in between put the hook
-      // into an endless loop, adding a duplicate set of listeners every cycle -
-      // the failure #153 and #154 fixed. A part-attached instance is the lesser
-      // fault, and the catch below records it.
+      // The first statement, claimed before anything below can throw. The
+      // 5-second monitor re-attaches whenever this marker does not match the
+      // live instance, so a throw ahead of the assignment leaves it stale and
+      // the monitor adds a duplicate set of listeners on every cycle. A
+      // part-attached instance is the lesser fault, and attachSafely() logs it.
       window.__sidraHookedMk = mk;
 
-      // Clear previous volume polling timer on re-hook
+      // The previous poll closes over the replaced instance, so a re-hook must
+      // stop it rather than leave two timers reporting different volumes.
       if (volumePollTimer !== null) {
         clearInterval(volumePollTimer);
         volumePollTimer = null;
@@ -58,6 +58,12 @@
 
       /**
        * Report explicit media session position state for OS media controls.
+       *
+       * The playbackTimeDidChange listener calls this on every tick and must
+       * not debounce it: music.apple.com writes to the same MediaSession from
+       * the same world, and the repeated call keeps Sidra's value in place. It
+       * starts no debounce timer, so the project rule against debounced sends
+       * from that event still holds.
        * @returns {void}
        */
       function reportPositionState() {
@@ -96,7 +102,8 @@
             position: Math.min(position, duration),
           });
         } catch (_) {
-          // Ignore media session position state errors.
+          // A value Chromium rejects is not worth failing the listener over;
+          // the next playbackTimeDidChange tick reports again.
         }
       }
 
@@ -114,7 +121,7 @@
         try {
           navigator.mediaSession.setPositionState();
         } catch (_) {
-          // Ignore media session position state errors.
+          // Clearing is best effort; the caller has nothing else to try.
         }
       }
 
@@ -178,7 +185,10 @@
         });
       });
 
-      /** Forward playback position (in microseconds) to the main process. */
+      /**
+       * Forward playback position (in microseconds) to the main process and
+       * refresh the media session position state.
+       */
       mk.addEventListener('playbackTimeDidChange', () => {
         sendToMain('playbackTimeDidChange',
           mk.currentPlaybackTime * 1_000_000
@@ -205,13 +215,18 @@
       // Send the initial volume so MPRIS (and any other listener) receives the
       // real value immediately, not just on subsequent changes.
       sendToMain('volumeDidChange', lastVolume);
+      // playbackVolumeDidChange is the only volume event MusicKit publishes, so
+      // binding volumeDidChange leaves the listener dead. The IPC channel below
+      // keeps the volumeDidChange name, which is Sidra's own and deliberately
+      // unrelated to the MusicKit event name.
       mk.addEventListener('playbackVolumeDidChange', () => {
         lastVolume = mk.volume;
         sendToMain('volumeDidChange', mk.volume);
       });
       // Poll mk.volume every 250ms as a fallback for a volume write the hook
-      // cannot observe through playbackVolumeDidChange - what the player bar
-      // volume control writes has not been confirmed.
+      // cannot observe through playbackVolumeDidChange. What the player bar
+      // volume control writes has never been confirmed, so this stays as the
+      // second of the only two paths reporting volume.
       volumePollTimer = setInterval(() => {
         const v = mk.volume;
         if (v !== lastVolume) {
@@ -288,17 +303,21 @@
         console.warn(`[Sidra] blocked unrecognised command: "${method}"`);
         return;
       }
-      // window.__sidra is the last thing attachToInstance() assigns, and
-      // attachSafely() installs this listener even when the attach threw before
-      // reaching it, so the hook object may be absent. Index it unguarded and a
-      // TypeError escapes the listener, which is the containment attachSafely()
-      // exists to provide leaking straight back out.
+      // window.__sidra is the last thing attachToInstance() assigns, and this
+      // listener installs even when the attach threw before reaching it, so the
+      // hook object may be absent. An unguarded index would throw a TypeError
+      // straight back out of the path attachSafely() exists to contain.
       if (typeof window.__sidra?.[method] === 'function') {
         window.__sidra[method](...(args || []));
       }
     });
 
-    /** Volume change applied per wheel notch. */
+    /**
+     * Volume change applied per wheel notch. The step is fixed and never scaled
+     * by deltaY magnitude: Chromium reports a wheel and a touchpad identically
+     * as DOM_DELTA_PIXEL, so scaling gives a wheel a full-range jump and a
+     * touchpad an invisible nudge.
+     */
     const VOLUME_STEP = 0.05;
     /** Chromium's default deltaY, in pixels, for one mouse wheel notch. */
     const WHEEL_NOTCH_DELTA = 100;
@@ -315,8 +334,14 @@
      * Both services put the `chrome-volume` class token on the control, on a
      * `div` for music.apple.com and on an `amp-chrome-volume` element for
      * classical.music.apple.com, so the gate matches that token anywhere in the
-     * composed path and never the element name. Writing mk.volume reaches the
-     * main process by the existing playbackVolumeDidChange route.
+     * composed path and never the element name, which would work on Classical
+     * and silently do nothing on Apple Music. Never write a Svelte scope hash
+     * into the selector; those change on any Apple rebuild. Writing mk.volume
+     * reaches the main process by the existing playbackVolumeDidChange route.
+     *
+     * The listener is on window rather than on the control itself, because the
+     * control does not exist when the hook runs and is replaced on navigation
+     * and service switches.
      *
      * @param {WheelEvent} event - The wheel event
      */
@@ -344,16 +369,17 @@
       wheelDelta -= steps * WHEEL_NOTCH_DELTA;
 
       // Read the live volume every time: a write MusicKit drops self-corrects
-      // on the next notch. Scrolling down (positive deltaY) lowers the volume.
+      // on the next notch. Scrolling down (positive deltaY) lowers the volume,
+      // and the result is clamped because MusicKit throws outside 0 to 1.
       const volume = hookedMk.volume - steps * VOLUME_STEP;
       hookedMk.volume = Math.min(1, Math.max(0, Math.round(volume * 100) / 100));
     }, { passive: false });
 
     console.log('[Sidra] MusicKit hooked successfully');
 
-    // Monitor for MusicKit instance replacement every 5 seconds.
-    // Apple Music may internally re-create the MusicKit instance during a
-    // session; this detects the change and re-attaches listeners.
+    // Apple Music may re-create the MusicKit instance during a session, which
+    // raises no event, so the replacement is only visible by comparing the live
+    // instance against the marker.
     setInterval(() => {
       try {
         const currentMk = MusicKit.getInstance();

--- a/assets/navigationBar.js
+++ b/assets/navigationBar.js
@@ -1,8 +1,14 @@
+// Back, forward and reload buttons for the Apple Music sidebar header. The web
+// UI has no need for them; a desktop window with no browser chrome does.
 (function () {
+  // The script runs on every page load and on SPA navigation, which can keep
+  // the existing header, so bail out rather than add a second set of buttons.
   if (document.getElementById('sidra-nav-buttons')) return;
 
-  // Replaced with a JSON object when src/main.ts reads this file. The script is
-  // injected with executeJavaScript(), so it cannot take query parameters.
+  // Not standalone-executable JavaScript: loadAssets() in src/main.ts replaces
+  // this bare token with the translated labels as JSON, because the script is
+  // injected with executeJavaScript() and cannot take the query parameters the
+  // splash screen uses. NAV_LABELS_TOKEN in src/i18n.ts is the shared spelling.
   /** @type {{ back: string, forward: string, reload: string }} */
   var LABELS = __SIDRA_NAV_LABELS__;
 
@@ -12,6 +18,8 @@
     return;
   }
 
+  // The buttons are appended to the logo row, so it has to lay out as a flex
+  // container before the margin-left: auto below can push them to the right.
   logoEl.setAttribute('style', [
     'display: flex !important',
     'align-items: center !important',

--- a/build/afterPack.cjs
+++ b/build/afterPack.cjs
@@ -2,10 +2,15 @@
 
 /**
  * afterPack hook: signs the packaged app with CastLabs EVS production VMP keys.
+ * electron-builder runs it from the "build.afterPack" key in package.json.
  *
- * VMP signing must happen BEFORE macOS code-signing (afterPack, not afterSign).
- * Without production VMP keys, Widevine refuses DRM licences on macOS.
+ * VMP signing must happen BEFORE macOS code-signing, which is why this is an
+ * afterPack hook and not afterSign. Without production VMP keys, Widevine
+ * refuses DRM licences on macOS.
  * Linux does not enforce VMP so this hook is a no-op there.
+ *
+ * Absent EVS credentials the signing is skipped rather than failed, so a
+ * contributor without an EVS account can still produce an unsigned build.
  *
  * Setup: uvx --from castlabs-evs evs-account signup
  * Docs:  https://github.com/castlabs/electron-releases/wiki/EVS

--- a/scripts/inject-lastfm-credentials.cjs
+++ b/scripts/inject-lastfm-credentials.cjs
@@ -1,8 +1,11 @@
 // Writes assets/lastfm-credentials.json from the SIDRA_LASTFM_API_KEY and
 // SIDRA_LASTFM_API_SECRET environment variables. It runs from npm's `prebuild`
 // hook and from the `build` recipe in the justfile, because `npx tsc` fires no
-// npm hook. In CI the env vars come from repository secrets; with no env set
-// the file is written empty and the integration stays inert.
+// npm hook. In CI the env vars come from repository secrets.
+//
+// With no env set the file is written empty rather than left absent, because
+// it is named in asarUnpack and packaging fails on a missing entry; an empty
+// key leaves the integration inert and the tray hides Last.fm entirely.
 //
 // An existing file that already holds credentials is left alone when the env is
 // unset, so building in a shell without the vars does not blank a working

--- a/scripts/update-electron-toolchain.cjs
+++ b/scripts/update-electron-toolchain.cjs
@@ -1,10 +1,21 @@
 #!/usr/bin/env node
 "use strict";
 
+// Points package.json at the newest CastLabs Electron, electron-builder and
+// electron-updater releases. The "Update Electron Toolchain" workflow runs it
+// weekly and opens a pull request when package.json changed; it installs
+// nothing and builds nothing itself.
+//
+// Versions are read from git tags rather than the npm registry because the
+// Widevine-enabled Electron ships from castlabs/electron-releases and is
+// depended on as a GitHub tag, so the registry does not know about it.
+
 const { execFileSync } = require("node:child_process");
 const fs = require("node:fs");
 
 const packageJsonPath = "package.json";
+// Anchored on the +wvcus suffix: that is the Widevine CDM variant Sidra needs
+// for DRM playback, and the bare version triplet keeps prereleases out.
 const castLabsStableTagPattern = /^v(\d+)\.(\d+)\.(\d+)\+wvcus$/;
 const electronBuilderRepo = "https://github.com/electron-userland/electron-builder.git";
 
@@ -42,6 +53,9 @@ function latestCastLabsElectronTag() {
     "refs/tags/v*+wvcus",
   ]);
 
+  // git ls-remote lists an annotated tag twice, the second ref carrying a ^{}
+  // suffix for the commit it dereferences to, so those refs are dropped to
+  // leave one entry per release.
   const latest = refs
     .split(/\r?\n/)
     .map((line) => line.split(/\s+/)[1])
@@ -59,6 +73,9 @@ function latestCastLabsElectronTag() {
   return latest.tag;
 }
 
+// electron-builder and electron-updater are released from one monorepo whose
+// tags are prefixed "<package>@", so both versions come from the same remote
+// and the pattern has to be built per package.
 function latestElectronBuilderTag(packageName) {
   const tagPattern = new RegExp(`^${packageName}@(\\d+)\\.(\\d+)\\.(\\d+)$`);
   const refs = run("git", [
@@ -91,6 +108,9 @@ function latestElectronBuilderTag(packageName) {
   return latest.tag.replace(`${packageName}@`, "");
 }
 
+// Throws on an absent key rather than creating one: a dependency that moved
+// section or was renamed should fail the workflow, not gain a second entry in
+// the section this script expected it in.
 function setDependency(packageJson, section, name, value) {
   if (packageJson[section]?.[name] === undefined) {
     throw new Error(`${section}.${name} is missing from package.json`);

--- a/scripts/validate-build-config.cjs
+++ b/scripts/validate-build-config.cjs
@@ -1,3 +1,7 @@
+// Checks the electron-builder configuration before a packaging run. `just
+// validate` runs it locally and the test-config job in builder.yml runs it in
+// CI, so a fault is named here rather than surfacing later as an installer that
+// builds but misbehaves.
 const fs = require("fs");
 const path = require("path");
 
@@ -7,11 +11,16 @@ function main() {
   // 1. The whole electron-builder config lives in package.json under "build",
   //    so reading that file reads the whole config. electron-builder exposes no
   //    public API for loading or schema-validating it, so no schema pass runs.
+  //    Do not reach into app-builder-lib/out/... for its internal validator: a
+  //    compiled internal path breaks on a dependency bump and is then reported
+  //    as a module-not-found error rather than as anything about the config.
   const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, "package.json"), "utf8"));
   const config = pkg.build ?? {};
   console.log("  \u2713 electron-builder config: read from package.json \"build\" (no schema check; electron-builder exposes no public validator)");
 
-  // 2. Check for deprecated options
+  // 2. Options electron-builder has dropped or renamed. Each error names the
+  //    replacement, because a setting that is no longer read shows up only as
+  //    an installer missing the behaviour it was meant to configure.
   if (config.npmSkipBuildFromSource === false) {
     throw new Error("npmSkipBuildFromSource is deprecated; use buildDependenciesFromSource");
   }
@@ -73,7 +82,10 @@ function main() {
     //    extra whitespace or a flag reordered ahead of the member stays
     //    harmless while the four parts that decide whether the launcher control
     //    works are all pinned: the command, the destination, the object path
-    //    and the member, which must be the final token.
+    //    and the member, which must be the final token. Do not replace this
+    //    with includes() over the whole string, which passes a wrong object
+    //    path, a suffixed member and a trailing argument alike, nor with
+    //    equality against one expected command, which fails on formatting.
     const exec = typeof action.Exec === "string" ? action.Exec : "";
     const tokens = exec.split(/\s+/).filter((token) => token !== "");
     const command = tokens.shift() ?? "";

--- a/src/aboutWindow.ts
+++ b/src/aboutWindow.ts
@@ -11,6 +11,7 @@ const aboutLog = log.scope('about');
 
 let aboutWindow: BrowserWindow | null = null;
 
+/** Show the About window, or focus the one already open. */
 export function showAboutWindow(): void {
   if (aboutWindow) {
     aboutWindow.focus();
@@ -18,6 +19,8 @@ export function showAboutWindow(): void {
   }
 
   aboutLog.info('showing About window');
+  // The window is not resizable, so its size must scale with the zoom factor
+  // applied to the contents or the page is clipped
   const zoomFactor = getZoomFactor();
   aboutWindow = new BrowserWindow({
     width: Math.round(ABOUT_WINDOW_WIDTH_PX * zoomFactor),
@@ -37,6 +40,7 @@ export function showAboutWindow(): void {
     },
   });
 
+  // Held back until the page has rendered, so the window never flashes empty
   aboutWindow.once('ready-to-show', () => {
     aboutWindow?.webContents.setZoomFactor(getZoomFactor());
     aboutWindow?.show();
@@ -50,6 +54,8 @@ export function showAboutWindow(): void {
   const trayStrings = getTrayStrings();
   const aboutStrings = getAboutStrings();
 
+  // The page is sandboxed with no preload, so every string and every product
+  // detail reaches it as a query parameter
   aboutWindow.loadFile(getAssetPath('assets', 'about.html'), {
     query: {
       name: info.productName,

--- a/src/artwork.ts
+++ b/src/artwork.ts
@@ -19,6 +19,11 @@ function cleanupTmpFile(tmpPath: string): void {
   fsPromises.unlink(tmpPath).catch(() => {});
 }
 
+// The filename carries the size token from the final path segment beside the
+// UUID, because Apple serves every size of one artwork under the same UUID and
+// the UUID alone would collide. SIZE_REGEX is anchored so a segment such as
+// mzl.abc123x456.jpg cannot be read as a size. A URL that parses but carries no
+// UUID falls back to a hash of the whole URL.
 const UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
 const SIZE_REGEX = /^\d+x\d+/;
 
@@ -39,15 +44,26 @@ function artworkCachePath(url: string): string {
 
 const inFlight = new Map<string, Promise<string | null>>();
 
+/**
+ * Download artwork into the cache directory and resolve its local path, or null
+ * when the download fails.
+ *
+ * Callers in flight for the same URL share one promise. Notifications, MPRIS and
+ * the tray all ask for the same artwork on a track change and all three run at
+ * once on Linux, so without this each change costs three fetches, three temp
+ * files and three renames onto one destination; on Windows a later rename can
+ * fail with EPERM while the tray holds the destination open. The key is the URL,
+ * not the cache path, because the URL is what the callers share.
+ */
 export function downloadArtwork(url: string): Promise<string | null> {
   const existing = inFlight.get(url);
   if (existing) {
     return existing;
   }
 
-  // The .finally() is attached before any caller sees the promise, so the entry is
-  // deleted ahead of every continuation and a call made after an await refetches
-  // instead of reusing a settled promise
+  // The .finally() is attached before any caller sees the promise, so the entry
+  // is deleted ahead of every continuation: a failure is never cached, and a
+  // call made after an await refetches instead of replaying a settled promise
   const pending = fetchArtwork(url).finally(() => {
     inFlight.delete(url);
   });
@@ -60,6 +76,9 @@ async function fetchArtwork(url: string): Promise<string | null> {
 
   if (fs.existsSync(filepath)) {
     artworkLog.debug('cache hit: %s', filepath);
+    // Touching mtime keeps the seven day sweep in cleanArtworkCache() from
+    // evicting artwork in daily use. Never awaited: a notification is waiting
+    // on the other end of this call
     const now = new Date();
     fsPromises.utimes(filepath, now, now).catch(() => {});
     return filepath;
@@ -67,6 +86,8 @@ async function fetchArtwork(url: string): Promise<string | null> {
 
   fs.mkdirSync(ARTWORK_CACHE_DIR, { recursive: true });
 
+  // Download to a temp file and rename, so a half-written file can never be
+  // read back as a cache hit
   const tmpPath = filepath + '.' + Date.now() + '.tmp';
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), ARTWORK_DOWNLOAD_TIMEOUT_MS);
@@ -119,6 +140,10 @@ async function fetchArtwork(url: string): Promise<string | null> {
   }
 }
 
+/**
+ * Evict cached artwork untouched for seven days. Run once at startup and left
+ * unawaited, so a slow directory never delays the window.
+ */
 export async function cleanArtworkCache(): Promise<void> {
   let entries: string[];
   try {

--- a/src/autoUpdate.ts
+++ b/src/autoUpdate.ts
@@ -7,6 +7,13 @@ import { setUpdateReady } from './update';
 
 const autoUpdateLog = log.scope('autoUpdate');
 
+/**
+ * True only where Sidra owns the install: an AppImage or a packaged Windows
+ * NSIS build. Every other target is updated by its package manager, so the
+ * updater must stay out of the way there and src/update.ts notifies instead.
+ * app-update.yml ships in every packaged build, so this runtime check is what
+ * keeps electron-updater from starting on deb, rpm and Nix.
+ */
 export function isAutoUpdateSupported(): boolean {
   if (process.env.SIDRA_DISABLE_AUTO_UPDATE === '1') {
     autoUpdateLog.info('auto-update disabled via SIDRA_DISABLE_AUTO_UPDATE');
@@ -40,19 +47,31 @@ export function isAutoUpdateSupported(): boolean {
   return false;
 }
 
+/** Install a downloaded update and restart. Only reachable once one is ready. */
 export function quitAndInstall(): void {
-  // electron-updater is lazy-required so it never loads on unsupported platforms
+  // electron-updater is lazy-required, never imported at module level, so it
+  // never loads on a platform that does not support it
   const { autoUpdater } = require('electron-updater');
   autoUpdater.quitAndInstall();
 }
 
+/**
+ * Check for an update and download it. Call only when isAutoUpdateSupported()
+ * is true. A finished download rebuilds the tray menu, raises a notification,
+ * and offers a restart.
+ */
 export async function initAutoUpdate(tray: Tray, rebuildMenu: (tray: Tray) => void): Promise<void> {
-  // electron-updater is lazy-required so it never loads on unsupported platforms
+  // electron-updater is lazy-required, never imported at module level, so it
+  // never loads on a platform that does not support it
   const { autoUpdater } = require('electron-updater');
 
+  // electron-updater's own logger is off; this module logs under its own scope,
+  // which is what makes an updater load on deb, rpm or Nix visible in the log
   autoUpdater.logger = null;
   autoUpdater.autoDownload = true;
 
+  // Windows builds are unsigned, so the signature check would reject every
+  // update Sidra publishes
   if (process.platform === 'win32') {
     autoUpdater.verifyUpdateCodeSignature = false;
   }
@@ -98,6 +117,7 @@ export async function initAutoUpdate(tray: Tray, rebuildMenu: (tray: Tray) => vo
   });
 
   autoUpdater.on('error', (error: Error) => {
+    // A repository with no release yet is a normal state, not a fault
     if (error.message.includes('No published versions')) {
       autoUpdateLog.info('no published releases found; skipping update check');
     } else {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@
  * read or written; nothing else touches the store directly. Each key gets a
  * getter/setter pair, and the schema carries no defaults: a default lives in
  * the getter that needs one, so keys such as storefront can still report
- * "never set" and drive the fallback chain in src/main.ts.
+ * "never set" and drive the fallback chain in src/storefront.ts.
  */
 import log from 'electron-log/main';
 import type { ThemeName } from './theme';

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,10 @@
+/**
+ * Typed wrapper around electron-conf and the single place persistent state is
+ * read or written; nothing else touches the store directly. Each key gets a
+ * getter/setter pair, and the schema carries no defaults: a default lives in
+ * the getter that needs one, so keys such as storefront can still report
+ * "never set" and drive the fallback chain in src/main.ts.
+ */
 import log from 'electron-log/main';
 import type { ThemeName } from './theme';
 import {
@@ -42,11 +49,17 @@ import { Conf } from 'electron-conf/main';
 
 const store = new Conf<StoreSchema>();
 
+/** Reads a key, or the caller's default when the user has never set it. */
 function getConfigValue<K extends keyof StoreSchema>(key: K, defaultValue: StoreSchema[K]): StoreSchema[K] {
   if (!store.has(key)) return defaultValue;
   return store.get(key);
 }
 
+/**
+ * Reads a key and returns undefined when it has never been set, for the keys
+ * where absence means something: an unset storefront defers to the system
+ * locale, while a stored null is the user's own choice.
+ */
 function getConfigValueOptional<K extends keyof StoreSchema>(key: K): StoreSchema[K] | undefined {
   if (!store.has(key)) return undefined;
   return store.get(key);

--- a/src/contentReady.ts
+++ b/src/contentReady.ts
@@ -2,6 +2,13 @@
 // The Stencil hydrated attribute on the playback control marks the first render, so JS has executed and chrome is interactive.
 export const CONTENT_READY_SELECTOR = '[data-testid="app-container"] amp-playback-controls-play[hydrated]';
 
+/**
+ * Build the expression main.ts runs with executeJavaScript() to poll a loading
+ * page. It returns a boolean and touches nothing, so it is safe to repeat until
+ * the chrome is interactive and the splash can be dismissed. The selector comes
+ * in as a parameter because each entry in the music service registry carries its
+ * own, and JSON.stringify() quotes it so its own quotes cannot end the literal.
+ */
 export function contentReadyProbeScript(selector: string = CONTENT_READY_SELECTOR): string {
   return `!!document.querySelector(${JSON.stringify(selector)})`;
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -26,17 +26,17 @@ function loadLocaleFile(filename: string): TranslationFile {
   }
 }
 
-// Module-level readFileSync calls are intentional here. The AGENTS.md guideline
-// about avoiding synchronous reads targets conditional platform modules, not
-// data-loading modules like this one. These reads must complete before the first
-// window renders, the locale files total under 5KB, and each read finishes in
-// under 1ms.
+// Read synchronously at module load, because the splash screen needs its string
+// before the first window renders and there is no point at which these files are
+// not wanted. The four together are a few kilobytes. The lazy-require rule in
+// AGENTS.md covers platform modules that must never load at all, which is a
+// different problem.
 const loadingData = loadLocaleFile('loading.json');
 const trayData = loadLocaleFile('tray.json');
 const aboutData = loadLocaleFile('about.json');
 const updateData = loadLocaleFile('update.json');
 
-// --- Re-export translation records (preserves existing import paths) ---
+// --- Translation records, re-exported so importers name a record, not a file ---
 
 export const LOADING_TEXT: Record<string, string> = loadingData.LOADING_TEXT;
 
@@ -97,6 +97,8 @@ const ZOOM_175 = '175%';
 const ZOOM_200 = '200%';
 
 // --- Cached system language list ---
+// Cached because every tray rebuild resolves the whole string set. A system
+// language changed mid-session therefore takes effect on the next launch
 let _cachedLangs: string[] | null = null;
 function getSystemLanguages(): string[] {
   if (!_cachedLangs) _cachedLangs = app.getPreferredSystemLanguages();
@@ -104,6 +106,12 @@ function getSystemLanguages(): string[] {
 }
 
 // --- Generic locale resolution ---
+
+/**
+ * Resolve one record against the caller's ordered language list: an exact BCP 47
+ * tag first, then the base language, so en-GB falls to en. English is the last
+ * resort, which every record must therefore carry.
+ */
 export function getLocalizedString(
   record: Record<string, string>,
   langs: string[],
@@ -125,6 +133,10 @@ function getLocalizedEntry(
 
 // --- Public API (uses Electron app internally) ---
 
+/**
+ * The Apple Music storefront path segment, taken from the region rather than the
+ * language: a Welsh or Gaelic UI in the United Kingdom still shops in gb.
+ */
 export function getStorefront(): string {
   const code = app.getLocaleCountryCode().toLowerCase();
   if (code) {
@@ -135,6 +147,10 @@ export function getStorefront(): string {
   return 'us';
 }
 
+/**
+ * The splash screen string, with the tag it resolved to. The splash needs the
+ * tag as well as the text, because Arabic and Hebrew switch it to right to left.
+ */
 export function getLoadingText(): { text: string; lang: string } {
   const langs = getSystemLanguages();
   const { value: text, lang } = getLocalizedEntry(LOADING_TEXT, langs);
@@ -183,6 +199,11 @@ export interface TrayStrings {
   closeToTray: string;
 }
 
+/**
+ * Every tray label in one object, resolved once per menu rebuild. Labels that
+ * name the app carry a {name} placeholder rather than the word "Sidra", so a
+ * translation cannot hardcode it and the product name stays in package.json.
+ */
 export function getTrayStrings(): TrayStrings {
   const langs = getSystemLanguages();
   const productName: string = getProductInfo().productName;
@@ -207,7 +228,7 @@ export function getTrayStrings(): TrayStrings {
   const on = getLocalizedString(ON_TEXT, langs);
   const off = getLocalizedString(OFF_TEXT, langs);
   const style = getLocalizedString(STYLE_TEXT, langs);
-  const styleAppleMusic = 'Apple Music';
+  const styleAppleMusic = 'Apple Music'; // A brand name, so never translated
   const zoom = getLocalizedString(ZOOM_TEXT, langs);
   const zoom100 = ZOOM_100;
   const zoom125 = ZOOM_125;

--- a/src/integrations/discord-presence/index.ts
+++ b/src/integrations/discord-presence/index.ts
@@ -23,6 +23,9 @@ function truncate(s: string, max: number): string {
   return s.slice(0, max - 1) + '\u2026';
 }
 
+// Discord rejects an activity string shorter than MIN_STRING_LEN, and the
+// refusal costs the whole update, so a one-character track title is padded
+// with zero-width spaces instead.
 function padMin(s: string, min: number): string {
   while (s.length < min) {
     s += '\u200b';
@@ -171,6 +174,8 @@ function sendActivity(): void {
     buttons,
   };
 
+  // Discord draws the progress bar from absolute timestamps, so the start is
+  // back-dated by the current playhead and the end sits one duration past it.
   const snap = playerRef!.playbackSnapshot();
   if (snap.isPlaying && durationMs > 0) {
     const currentPositionMs = snap.positionUs / 1000;
@@ -205,6 +210,7 @@ function scheduleReconnect(): void {
   }, delay);
 }
 
+/** Turns presence on from the tray toggle; connects if the client is idle. */
 export function enable(): void {
   if (!client) return;
   if (!client.isConnected) {
@@ -216,11 +222,13 @@ export function enable(): void {
   }
 }
 
+/** Turns presence off from the tray toggle; clears the activity and drops every timer. */
 export function disable(): void {
   if (!client) return;
   disconnectClient();
 }
 
+/** Starts the presence client and mirrors player events into a Discord activity. */
 export function init(ctx: IntegrationContext): void {
   const { player } = ctx;
   playerRef = player;
@@ -253,7 +261,8 @@ export function init(ctx: IntegrationContext): void {
       trackUrl = payload.url;
     }
 
-    // Cancel pause timer on new track
+    // A track change supersedes an earlier pause, so the pending clear-activity
+    // timer must not fire over the new track
     pauseTimeout.cancel();
 
     scheduleUpdate();

--- a/src/integrations/lastfm/index.ts
+++ b/src/integrations/lastfm/index.ts
@@ -355,9 +355,10 @@ function foldPlayTime(): void {
 }
 
 /**
- * Cancels any in-progress auth flow. Bumping the generation invalidates in-flight
- * `apiCall` promises so a late response cannot reconnect the user, clears the poll
- * timer, and resets `authInProgress` so a fresh attempt is not blocked.
+ * Cancels any auth flow in progress. Bumping the generation sends every
+ * in-flight auth response back at its own guard, so a late one cannot reconnect
+ * the user. The poll timer is cleared and `authInProgress` released, so a fresh
+ * attempt is not blocked by the one abandoned.
  */
 function cancelAuth(): void {
   authGeneration += 1;
@@ -368,6 +369,11 @@ function cancelAuth(): void {
   authInProgress = false;
 }
 
+/**
+ * The single gate every request path checks: credentials in the build, the
+ * feature on, an account connected, and a track worth naming. A build without
+ * credentials therefore never reaches Last.fm at all.
+ */
 function active(): boolean {
   return isConfigured() && getLastfmEnabled() && !!getLastfmSessionKey() && !!artist && !!track;
 }
@@ -534,6 +540,11 @@ function flushPendingScrobbles(sessionKey: string): void {
     });
 }
 
+/**
+ * Tells Last.fm what is playing now, on every track start and resume. Its
+ * success is also one of the two places a queued backlog goes out, because a
+ * request the user's own playback triggered is the only thing that drains it.
+ */
 function sendNowPlaying(): void {
   if (!active()) return;
   const sessionKey = getLastfmSessionKey()!;
@@ -594,6 +605,10 @@ function playbackReachedThreshold(): boolean {
   return snapshot.positionUs / 1000 + POSITION_TOLERANCE_MS >= threshold;
 }
 
+/**
+ * Submits the current track as a play. Reached from the armed timer and from
+ * `armScrobbleTimer()` when the threshold is already behind the playhead.
+ */
 function doScrobble(): void {
   clearScrobbleTimer();
   if (scrobbled || !active()) return;
@@ -657,6 +672,12 @@ function doScrobble(): void {
     });
 }
 
+/**
+ * Waits out the play time the track still owes before it can be scrobbled.
+ * `accumulatedMs` already holds the time banked before the last pause, so a
+ * resume waits only for the remainder, and a threshold met while paused
+ * submits at once rather than waiting a second time.
+ */
 function armScrobbleTimer(): void {
   clearScrobbleTimer();
   if (scrobbled || !active()) return;
@@ -670,6 +691,12 @@ function armScrobbleTimer(): void {
   scrobbleTimer = setTimeout(doScrobble, remaining);
 }
 
+/**
+ * Adopts a new track and clears every counter the previous one left behind.
+ * `positionReported` goes with them, so the playhead cannot be trusted again
+ * until the player reports a position for this track: see
+ * `playbackReachedThreshold()`.
+ */
 function resetTrack(payload: NowPlayingPayload | null): void {
   clearScrobbleTimer();
   artist = payload?.artistName ?? null;
@@ -696,6 +723,10 @@ function markPlaybackStarted(): void {
   armScrobbleTimer();
 }
 
+/**
+ * Starts scrobbling for playback that is already under way, so turning the
+ * feature on mid-track counts that track rather than waiting for the next one.
+ */
 export function enable(): void {
   if (!isConfigured()) {
     lastfmLog.warn('enabled but no API credentials configured; scrobbling is inert');
@@ -707,6 +738,11 @@ export function enable(): void {
   lastfmLog.info('scrobbling enabled');
 }
 
+/**
+ * Stops scrobbling but keeps the track state. The play time banked so far is
+ * folded first, so turning the feature back on mid-track resumes the count
+ * instead of starting it over.
+ */
 export function disable(): void {
   clearScrobbleTimer();
   foldPlayTime();
@@ -766,6 +802,13 @@ export function startAuth(onComplete?: () => void): void {
     });
 }
 
+/**
+ * Asks for the session until the user approves the token in their browser.
+ * Last.fm offers no callback, so each refusal reschedules the next attempt and
+ * the whole flow gives up at `AUTH_POLL_TIMEOUT_MS`. Every response returns at
+ * the generation guard once `cancelAuth()` has run, so an abandoned flow cannot
+ * connect an account behind the user's back.
+ */
 function pollForSession(token: string, startedAt: number, generation: number, onComplete?: () => void): void {
   apiCall({ method: 'auth.getSession', api_key: API_KEY, token }, false)
     .then((res) => {
@@ -800,6 +843,11 @@ function pollForSession(token: string, startedAt: number, generation: number, on
     });
 }
 
+/**
+ * Forgets the account: the stored session, the queued plays and the enabled
+ * flag all go. Called from the tray, and from `handleInvalidSession()` when
+ * Last.fm rejects the key the user revoked at their end.
+ */
 export function disconnect(): void {
   cancelAuth();
   disable();
@@ -816,6 +864,11 @@ export function disconnect(): void {
   lastfmLog.info('disconnected from Last.fm');
 }
 
+/**
+ * Subscribes to the three player events scrobbling needs, and releases them on
+ * `will-quit`. The module runs on every platform and stays inert without
+ * credentials, so no gate keeps it out of a build.
+ */
 export function init(ctx: IntegrationContext): void {
   playerRef = ctx.player;
   getWindow = ctx.getMainWindow ?? (() => null);

--- a/src/integrations/macos-dock/index.ts
+++ b/src/integrations/macos-dock/index.ts
@@ -13,6 +13,7 @@ const DOCK_PAUSE_TIMEOUT_MS = 30_000;
 let sendCommandCallback: ((channel: ReceiveChannel, ...args: unknown[]) => void) | null = null;
 let getMainWindowCallback: (() => BrowserWindow | null) | null = null;
 
+/** Supplies the main-process sender the dock menu items use to reach the renderer. */
 export function setDockSendCommandCallback(callback: (channel: ReceiveChannel, ...args: unknown[]) => void): void {
   sendCommandCallback = callback;
 }
@@ -33,7 +34,6 @@ function buildDockMenu(
     items.push({ label: nowPlayingText, enabled: false });
     items.push({ type: 'separator' });
 
-    // Share item using ShareMenu
     const shareUrl = getShareUrl(payload);
     if (shareUrl) {
       items.push({
@@ -79,6 +79,7 @@ function clearDockProgressBar(): void {
   clearProgressBar(win);
 }
 
+/** Installs the macOS dock menu and progress bar; no-op on every other platform. */
 export function init(ctx: IntegrationContext): void {
   if (process.platform !== 'darwin') return;
 
@@ -155,7 +156,8 @@ export function init(ctx: IntegrationContext): void {
     dockPauseTimer.destroy();
   });
 
-  // Initialise with empty dock menu
+  // The menu must exist before playback starts, so the dock carries the
+  // Not Playing entry from launch rather than nothing at all
   rebuildDock(false);
   dockLog.info('dock menu initialised');
 }

--- a/src/integrations/mpris/index.ts
+++ b/src/integrations/mpris/index.ts
@@ -15,7 +15,13 @@ const {
 } = dbus.interface;
 const { Variant } = require('@holusion/dbus-next');
 
+// How close an incoming volume has to be to one this interface set for it to
+// count as that value echoing back rather than as a change made in the app.
 const VOLUME_ECHO_TOLERANCE = 0.01;
+// How many unmatched `set Volume` values are tracked at once. A drag issues a
+// burst of sets inside one echo round trip, and a single slot leaves all but
+// the newest untracked: their echoes then read as in-app changes and pull the
+// cached volume back behind the level the player has actually reached.
 const MAX_PENDING_VOLUMES = 8;
 const MS_TO_US = 1000;
 
@@ -23,6 +29,10 @@ const mprisLog = log.scope('mpris');
 
 const MPRIS_PATH = '/org/mpris/MediaPlayer2';
 
+/**
+ * The `org.mpris.MediaPlayer2` root interface: how Sidra identifies itself to
+ * media clients, and the two window actions the spec puts here.
+ */
 class MediaPlayer2 extends Interface {
   private _getMainWindow: () => BrowserWindow | null;
 
@@ -117,6 +127,8 @@ MediaPlayer2.configureMembers({
 
 const NO_TRACK = '/org/mpris/MediaPlayer2/TrackList/NoTrack';
 
+// `mpris:trackid` is a D-Bus object path ('o'), whose elements accept only
+// [A-Za-z0-9_]. An Apple identifier carrying anything else fails to marshal.
 function sanitiseTrackId(trackId: string): string {
   return trackId.replace(/[^A-Za-z0-9_]/g, '_');
 }
@@ -128,6 +140,10 @@ function buildTrackId(rawId: string): string {
 
 function buildMetadata(payload: NowPlayingPayload): Record<string, InstanceType<typeof Variant>> {
   const trackId = buildTrackId(payload.trackId ?? 'unknown');
+  // MusicKit leaves `attributes.url` unset on a library item, so `xesam:url`
+  // comes from getShareUrl(), which rebuilds the link from the catalogue id.
+  // Radio and Classical playParams carry no such id, so it returns undefined
+  // there and the key is left out.
   const trackUrl = getShareUrl(payload);
 
   const metadata: Record<string, InstanceType<typeof Variant>> = {
@@ -183,6 +199,12 @@ function buildMetadata(payload: NowPlayingPayload): Record<string, InstanceType<
   return metadata;
 }
 
+/**
+ * The `org.mpris.MediaPlayer2.Player` interface. Property values are cached
+ * here rather than read on demand: D-Bus asks for them at any moment, and the
+ * renderer can only be reached asynchronously. Player events write the cache,
+ * and control methods travel the other way as IPC to the hook.
+ */
 class MediaPlayer2Player extends Interface {
   private _getMainWindow: () => BrowserWindow | null;
 
@@ -202,8 +224,12 @@ class MediaPlayer2Player extends Interface {
   private _lastPositionUs = 0;
   private _lastPositionTimestamp = Date.now();
 
-  // Volume suppression state - prevents feedback loops when MPRIS sets volume
-  private readonly _volumeSafetyMs = 2000; // safety timeout to prevent permanent suppression
+  // Volume echo suppression state. A `set Volume` reaches MusicKit, which
+  // reports the new level straight back, and treating that report as an in-app
+  // change would loop. The safety timeout drops the whole queue, so an echo
+  // that never arrives cannot suppress volume changes for the rest of the
+  // session.
+  private readonly _volumeSafetyMs = 2000;
   private _pendingVolumes: number[] = [];
   private _volumeSafetyTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -224,6 +250,14 @@ class MediaPlayer2Player extends Interface {
     }
   }
 
+  /**
+   * Coalesces property changes into one `PropertiesChanged` signal. dbus-next
+   * emits nothing of its own accord, so a cached property that changes without
+   * passing through here is one no client ever learns about.
+   *
+   * `Position` must never be among the properties: the MPRIS spec excludes it,
+   * and clients read the property or follow `Seeked` instead.
+   */
   private _schedulePropertyEmission(properties: Record<string, unknown>): void {
     Object.assign(this._pendingChanges, properties);
     if (this._debounceTimer) {
@@ -247,7 +281,12 @@ class MediaPlayer2Player extends Interface {
   updatePlaybackStatus(payload: PlaybackStatePayload): void {
     if (!payload) return;
 
-    // MusicKit PlaybackStates
+    // Only Playing and Paused have an MPRIS value of their own. Every other
+    // MusicKit state falls through to 'Stopped', the transient ones (loading,
+    // seeking, waiting, stalled) included, so MPRIS always reports the state
+    // the player is in. Do not add early returns for the transient states, and
+    // do not map Stopped to 'Paused', which shows clients a pause button for a
+    // player that has stopped.
     let status: string;
     if (payload.state === PlaybackState.Playing) {
       status = 'Playing';
@@ -261,6 +300,12 @@ class MediaPlayer2Player extends Interface {
     this._schedulePropertyEmission({ PlaybackStatus: status });
   }
 
+  /**
+   * Publishes the new track, or an empty metadata set when playback has nothing
+   * loaded. Either way the playhead goes back to zero and `Seeked(0)` is
+   * signalled: `Position` is barred from `PropertiesChanged`, so the signal is
+   * the only way a client learns the playhead has moved without it asking.
+   */
   updateNowPlaying(payload: NowPlayingPayload | null): void {
     if (!payload) {
       const emptyMetadata: Record<string, InstanceType<typeof Variant>> = {
@@ -291,7 +336,8 @@ class MediaPlayer2Player extends Interface {
     if (payload.artworkUrl && payload.artworkUrl.startsWith('https://')) {
       downloadArtwork(payload.artworkUrl).then((localPath) => {
         if (!localPath) return;
-        // Only update if this track is still current
+        // The download outlives a fast track change, and a late one would
+        // otherwise put the previous cover on the track now playing.
         if (this._currentTrackId !== trackId) return;
         const fileUri = `file://${localPath}`;
         metadata['mpris:artUrl'] = new Variant('s', fileUri);
@@ -370,6 +416,10 @@ class MediaPlayer2Player extends Interface {
     this._position = newPositionUs;
   }
 
+  /**
+   * Drops every timer and every piece of cached echo state on shutdown, so
+   * nothing fires into a bus that has already been disconnected.
+   */
   cleanup(): void {
     if (this._volumeSafetyTimer) {
       clearTimeout(this._volumeSafetyTimer);
@@ -512,7 +562,8 @@ class MediaPlayer2Player extends Interface {
   }
 
   Stop(): void {
-    // Maps to pause(), not mk.stop(), to preserve queue state
+    // Pause, never MusicKit's stop(): stop() clears the queue, and the MPRIS
+    // spec requires Play() after Stop() to resume from the start of the track.
     this._send('player:pause');
   }
 
@@ -537,6 +588,11 @@ class MediaPlayer2Player extends Interface {
     this._send('player:seek', targetSeconds);
   }
 
+  /**
+   * Opens a service URL a client hands over. The window navigates directly and
+   * the persisted `musicService` is left alone, so after an OpenUri the window
+   * can sit on one service's host while config still names the other.
+   */
   OpenUri(uri: string): void {
     try {
       const parsed = new URL(uri);
@@ -699,6 +755,11 @@ function disconnectBus(): void {
 
 // --- Public API ---
 
+/**
+ * Exports both MPRIS interfaces on the session bus, claims
+ * `org.mpris.MediaPlayer2.<app name>` and wires the interfaces to player
+ * events. Linux only, and required lazily by `main.ts` for that reason.
+ */
 export function init(ctx: IntegrationContext): void {
   const { player, getMainWindow } = ctx;
   if (!getMainWindow) throw new Error('MPRIS requires getMainWindow');
@@ -708,7 +769,8 @@ export function init(ctx: IntegrationContext): void {
   const rootIface = new MediaPlayer2(getMainWindow);
   const playerIface = new MediaPlayer2Player(getMainWindow);
 
-  // Thin wrappers with stable references for removeListener
+  // Named wrappers, because `will-quit` has to hand removeListener the same
+  // function reference; an inline handler could never be detached.
   const onPlaybackStateDidChange = (payload: PlaybackStatePayload): void => {
     playerIface.updatePlaybackStatus(payload);
   };
@@ -743,11 +805,11 @@ export function init(ctx: IntegrationContext): void {
 
   // A session bus is not guaranteed to exist. dbus-next falls through to
   // getDbusAddressFromFs(), which throws synchronously when
-  // DBUS_SESSION_BUS_ADDRESS is unset - containers, bare X and su-launched
-  // sessions all hit it. init() runs inside the did-finish-load handler, so an
-  // escaping throw would skip every integration after this one and leave the
-  // splash screen up for the life of the process. Losing MPRIS is the correct
-  // outcome here; losing the app is not. The connection is not retried.
+  // DBUS_SESSION_BUS_ADDRESS is unset; containers, bare X and su-launched
+  // sessions all hit it. Catching it here reports a missing bus as the ordinary
+  // condition it is, rather than letting an exception stand in for it, and the
+  // return leaves the export and the player subscriptions below undone. Losing
+  // MPRIS is the correct outcome, and the connection is not retried.
   try {
     bus = dbus.sessionBus();
   } catch (err: unknown) {
@@ -769,7 +831,8 @@ export function init(ctx: IntegrationContext): void {
     mprisLog.error('failed to acquire bus name:', busName, err.message);
   });
 
-  // Subscribe to player events
+  // Subscribed after the bus, so the return on a missing bus leaves no
+  // listener attached to update an interface no client can reach.
   player.on('playbackStateDidChange', onPlaybackStateDidChange);
   player.on('nowPlayingItemDidChange', onNowPlayingItemDidChange);
   player.on('repeatModeDidChange', onRepeatModeDidChange);

--- a/src/integrations/notifications/index.ts
+++ b/src/integrations/notifications/index.ts
@@ -21,12 +21,14 @@ async function showNotification(
   }
 
   // Checked before the artwork download so a daemon-less session does no
-  // repeated network and disk work per track
+  // network and disk work per track
   if (!notificationsAvailable()) {
     notifLog.debug('skipping notification: no notification daemon');
     return;
   }
 
+  // A slow artwork fetch must not hold the notification past the track it
+  // announces, so the download races a timeout and loses its icon on expiry
   const artworkPath = payload.artworkUrl
     ? await Promise.race([
         downloadArtwork(payload.artworkUrl).catch((error: unknown) => {
@@ -73,6 +75,10 @@ async function showNotification(
   notifLog.debug('notification requested:', payload.name);
 }
 
+/**
+ * Announces each new track as a desktop notification. The debounce keeps a
+ * queue jump or a burst of metadata updates to a single notification.
+ */
 export function init(ctx: IntegrationContext): void {
   const { player, getMainWindow } = ctx;
   const getWin = getMainWindow ?? (() => null);

--- a/src/integrations/windows-taskbar/index.ts
+++ b/src/integrations/windows-taskbar/index.ts
@@ -11,7 +11,8 @@ const taskbarLog = log.scope('taskbar');
 const iconsDir = getAssetPath('assets', 'icons');
 const menuIconsDir = path.join(iconsDir, 'tray', 'menu');
 
-// Transient playback states where overlay should be left unchanged
+// Transient states hold the overlay badge at its last value: each one lasts a
+// moment and clearing the badge for it makes the taskbar icon flicker
 const TRANSIENT_STATES: ReadonlySet<number> = new Set([
   PlaybackState.Loading,
   PlaybackState.Seeking,
@@ -21,6 +22,7 @@ const TRANSIENT_STATES: ReadonlySet<number> = new Set([
 
 let sendCommandCallback: ((channel: ReceiveChannel, ...args: unknown[]) => void) | null = null;
 
+/** Supplies the main-process sender the thumbar buttons use to reach the renderer. */
 export function setTaskbarSendCommandCallback(callback: (channel: ReceiveChannel, ...args: unknown[]) => void): void {
   sendCommandCallback = callback;
 }
@@ -83,6 +85,7 @@ function setOverlayIcon(win: BrowserWindow, state: number): void {
   }
 }
 
+/** Installs the taskbar thumbar buttons, overlay badge and progress bar; no-op off Windows. */
 export function init(ctx: IntegrationContext): void {
   if (process.platform !== 'win32') return;
 
@@ -147,7 +150,6 @@ export function init(ctx: IntegrationContext): void {
     const { isPlaying } = player.playbackSnapshot();
     setThumbarButtons(win, isPlaying);
 
-    // Skip overlay update for transient states to avoid flicker
     if (!TRANSIENT_STATES.has(state)) {
       setOverlayIcon(win, state);
     }

--- a/src/itms.ts
+++ b/src/itms.ts
@@ -5,8 +5,10 @@
 
 import { MUSIC_SERVICES } from './musicService';
 
+/** The named destinations Apple's itms://music.apple.com/deeplink?p= form carries. */
 export type ItmsRouteToken = 'library' | 'browse' | 'radio' | 'listenNow' | 'subscribe';
 
+/** Either a catalogue URL to open as-is, or a route the storefront resolves to one. */
 export type ItmsTarget =
   | { kind: 'url'; url: string }
   | { kind: 'route'; token: ItmsRouteToken };
@@ -23,6 +25,11 @@ function isRouteToken(value: string | null): value is ItmsRouteToken {
   return value !== null && ROUTE_TOKENS.has(value as ItmsRouteToken);
 }
 
+/**
+ * Validates one itms:// URL and converts it to something Sidra can open. This is
+ * a trust boundary: the URL arrives from the OS, so the scheme, the host and the
+ * route token are each checked against an allowlist and anything else is null.
+ */
 export function transformItmsUrl(input: string): ItmsTarget | null {
   let parsed: URL;
   try {
@@ -56,6 +63,10 @@ export function transformItmsUrl(input: string): ItmsTarget | null {
   return { kind: 'url', url: rebuilt.toString() };
 }
 
+/**
+ * First valid itms:// URL in a process argv, or null. Used at launch and by the
+ * second-instance handler, where the link arrives as an argument rather than an event.
+ */
 export function extractItmsUrlFromArgv(argv: readonly string[]): ItmsTarget | null {
   for (const arg of argv) {
     if (arg.startsWith('itms:')) {

--- a/src/itms.ts
+++ b/src/itms.ts
@@ -26,9 +26,10 @@ function isRouteToken(value: string | null): value is ItmsRouteToken {
 }
 
 /**
- * Validates one itms:// URL and converts it to something Sidra can open. This is
- * a trust boundary: the URL arrives from the OS, so the scheme, the host and the
- * route token are each checked against an allowlist and anything else is null.
+ * Validates one itms:// URL and converts it to something Sidra can open. This is a
+ * trust boundary: the URL arrives from the OS, so a bad scheme or host is null, and
+ * a /deeplink path is null unless its `p` token is on the allowlist. Any other path
+ * becomes an https catalogue URL with the `app` parameter stripped.
  */
 export function transformItmsUrl(input: string): ItmsTarget | null {
   let parsed: URL;

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,7 +57,8 @@ const mainLog = log.scope('main');
 const splashLog = log.scope('splash');
 mainLog.info(`${app.name} ${app.getVersion()}`);
 
-// --- App identity: required on Windows for notifications to appear ---
+// --- App identity: must be set before app.whenReady() on Windows, or neither
+// desktop notifications nor the GSMTC media identity attach to Sidra ---
 if (process.platform === 'win32') {
   app.setAppUserModelId('com.wimpysworld.sidra');
 }
@@ -65,10 +66,15 @@ if (process.platform === 'win32') {
 // --- Platform switches: must run before app.whenReady() ---
 if (process.platform === 'linux') {
   app.commandLine.appendSwitch('enable-features', 'UseOzonePlatform,WaylandWindowDecorations');
+  // MediaSessionService off: Sidra registers its own MPRIS service, and
+  // Chromium's would be a second, conflicting registration on the same bus.
+  // AudioServiceOutOfProcess off: it moves audio back in-process, which is
+  // where SetGlobalAppName can reach PulseAudio at all.
   app.commandLine.appendSwitch('disable-features', 'MediaSessionService,WaylandWpColorManagerV1,AudioServiceOutOfProcess');
   // Set the XDG desktop name so GetXdgAppId() returns 'sidra' and
   // GetPossiblyOverriddenApplicationName() can read Name= from sidra.desktop.
-  // Required for correct PulseAudio stream identity once Kesefon's patch lands.
+  // Pairs with the AudioServiceOutOfProcess switch above: without both, the
+  // PulseAudio stream is labelled "Chromium" and no PULSE_PROP_* override helps.
   app.setDesktopName('sidra.desktop');
   mainLog.info('Linux platform switches applied');
 }
@@ -289,6 +295,11 @@ function createMainWindow(ses: Electron.Session): { win: BrowserWindow; winReady
     },
   });
 
+  // did-finish-load fires while Apple Music is still an empty shell, so the
+  // window is held back until the service's contentReadySelector appears in the
+  // page. The poll starts at the first in-page navigation, which is where the
+  // SPA takes over rendering, and a timeout shows the window regardless so a
+  // selector Apple has renamed delays the launch instead of blocking it.
   let pollCancelled = false;
   const winReady = Promise.race([
     new Promise<void>(resolve => {
@@ -497,6 +508,12 @@ function buildAuthFrameInjectionScript(authCss: string): string {
   })();`;
 }
 
+// Apple's sign-in iframe offers passkey and "Sign in with iPhone" alongside
+// password sign-in, plus captions naming an iOS version requirement. Those are
+// hidden so password sign-in is the visible route. The script re-runs from a
+// MutationObserver because the frame re-renders as the user moves through the
+// flow, and the frame reports its results back over console-message, which is
+// the only channel out of a frame the main process has not preloaded.
 function setupAuthFrameInjection(win: BrowserWindow, authCss: string): void {
   const authLog = log.scope('auth-frame');
   const script = buildAuthFrameInjectionScript(authCss);
@@ -553,6 +570,9 @@ function setupWindowEvents(win: BrowserWindow, markCssReady: () => void): void {
     mainLog.error('page load failed:', errorCode, errorDescription);
   });
 
+  // Apple Music registers a beforeunload handler while audio plays. Electron
+  // shows no confirmation dialog, so the handler silently blocks close() and
+  // app.quit() with no error; overriding it here is what lets Sidra exit.
   win.webContents.on('will-prevent-unload', (event) => {
     event.preventDefault();
   });
@@ -639,9 +659,9 @@ function setupContentHandlers(win: BrowserWindow, player: Player, markCssReady: 
         ['wedgeDetector', () => initWedgeDetector({ player, getMainWindow: () => win })],
         ['trayState', () => {
           if (!appTray) return;
-          // The returned closure destroys the pause timer, cancels the pending
-          // rebuild and removes the three player listeners. Dropping it left
-          // all four attached.
+          // The returned closure is the teardown for all four resources it
+          // holds, so it must reach will-quit; called as a bare statement it
+          // would be discarded and every one of them would stay attached.
           const teardownTrayState = initTrayStateManager(player, appTray);
           app.on('will-quit', teardownTrayState);
         }],

--- a/src/musicService.ts
+++ b/src/musicService.ts
@@ -4,13 +4,16 @@
 
 import { CONTENT_READY_SELECTOR } from './contentReady';
 
+/** The two Apple web services Sidra wraps. */
 export type MusicServiceId = 'music' | 'classical';
 
+/** One start page choice: the id persisted in config, and its path under the storefront. */
 export interface StartPage<PageId extends string = string> {
   id: PageId;
   path: string;
 }
 
+/** A wrapped web service and everything Sidra needs to address and drive it. */
 export interface MusicService<PageId extends string = string> {
   id: MusicServiceId;
   host: string;
@@ -36,6 +39,7 @@ function defineService<const PageId extends string>(
 
 const SHARED_AUTH_FRAME_HOSTS = ['auth.music.apple.com', 'idmsa.apple.com'] as const;
 
+/** The registry. Every host, origin and start page comes from here, never from a literal at the call site. */
 export const MUSIC_SERVICES = {
   music: defineService({
     id: 'music',
@@ -78,8 +82,10 @@ export type ClassicalStartPageId = typeof MUSIC_SERVICES.classical.startPages[nu
 /** Every start page id in the registry, for records that must cover both services. */
 export type AnyStartPageId = MusicStartPageId | ClassicalStartPageId;
 
+/** Service used when nothing is persisted, and when a stored id turns out not to be one. */
 export const DEFAULT_SERVICE_ID: MusicServiceId = 'music';
 
+/** Narrows a stored or externally supplied string to a registry id. */
 export function isMusicServiceId(value: string): value is MusicServiceId {
   return Object.hasOwn(MUSIC_SERVICES, value);
 }
@@ -90,10 +96,12 @@ export function getService(id: MusicServiceId): MusicService {
   return MUSIC_SERVICES[id] ?? MUSIC_SERVICES[DEFAULT_SERVICE_ID];
 }
 
+/** The service serving a hostname, or undefined when the host is not one of ours. */
 export function getServiceByHost(host: string): MusicService | undefined {
   return Object.values(MUSIC_SERVICES).find(svc => svc.host === host);
 }
 
+/** Every registered service, for callers that iterate rather than look one up. */
 export function allServices(): readonly MusicService[] {
   return Object.values(MUSIC_SERVICES);
 }

--- a/src/notificationDaemon.ts
+++ b/src/notificationDaemon.ts
@@ -3,6 +3,11 @@ import log from 'electron-log/main';
 
 import { errorMessage } from './utils';
 
+// Linux-only companion to ./notify. It answers whether anything owns
+// org.freedesktop.Notifications, then follows NameOwnerChanged, so the freeze
+// documented in ./notify is avoided without a restart when a daemon arrives or
+// goes away mid-session.
+
 // @holusion/dbus-next is bare-required because this module only loads on Linux
 const dbus = require('@holusion/dbus-next');
 
@@ -29,8 +34,9 @@ interface DbusMessage {
 // Module-level bus reference for graceful shutdown
 let bus: InstanceType<typeof dbus.MessageBus> | null = null;
 
-// Typed interface for dbus-next internal socket access.
-// Verified against @holusion/dbus-next 0.11.2.
+// dbus-next exposes no public API to fully close its socket, so the internal
+// stream is reached through this shape. Verified against
+// @holusion/dbus-next 0.11.2.
 interface DbusMessageBusInternals {
   _connection?: {
     stream?: {
@@ -67,6 +73,12 @@ function dbusCall(member: string, argument: string): Promise<DbusMessage | null>
   }));
 }
 
+/**
+ * Report whether a notification daemon owns the name, once for the probe reply
+ * and again on every later owner change. A session bus that cannot be opened,
+ * which happens in containers and in su-launched sessions, leaves notifications
+ * off for the session; the connection is not retried.
+ */
 export function initDaemonProbe(onOwnerChange: (hasOwner: boolean) => void): void {
   try {
     bus = dbus.sessionBus();

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -5,6 +5,16 @@ import { errorMessage } from './utils';
 
 const notifyLog = log.scope('notify');
 
+// The only place in Sidra a Notification is constructed, because on Linux
+// Notification.show() blocks the browser UI thread when nothing owns
+// org.freedesktop.Notifications. Electron calls notify_notification_show()
+// inline, libnotify builds its GDBusProxy without DO_NOT_AUTO_START, so GLib
+// runs StartServiceByName in a nested main loop and waits the 25 second D-Bus
+// activation timeout; Electron queries server capabilities three times before
+// the show, so one notification freezes the window for about 100 seconds.
+// createNotification() returns null while the gate is closed, and constructing
+// a Notification anywhere else reopens the freeze.
+
 // The gate starts closed on Linux and opens on the first probe reply: a
 // notification raised before the reply lands has no verified answer, and
 // guessing wrong costs a 100 second freeze. macOS and Windows have no daemon
@@ -12,10 +22,16 @@ const notifyLog = log.scope('notify');
 let daemonAvailable = process.platform !== 'linux';
 let failureLatched = false;
 
+/** True when a notification can be raised without risking the freeze above. */
 export function notificationsAvailable(): boolean {
   return daemonAvailable && !failureLatched;
 }
 
+/**
+ * Open the gate on Linux once a notification daemon is confirmed, and follow it
+ * for the rest of the session. Called once from app.whenReady(); a no-op on
+ * every other platform.
+ */
 export function initNotificationProbe(): void {
   if (process.platform !== 'linux') {
     return;
@@ -46,6 +62,10 @@ export function initNotificationProbe(): void {
   }
 }
 
+/**
+ * Build a Notification, or return null when nothing can receive it. Callers
+ * must handle the null rather than assume a notification exists.
+ */
 export function createNotification(
   options: Electron.NotificationConstructorOptions,
 ): Notification | null {

--- a/src/palettes.ts
+++ b/src/palettes.ts
@@ -26,6 +26,7 @@ interface BundledTheme extends ThemeDefinition {
   name: BundledThemeName;
 }
 
+/** Names of the themes Sidra ships, as stored in config and shown in the tray. */
 export type BundledThemeName =
   | 'catppuccin'
   | 'dracula'
@@ -51,6 +52,7 @@ const draculaDark: SchemeColours = {
   accentHover: '#ff79c6',
 };
 
+/** Every bundled theme, in the order the tray Style submenu lists them. */
 export const BUNDLED_THEMES: readonly BundledTheme[] = [
   {
     name: 'catppuccin',
@@ -226,6 +228,7 @@ export const BUNDLED_THEMES: readonly BundledTheme[] = [
   },
 ];
 
+/** Tray label for a theme name. An unknown name reads as Apple Music, the no-override default. */
 export function themeLabel(name: string): string {
   if (name === 'custom') return 'Custom';
   const theme = BUNDLED_THEMES.find(t => t.name === name);

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -4,8 +4,8 @@ import path from 'path';
 /**
  * Resolve a path to a bundled asset in both a checkout and a packaged build. A
  * packaged build reads from app.asar.unpacked, so anything resolved here must
- * also be listed individually under asarUnpack in package.json; asarUnpack takes
- * no globs, and a missing entry fails only at runtime.
+ * also be covered by an entry under asarUnpack in package.json. A file left
+ * uncovered builds cleanly and fails only at runtime.
  */
 export function getAssetPath(...parts: string[]): string {
   const base = app.isPackaged

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,6 +1,12 @@
 import { app } from 'electron';
 import path from 'path';
 
+/**
+ * Resolve a path to a bundled asset in both a checkout and a packaged build. A
+ * packaged build reads from app.asar.unpacked, so anything resolved here must
+ * also be listed individually under asarUnpack in package.json; asarUnpack takes
+ * no globs, and a missing entry fails only at runtime.
+ */
 export function getAssetPath(...parts: string[]): string {
   const base = app.isPackaged
     ? path.join(process.resourcesPath, 'app.asar.unpacked')
@@ -24,6 +30,13 @@ export interface ProductInfo {
 
 let cachedProductInfo: ProductInfo | null = null;
 
+/**
+ * Product details taken from package.json, which is the single source for the
+ * About window and the tray. The author email is stripped, because the About
+ * window shows the name alone. require() reads through the asar archive, so
+ * package.json is loaded relative to the compiled output and needs no
+ * asarUnpack entry, unlike everything getAssetPath() resolves.
+ */
 export function getProductInfo(): ProductInfo {
   if (cachedProductInfo) {
     return cachedProductInfo;

--- a/src/pauseTimer.ts
+++ b/src/pauseTimer.ts
@@ -1,9 +1,21 @@
+/**
+ * A restartable one-shot timer for a pause that turns into a stop. The tray, the
+ * macOS dock and Discord presence each hold one and clear their now-playing
+ * state when it expires, so a paused player does not sit in the UI for ever.
+ */
 export interface PauseTimer {
+  /** Arm the timer, discarding any run already in progress. */
   start(): void;
+  /** Disarm without firing, for a resume or a track change. */
   cancel(): void;
+  /**
+   * Disarm for teardown. Named apart from cancel() so a will-quit handler reads
+   * as teardown: an expiry after teardown calls back into a UI that has gone.
+   */
   destroy(): void;
 }
 
+/** Build a timer that calls onExpiry once, timeoutMs after the last start(). */
 export function createPauseTimer(timeoutMs: number, onExpiry: () => void): PauseTimer {
   let timer: ReturnType<typeof setTimeout> | null = null;
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -60,6 +60,12 @@ export function getShareUrl(payload: NowPlayingPayload): string | undefined {
   return undefined;
 }
 
+/**
+ * MusicKit playback states as the hook reports them. Integrations map every
+ * value, transient ones included: src/integrations/mpris gives Playing and
+ * Paused an MPRIS status of their own and lets the rest fall through to
+ * 'Stopped', and test/mpris.test.ts fails when a state added here has no row.
+ */
 export const PlaybackState = {
   None: 0,
   Loading: 1,
@@ -78,7 +84,7 @@ export type PlaybackStatePayload = { status: boolean; state: number } | null;
 export interface PlayerEvents {
   playbackStateDidChange: [payload: PlaybackStatePayload];
   nowPlayingItemDidChange: [payload: NowPlayingPayload | null];
-  /** Playback position in microseconds (from MusicKit.currentPlaybackTime * 1e6 in assets/musicKitHook.js:40). */
+  /** Playback position in microseconds, sent by the playbackTimeDidChange listener in assets/musicKitHook.js. */
   playbackTimeDidChange: [payload: number];
   repeatModeDidChange: [payload: number | null];
   shuffleModeDidChange: [payload: number | null];
@@ -105,9 +111,12 @@ const PLAYBACK_STATES: Record<number, string> = Object.fromEntries(
   Object.entries(PlaybackState).map(([k, v]) => [v, k.toLowerCase()])
 );
 
-// Type-safe EventEmitter wrapper. Provides compile-time payload checking on
-// emit, on, once, removeListener, and off while preserving full runtime
-// compatibility with Node's EventEmitter.
+/**
+ * Type-safe EventEmitter wrapper. Gives emit, on, once, removeListener and off
+ * compile-time payload checking while staying a plain Node EventEmitter at
+ * runtime, so a misspelled event or a wrong payload fails tsc rather than
+ * reaching an integration as a listener that never fires.
+ */
 export class TypedEmitter<Events extends { [K in keyof Events]: unknown[] }> extends EventEmitter {
   override emit<K extends keyof Events & string>(event: K, ...args: Events[K]): boolean {
     return super.emit(event, ...args);
@@ -136,6 +145,12 @@ export interface PlaybackSnapshot {
   state: number;
 }
 
+/**
+ * Main-process hub for the renderer's MusicKit events. Each handle* method is
+ * wired to one IPC channel in initPlayerIPC() (src/main.ts), validates the
+ * payload the untrusted renderer sent, then re-emits it to the integrations.
+ * An invalid payload is logged and dropped rather than forwarded.
+ */
 export class Player extends TypedEmitter<PlayerEvents> {
   private lastTimeLogAt = 0;
   private _isPlaying = false;
@@ -146,6 +161,11 @@ export class Player extends TypedEmitter<PlayerEvents> {
     super();
   }
 
+  /**
+   * Current playback state, for callers that must read it outside an event.
+   * The Last.fm scrobble timer is wall-clock, so it re-reads this at submission
+   * time to confirm the play is still live and the playhead has advanced.
+   */
   playbackSnapshot(): PlaybackSnapshot {
     return { isPlaying: this._isPlaying, positionUs: this._positionUs, state: this._state };
   }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -45,11 +45,12 @@ const RECEIVE_CHANNELS = channelSet<ReceiveChannel>({
   'player:setShuffle': true,
 });
 
-// Register receive channel handlers that bridge commands to the main world.
 // The preload runs in the isolated world (contextIsolation: true), so it cannot
-// access window.__sidra directly - that object lives in the main world, set up
-// by musicKitHook.js. window.postMessage() crosses the isolation boundary;
-// musicKitHook.js listens for these messages and dispatches to __sidra methods.
+// call window.__sidra directly - that object lives in the main world, set up by
+// musicKitHook.js. window.postMessage() crosses the isolation boundary, and the
+// hook dispatches each sidra:command message to the matching __sidra method.
+// The target origin is window.location.origin, so the bridge works on either
+// service host without naming one.
 for (const channel of RECEIVE_CHANNELS.all) {
   ipcRenderer.on(channel, (_event, ...args: unknown[]) => {
     window.postMessage({ type: 'sidra:command', channel, args }, window.location.origin);
@@ -57,8 +58,12 @@ for (const channel of RECEIVE_CHANNELS.all) {
 }
 
 /**
- * Minimal IPC bridge exposed to the renderer as window.AMWrapper.
- * MLP: validates contextBridge works. No MusicKit hook consumes this yet.
+ * The renderer-to-main half of the bridge, exposed as window.AMWrapper and used
+ * by sendToMain() in assets/musicKitHook.js. Sending is the only capability the
+ * renderer gets, and an unlisted channel is dropped with a warning rather than
+ * forwarded. The satisfies clause is what type-checks the payload at all:
+ * exposeInMainWorld() takes it untyped, so the declaration in
+ * src/types/hook.d.ts would otherwise be checked against nothing.
  */
 contextBridge.exposeInMainWorld('AMWrapper', {
   ipcRenderer: {

--- a/src/serviceSwitch.ts
+++ b/src/serviceSwitch.ts
@@ -15,11 +15,18 @@ import { reset as resetWedgeDetector } from './wedgeDetector';
 let getTrayCallback: (() => Tray | null) | null = null;
 let loadURLCallback: ((url: string) => void) | null = null;
 
+/** Receives the window and tray accessors from main.ts. Call once, before any switch. */
 export function initServiceSwitch(deps: { getTray: () => Tray | null; loadURL: (url: string) => void }): void {
   getTrayCallback = deps.getTray;
   loadURLCallback = deps.loadURL;
 }
 
+/**
+ * Persist the service and navigate to it. The order is essential: the wedge
+ * detector goes first because stopping its timer suppresses a skip-forward into
+ * the page as it re-initialises, and the service is persisted before the tray
+ * menu and the URL are built, since both read it back.
+ */
 export function switchService(id: MusicServiceId, targetUrl?: string): void {
   resetWedgeDetector();
   setMusicService(id);

--- a/src/storefront.ts
+++ b/src/storefront.ts
@@ -1,3 +1,8 @@
+// src/storefront.ts
+// Builds every URL Sidra navigates to itself, and records where the user has
+// been. Storefront, language and start page are resolved per service through the
+// registry in src/musicService.ts, so neither host is written down here.
+
 import log from 'electron-log/main';
 import { getStorefront, setStorefront, getLanguage, setLanguage, getStartPage, getLastPageUrl, getMusicService, getClassicalStartPage, getClassicalLastPageUrl, setClassicalLastPageUrl, setLastPageUrl } from './config';
 import { getStorefront as getLocaleStorefront } from './i18n';
@@ -29,6 +34,11 @@ function appendLanguage(url: string, language: string | null | undefined): strin
   return parsed.toString();
 }
 
+/**
+ * Launch URL for the active service. The storefront is the persisted one, else
+ * the one detected from the system locale, else 'us'; the page is the stored
+ * start page, falling back to the service default when it names nothing valid.
+ */
 export function buildAppleMusicURL(): string {
   let storefront = getStorefront();
   let source: string;
@@ -67,6 +77,7 @@ export function buildAppleMusicURL(): string {
   return appendLanguage(`${service.origin}/${storefront}${pagePath}`, language);
 }
 
+/** In-app URL for an itms:// deeplink route token, on the user's storefront and language. */
 export function buildItmsRouteURL(token: ItmsRouteToken): string {
   let storefront = getStorefront();
   if (storefront === undefined) {
@@ -78,6 +89,11 @@ export function buildItmsRouteURL(token: ItmsRouteToken): string {
   return appendLanguage(`${getService('music').origin}/${storefront}/${path}`, language);
 }
 
+/**
+ * Reads the storefront and the 'l' language out of a service URL. Null when the
+ * URL is unparseable, the host is not a known service, or the first path segment
+ * is not a two-letter storefront code.
+ */
 export function extractStorefrontFromURL(url: string): { storefront: string; language: string | null } | null {
   try {
     const parsed = new URL(url);
@@ -100,6 +116,10 @@ export function extractStorefrontFromURL(url: string): { storefront: string; lan
   }
 }
 
+/**
+ * Follow the user: Apple's own region and language switchers navigate, so a
+ * changed storefront or language in the URL is persisted as the new preference.
+ */
 export function handleStorefrontNavigation(url: string): void {
   const result = extractStorefrontFromURL(url);
   if (!result) {
@@ -124,6 +144,10 @@ export function handleStorefrontNavigation(url: string): void {
   }
 }
 
+/**
+ * Record the current page against its service, for the 'last' start page. The
+ * storefront segment is stripped so the path survives a change of region.
+ */
 export function handleLastPageNavigation(url: string): void {
   try {
     const parsed = new URL(url);

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -6,6 +6,7 @@ import { BUNDLED_THEMES, type BundledThemeName } from './palettes';
 import { buildThemeCss } from './themeTemplate';
 import { getTheme } from './config';
 
+/** Active theme. 'apple-music' means no override CSS is injected at all. */
 export type ThemeName = 'apple-music' | BundledThemeName | 'custom';
 
 const themeLog = log.scope('theme');
@@ -24,7 +25,8 @@ let customCssCache: string | null = null;
 let customCssCached = false;
 let customCssCacheEnabled = true;
 
-// Track injected theme CSS for live toggle
+// The insertCSS key of the sheet currently on the page, which is what a later
+// removeInsertedCSS needs. Null means no sheet is tracked.
 let themeCssKey: string | null = null;
 
 // Every mutation of themeCssKey runs on this one chain, so a theme change and a
@@ -64,15 +66,14 @@ function enqueueThemeCssOp(work: (generation: number) => Promise<void>): Promise
       }
       return work(generation);
     })
-    // The catch sits at the end so it handles this operation's own failure and
-    // the promise stored and returned here always fulfils. applyTheme() discards
-    // that promise, so a rejection left on it is an unhandled rejection in the
-    // main process until some later operation happens to chain onto it. A
-    // fulfilled promise is also what keeps a failure from deadlocking the queue:
-    // the next operation still runs. It drops the tracked key because the failed
-    // operation left it naming a sheet that either cannot be removed or is
-    // already gone, and keeping it would send every later change back down the
-    // same rejected removal, so none would reach its insertion.
+    // The catch sits at the end, so the promise stored and returned here always
+    // fulfils. applyTheme() discards that promise, and a rejection left on it is
+    // an unhandled rejection in the main process; a fulfilled one also keeps one
+    // failure from deadlocking the queue, because the next operation still runs.
+    // It drops the tracked key because a failed operation leaves it naming a
+    // sheet that either cannot be removed or is already gone, and keeping it
+    // would send every later change down the same rejected removal, so none
+    // would reach its insertion.
     .catch((error: unknown) => {
       themeCssKey = null;
       themeLog.warn('Theme CSS operation failed', error);
@@ -89,14 +90,17 @@ let applyThemeCSSInternal: (name: ThemeName) => Promise<void> = () => Promise.re
 // tray.ts imports theme.ts, so theme.ts cannot import rebuildTrayMenu back; main.ts supplies it.
 let rebuildTrayCallback: (() => void) | null = null;
 
+/** Queue a theme change against the live page. Failures are logged, never thrown. */
 export function applyTheme(name: ThemeName): void {
   void applyThemeCSSInternal(name);
 }
 
+/** Where a user drops their own stylesheet: custom.css in the userData directory. */
 export function customCssPath(): string {
   return path.join(app.getPath('userData'), customCssFilename);
 }
 
+/** True when custom.css is readable and non-blank; existing is not enough. */
 export function hasCustomCss(): boolean {
   return getThemeCss('custom') !== null;
 }
@@ -107,6 +111,10 @@ function isThemeName(value: string): value is ThemeName {
     || bundledThemesByName.has(value as BundledThemeName);
 }
 
+/**
+ * The theme to render: the stored one, falling back to 'apple-music' when it is
+ * unknown or when 'custom' is stored with no readable custom.css behind it.
+ */
 export function resolveTheme(): ThemeName {
   const theme = getTheme();
   if (!isThemeName(theme)) return 'apple-music';
@@ -127,7 +135,7 @@ function readCustomCss(): string | null {
   }
 }
 
-// Exported for the watcher below and for tests; nothing else needs it.
+/** Drop the cached custom.css. Exported for the watcher below and for tests; nothing else needs it. */
 export function invalidateCustomCssCache(): void {
   customCssCache = null;
   customCssCached = false;
@@ -138,6 +146,11 @@ function disableCustomCssCache(): void {
   invalidateCustomCssCache();
 }
 
+/**
+ * Stylesheet for a theme, or null for 'apple-music' and for a missing or blank
+ * custom.css. Bundled themes are rendered once and cached; custom.css is cached
+ * only while the watcher below is alive to invalidate it.
+ */
 export function getThemeCss(name: ThemeName): string | null {
   if (name === 'apple-music') return null;
   if (name === 'custom') {
@@ -159,9 +172,11 @@ export function getThemeCss(name: ThemeName): string | null {
   return css;
 }
 
-// Inject the resolved theme CSS after a page load. main.ts calls this on every load.
-// The load replaced the document, so nothing is removed here: any key held belongs
-// to the old document and removeInsertedCSS would reject on it.
+/**
+ * Inject the resolved theme CSS after a page load. main.ts calls this on every
+ * load. The load replaced the document, so nothing is removed here: any key held
+ * belongs to the old document and removeInsertedCSS would reject on it.
+ */
 export function injectThemeCss(contents: WebContents): Promise<void> {
   return enqueueThemeCssOp(async (generation) => {
     const theme = resolveTheme();
@@ -183,6 +198,11 @@ export function injectThemeCss(contents: WebContents): Promise<void> {
   });
 }
 
+/**
+ * Bring the theme system to life against a window: document tracking, the real
+ * applyTheme implementation, re-application on a system colour-scheme change,
+ * and the custom.css watcher. Call once.
+ */
 export function initThemeCSS(win: BrowserWindow): void {
   // Commit of a main-frame navigation; did-navigate-in-page keeps the document,
   // so it is not one and must not advance the counter.
@@ -269,10 +289,15 @@ export function initThemeCSS(win: BrowserWindow): void {
   });
 }
 
+/**
+ * Set or clear the tracked key. serviceSwitch.ts clears it before its navigation,
+ * because the document that key belongs to is about to be replaced.
+ */
 export function setThemeCssKey(key: string | null): void {
   themeCssKey = key;
 }
 
+/** main.ts supplies rebuildTrayMenu here; see the note on rebuildTrayCallback above. */
 export function setRebuildTrayCallback(callback: () => void): void {
   rebuildTrayCallback = callback;
 }

--- a/src/themeTemplate.ts
+++ b/src/themeTemplate.ts
@@ -1,10 +1,11 @@
 // Pure module: no electron imports so tests can exercise it directly.
 //
 // Renders a complete Apple Music override stylesheet from a 12-slot
-// palette. The template reproduces the structure of the original
-// hand-written catppuccin.css; the Catppuccin palette renders to the
-// same values it shipped with (see test/themes.test.ts).
+// palette. Catppuccin renders byte for byte to the values the retired
+// hand-written catppuccin.css asset shipped, which test/themes.test.ts
+// pins, so the emitted form is not free to drift.
 
+/** The 12 semantic colour slots a palette fills for one colour scheme. */
 export interface SchemeColours {
   /** Page background */
   base: string;
@@ -32,6 +33,7 @@ export interface SchemeColours {
   accentHover: string;
 }
 
+/** A theme: registry name, tray label, and one palette per colour scheme. */
 export interface ThemeDefinition {
   name: string;
   label: string;
@@ -51,8 +53,8 @@ function rgba(hex: string, alpha: number): string {
   return `rgba(${rgbTriplet(hex)},${alpha})`;
 }
 
-// The original stylesheet used spaced rgba() in the side-panel block;
-// preserved for byte compatibility with the previous catppuccin.css asset.
+// The side-panel block alone emits spaced rgba(). test/themes.test.ts pins that
+// form against the values the retired catppuccin.css asset shipped.
 function rgbaSpaced(hex: string, alpha: number): string {
   return `rgba(${rgbTriplet(hex).split(',').join(', ')}, ${alpha})`;
 }
@@ -201,6 +203,11 @@ function schemeBlock(c: SchemeColours): string {
   }`;
 }
 
+/**
+ * Renders the whole override stylesheet for a theme, both colour-scheme variants
+ * included. Everything inside the returned literal, comments as well as rules,
+ * ships to the renderer, so keep rationale in the source and out of the output.
+ */
 export function buildThemeCss(theme: ThemeDefinition): string {
   return `/*
  * ${theme.label} theme for Apple Music

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -524,7 +524,7 @@ function buildNowPlayingMenuItems(strings: TrayStrings, isLinux: boolean): Elect
     ...(artistIcon ? { icon: artistIcon } : {}),
   };
   const albumLabel = truncateMenuLabel(payload.albumName ?? '');
-  // 1981 is the last year before the CD shipped, so anything older shows the vinyl icon.
+  // 1981 is the last year before the CD shipped, so 1981 and earlier shows the vinyl icon.
   const releaseYear = payload.releaseDate ? parseInt(payload.releaseDate.slice(0, 4), 10) : NaN;
   const albumIconKey = !isNaN(releaseYear) && releaseYear <= 1981 ? 'record-vinyl' : 'album';
   const albumIcon = getMenuIcon(albumIconKey);

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -81,6 +81,12 @@ function isMacOSTahoeOrLater(): boolean {
   return !isNaN(major) && major >= 26;
 }
 
+/**
+ * Icon for a menu action, or undefined when the platform or the action has
+ * none. Callers spread the result conditionally, because Electron renders a
+ * blank gutter for an empty NativeImage. macOS draws SF Symbols and only from
+ * Tahoe, where they are available; Linux and Windows use themed PNGs.
+ */
 export function getMenuIcon(action: string): Electron.NativeImage | undefined {
   if (process.platform === 'darwin') {
     if (!isMacOSTahoeOrLater()) return undefined;
@@ -127,7 +133,6 @@ function getTrayIconPath(): string {
     return path.join(iconsDir, 'sidra-tray.png');
   }
 
-  // Linux: select icon based on current theme
   return getLinuxTrayIconPath();
 }
 
@@ -138,10 +143,22 @@ function escapePango(text: string): string {
     .replace(/>/g, '&gt;');
 }
 
+/**
+ * Replaces `&` with a fullwidth ampersand (U+FF06) for Linux menu labels.
+ * Electron escapes labels only partially for GTK/Pango and leaves a bare `&`,
+ * which Pango reads as the start of a markup entity and then rejects the label.
+ * macOS and Windows need no such substitution, so callers apply this on Linux only.
+ */
 export function sanitiseLinuxLabel(text: string): string {
   return text.replace(/&/g, '\uFF06');
 }
 
+/**
+ * Shortens a track, artist or album name for a menu row. The text is first cut
+ * at the opening bracket of a trailing qualifier such as "(Remastered 2011)",
+ * which carries little for the reader and consumes the whole row, then
+ * ellipsised at maxLength so one long title cannot stretch the menu.
+ */
 export function truncateMenuLabel(text: string, maxLength = 32): string {
   const splitIndex = text.search(/[([]/);
   const trimmed = splitIndex > 0 ? text.slice(0, splitIndex).trimEnd() : text;
@@ -491,10 +508,8 @@ function buildNowPlayingMenuItems(strings: TrayStrings, isLinux: boolean): Elect
     }
   }
 
-  // Metadata items - Electron partially escapes labels for GTK/Pango but
-  // does not escape bare `&`, which Pango consumes as a markup entity start.
-  // sanitiseLinuxLabel replaces `&` with fullwidth ampersand (U+FF06) to
-  // avoid this on Linux without affecting macOS or Windows.
+  // Metadata items. Every label is user content Apple supplies, so each one
+  // goes through sanitiseLinuxLabel on Linux to keep Pango from reading it as markup.
   const trackLabel = truncateMenuLabel(payload.name ?? '');
   const trackItem: Electron.MenuItemConstructorOptions = {
     label: isLinux ? sanitiseLinuxLabel(trackLabel) : trackLabel,
@@ -509,6 +524,7 @@ function buildNowPlayingMenuItems(strings: TrayStrings, isLinux: boolean): Elect
     ...(artistIcon ? { icon: artistIcon } : {}),
   };
   const albumLabel = truncateMenuLabel(payload.albumName ?? '');
+  // 1981 is the last year before the CD shipped, so anything older shows the vinyl icon.
   const releaseYear = payload.releaseDate ? parseInt(payload.releaseDate.slice(0, 4), 10) : NaN;
   const albumIconKey = !isNaN(releaseYear) && releaseYear <= 1981 ? 'record-vinyl' : 'album';
   const albumIcon = getMenuIcon(albumIconKey);
@@ -540,7 +556,6 @@ function buildNowPlayingMenuItems(strings: TrayStrings, isLinux: boolean): Elect
     click: () => { if (sendCommand) sendCommand('player:next'); },
   };
 
-  // Volume submenu with radio items
   const volumePct = Math.round(volume * 100);
   const volumeIcon = getMenuIcon('volume');
   const volumeParentLabel = `${strings.volume}: ${volumePct}%`;
@@ -773,6 +788,13 @@ export function createTray(applyZoom?: (factor: number) => void): Tray {
   return tray;
 }
 
+/**
+ * Keeps the tray menu and tooltip in step with playback, and clears Now Playing
+ * once a pause has lasted TRAY_PAUSE_TIMEOUT_MS. The caller must register the
+ * returned closure on will-quit: it destroys the pause timer, cancels a pending
+ * rebuild and removes the three player listeners, all of which otherwise outlive
+ * the tray they act on.
+ */
 export function initTrayStateManager(player: Player, tray: Tray): () => void {
   const TRAY_PAUSE_TIMEOUT_MS = 30_000;
   let currentVolume = 1;
@@ -792,7 +814,6 @@ export function initTrayStateManager(player: Player, tray: Tray): () => void {
   const trayPauseTimer = createPauseTimer(TRAY_PAUSE_TIMEOUT_MS, clearNowPlaying);
 
   const onNowPlayingItemDidChange = async (payload: NowPlayingPayload | null): Promise<void> => {
-    // Cancel pause timer on track change
     trayPauseTimer.cancel();
     if (!payload) {
       trayLog.debug('nowPlayingItemDidChange (tray handler): null payload, clearing state');
@@ -832,7 +853,9 @@ export function initTrayStateManager(player: Player, tray: Tray): () => void {
     }
     const { isPlaying } = player.playbackSnapshot();
 
-    // Pause timeout: clear Now Playing after 30s of inactivity
+    // The timer is armed on the playing-to-paused edge only. Paused states
+    // repeat, and starting it on each one would push the clear-down further
+    // away every time, so a paused player would keep its Now Playing rows.
     if (isPlaying) {
       trayPauseTimer.cancel();
     }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -1,13 +1,20 @@
-// Module augmentation for CastLabs Electron type gaps.
-// CastLabs ECS exposes these APIs at runtime but omits them from its bundled
-// electron.d.ts declarations.
+// Module augmentation for CastLabs Electron type gaps. CastLabs ECS exposes
+// these APIs at runtime but omits them from its bundled electron.d.ts. They are
+// declared once here rather than cast at each call site, so every use is still
+// checked against a signature and a genuine mistake is not hidden by a cast.
 
 declare namespace Electron {
   interface App {
-    /** Set the XDG desktop filename (Linux). CastLabs exposes this at runtime. */
+    /**
+     * Set the XDG desktop filename (Linux). It sets CHROME_DESKTOP, which is
+     * what gives Sidra's audio stream its own name and icon in PulseAudio.
+     */
     setDesktopName(name: string): void;
 
-    /** 'cache' is a valid runtime path but absent from the CastLabs union type. */
+    /**
+     * 'cache' is a valid runtime path, used for the artwork cache, but is
+     * absent from the CastLabs union type.
+     */
     getPath(name: 'cache'): string;
   }
 }

--- a/src/types/hook.d.ts
+++ b/src/types/hook.d.ts
@@ -2,12 +2,21 @@
 // assets/musicKitHook.js defines window.__sidra, window.__sidraHookedMk, and
 // window.AMWrapper at runtime. These declarations formalise that contract so
 // TypeScript can reference the shapes from preload and test code.
+//
+// One of three artefacts that define the same contract, with the hook itself and
+// src/preload.ts. The preload builds both allowlists from the unions below, so
+// tsc holds those two together. The hook is plain JavaScript and is never type
+// checked, so the contract tests read it off disk instead.
 
 // ---------------------------------------------------------------------------
 // IPC channel string literal types
 // ---------------------------------------------------------------------------
 
-/** Channels the renderer sends to the main process (renderer → main). */
+/**
+ * Channels the renderer sends to the main process (renderer → main). The preload
+ * allowlist is a Record over this union, so a channel dropped or misspelled
+ * there fails the type check rather than being silently discarded at runtime.
+ */
 type SendChannel =
   | 'playbackStateDidChange'
   | 'nowPlayingItemDidChange'
@@ -19,7 +28,11 @@ type SendChannel =
   | 'nav:forward'
   | 'nav:reload';
 
-/** Channels the main process sends to the renderer (main → renderer). */
+/**
+ * Channels the main process sends to the renderer (main → renderer). Every
+ * sender is typed against this union, so a misspelled channel fails tsc instead
+ * of reaching the preload allowlist, which would drop it without a trace.
+ */
 type ReceiveChannel =
   | 'player:play'
   | 'player:pause'
@@ -35,7 +48,11 @@ type ReceiveChannel =
 // Hook interfaces
 // ---------------------------------------------------------------------------
 
-/** Methods exposed on window.__sidra by assets/musicKitHook.js. */
+/**
+ * Methods exposed on window.__sidra by assets/musicKitHook.js. Each key answers
+ * one ReceiveChannel; the contract test reads the hook off disk and compares its
+ * command table to this interface, which is the only thing tying the two.
+ */
 interface SidraHook {
   play(): Promise<void>;
   pause(): Promise<void>;
@@ -48,14 +65,22 @@ interface SidraHook {
   setShuffle(mode: number): void;
 }
 
-/** IPC bridge exposed on window.AMWrapper via contextBridge. */
+/**
+ * IPC bridge exposed on window.AMWrapper via contextBridge. The preload object
+ * carries `satisfies AMWrapperBridge`, because exposeInMainWorld() takes its
+ * payload untyped and this declaration is otherwise checked against nothing.
+ */
 interface AMWrapperBridge {
   ipcRenderer: {
     send(channel: SendChannel, data?: unknown): void;
   };
 }
 
-/** Payload shape for the window.postMessage bridge between preload and hook. */
+/**
+ * Payload shape for the window.postMessage bridge between preload and hook.
+ * postMessage is what carries a command across the context isolation boundary,
+ * since the hook runs in the main world and cannot see the preload directly.
+ */
 interface SidraCommandMessage {
   type: 'sidra:command';
   channel: ReceiveChannel;
@@ -67,8 +92,18 @@ interface SidraCommandMessage {
 // ---------------------------------------------------------------------------
 
 interface Window {
+  /** The command surface, assigned last so a part-attached hook leaves it unset. */
   __sidra: SidraHook;
+  /**
+   * Set once at the top of the hook's IIFE and never cleared. It stops a second
+   * injection installing a duplicate set of message and wheel listeners.
+   */
   __sidraHookInjected: boolean;
+  /**
+   * The MusicKit instance the hook is attached to. A different marker from the
+   * one above: the monitor compares it against the current singleton to catch a
+   * replaced instance and re-attach.
+   */
   __sidraHookedMk: unknown;
   AMWrapper: AMWrapperBridge;
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -5,6 +5,12 @@ import { getUpdateStrings } from './i18n';
 import { createNotification } from './notify';
 import { errorMessage } from './utils';
 
+// Update state shared with the tray, plus the notify-only check used where
+// isAutoUpdateSupported() is false. Those builds are updated by a package
+// manager, so the check reports a new release and links to it rather than
+// downloading anything; src/autoUpdate.ts owns the AppImage and NSIS path and
+// reports back here through setUpdateReady().
+
 const SEMVER_PARTS = 3;
 const UPDATE_CHECK_TIMEOUT_MS = 10000;
 
@@ -14,21 +20,31 @@ const GITHUB_API_URL = 'https://api.github.com/repos/wimpysworld/sidra/releases/
 
 export interface UpdateInfo {
   version: string;
+  /** Release page to open. Empty when the update is already downloaded. */
   url: string;
+  /** True once the update is downloaded and a restart would install it. */
   ready: boolean;
 }
 
 let updateInfo: UpdateInfo | null = null;
 
+/** The newest update seen this session, or null when none has been found. */
 export function getUpdateInfo(): UpdateInfo | null {
   return updateInfo;
 }
 
+/** Record a downloaded update, so the tray offers a restart rather than a link. */
 export function setUpdateReady(version: string): void {
   updateInfo = { version, url: '', ready: true };
   updateLog.info('update ready to install:', version);
 }
 
+/**
+ * Compare two major.minor.patch versions numerically, so 0.10.0 beats 0.9.0
+ * where a string compare would not. Sidra tags releases with exactly three
+ * numeric parts; any other form yields NaN, every comparison is then false and
+ * the result is "not newer", so a malformed tag never offers an update.
+ */
 export function isNewer(remote: string, local: string): boolean {
   const r = remote.split('.').map(Number);
   const l = local.split('.').map(Number);
@@ -39,6 +55,12 @@ export function isNewer(remote: string, local: string): boolean {
   return false;
 }
 
+/**
+ * Ask GitHub for the latest release and record it when it is newer. The menu is
+ * rebuilt on both answers, because the tray shows the up-to-date state too. A
+ * failed check is logged at debug and never surfaced: the user did not ask for
+ * it, and no network is a normal condition.
+ */
 export async function checkForUpdates(tray: Tray, rebuildMenu: (tray: Tray) => void): Promise<void> {
   const localVersion = app.getVersion();
   updateLog.debug('checking for updates, current version:', localVersion);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,14 @@
+/**
+ * The message of an Error, or the value itself as a string. A catch binds
+ * unknown under strict mode, so this holds the narrowing every log site needs.
+ */
 export function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-// Each step is isolated so one failure cannot cancel the steps after it. The
-// reporter is a parameter to keep this module free of electron-log.
+// Run named steps in order, each isolated so one failure cannot cancel the steps
+// after it. The reporter is a parameter to keep this module free of
+// electron-log.
 export function runSteps(
   steps: readonly (readonly [string, () => void])[],
   report: (name: string, err: unknown) => void,

--- a/src/utils/progressBar.ts
+++ b/src/utils/progressBar.ts
@@ -4,8 +4,11 @@ import { BrowserWindow } from 'electron';
 const US_PER_SEC = 1_000_000;
 
 /**
- * Update the taskbar/dock progress bar based on playback position.
- * Works on macOS (dock), Windows (taskbar), and Linux (Unity launcher).
+ * Show playback position on the taskbar or dock progress bar: the macOS dock,
+ * the Windows taskbar and the Linux Unity launcher. Media with no known
+ * duration, such as a radio stream, clears the bar rather than showing an empty
+ * one, and the fraction is clamped so a position past the reported duration
+ * cannot overfill it.
  */
 export function updateProgressBar(win: BrowserWindow, positionUs: number, durationMs: number | undefined): void {
   if (!durationMs || durationMs <= 0) {
@@ -20,7 +23,8 @@ export function updateProgressBar(win: BrowserWindow, positionUs: number, durati
 }
 
 /**
- * Clear the taskbar/dock progress bar.
+ * Remove the progress bar. A negative value is how Electron expresses "no
+ * progress" on every platform.
  */
 export function clearProgressBar(win: BrowserWindow): void {
   win.setProgressBar(-1);

--- a/src/wedgeDetector.ts
+++ b/src/wedgeDetector.ts
@@ -4,6 +4,12 @@ import { Player, PlaybackState, PlaybackStatePayload, NowPlayingPayload, Integra
 
 const wedgeLog = log.scope('wedge');
 
+// Recovery for a wedged player: the web player can keep reporting Playing while
+// the playhead stops advancing, and nothing on the page recovers from it. A one
+// second check skips forward when nothing has advanced for STALL_THRESHOLD_MS.
+// END_SAFETY_MARGIN_MS holds the end of a track out of scope, where a track
+// about to finish looks the same as a stall, and MAX_SKIP_ATTEMPTS bounds the
+// recovery so a queue that will not play cannot be skipped through end to end.
 const STALL_THRESHOLD_MS = 5000;
 const END_SAFETY_MARGIN_MS = 10000;
 const CHECK_INTERVAL_MS = 1000;
@@ -42,11 +48,17 @@ function checkForWedge(getWin: () => BrowserWindow | null): void {
   getWin()?.webContents.send('player:next' satisfies ReceiveChannel);
 }
 
+/**
+ * Clear the skip count and stop the check timer. A reload and a service switch
+ * must call this first: the timer otherwise survives the navigation and fires a
+ * spurious skip-forward once the page has re-initialised.
+ */
 export function reset(): void {
   skipAttempts = 0;
   stopTimer();
 }
 
+/** Attach the detector to the player. A repeat call is refused, see below. */
 export function init(ctx: IntegrationContext): void {
   const { player, getMainWindow: getWin } = ctx;
   if (!getWin) throw new Error('wedgeDetector requires getMainWindow');
@@ -67,7 +79,8 @@ export function init(ctx: IntegrationContext): void {
 
   let lastSeenPositionUs = 0;
 
-  // Named listener references for removeListener in will-quit
+  // Named references, because will-quit removes each one and an inline listener
+  // cannot be removed
   const onPlaybackStateDidChange = (payload: PlaybackStatePayload): void => {
     const nowPlaying = payload?.state === PlaybackState.Playing;
     lastAdvanceTime = Date.now();

--- a/test/aboutWindow.test.ts
+++ b/test/aboutWindow.test.ts
@@ -143,13 +143,14 @@ describe('showAboutWindow', () => {
   it('resets aboutWindow to null on closed event', () => {
     showAboutWindow();
 
-    // Simulate the window closing
     const closedHandlers = latestMockInstance._listeners['closed'];
     expect(closedHandlers).toBeDefined();
     expect(closedHandlers.length).toBeGreaterThan(0);
     closedHandlers[0]();
 
-    // Now a new call should create a new window
+    // The module holds one window reference, so a closed window that is not
+    // cleared leaves the About item dead for the rest of the session: focus()
+    // would be called on a destroyed window and nothing would be shown.
     const newMockInstance = createMockBrowserWindow();
     latestMockInstance = newMockInstance;
     vi.mocked(BrowserWindow).mockClear();

--- a/test/artwork.test.ts
+++ b/test/artwork.test.ts
@@ -115,14 +115,11 @@ describe('downloadArtwork', () => {
     mockFinishingWriteStream();
     vi.mocked(net.fetch).mockResolvedValue(createMockResponse(200, true));
 
-    // First call - triggers download
     const firstResult = await downloadArtwork(url);
     expect(firstResult).toMatch(/\.jpg$/);
 
-    // Set existsSync to return true for the cached file
     vi.mocked(fs.existsSync).mockReturnValue(true);
 
-    // Second call with same URL - should return cached path without calling net.fetch again
     vi.mocked(net.fetch).mockClear();
     const secondResult = await downloadArtwork(url);
     expect(secondResult).toBe(firstResult);
@@ -142,7 +139,8 @@ describe('downloadArtwork', () => {
     expect(result).toMatch(/\.jpg$/);
     expect(fs.mkdirSync).toHaveBeenCalled();
     expect(fs.createWriteStream).toHaveBeenCalled();
-    // Verify .tmp file was written and renamed
+    // The download lands on a .tmp path and is renamed onto the cache path, so
+    // a half-written file can never be read back as a cache hit.
     const writeCall = vi.mocked(fs.createWriteStream).mock.calls[0][0] as string;
     expect(writeCall).toMatch(/\.tmp$/);
     expect(fsPromises.rename).toHaveBeenCalled();
@@ -155,7 +153,9 @@ describe('downloadArtwork', () => {
 
     const result = await downloadArtwork(url);
     expect(result).toBeNull();
-    // Should not attempt to write a file on non-200
+    // The status is checked before the stream is opened, so an error page body
+    // is never written and renamed onto the cache path, where it would be
+    // served as this track's artwork until the seven day sweep took it.
     expect(fs.createWriteStream).not.toHaveBeenCalled();
   });
 
@@ -166,7 +166,9 @@ describe('downloadArtwork', () => {
 
     const result = await downloadArtwork(url);
     expect(result).toBeNull();
-    // Should attempt to clean up the tmp file
+    // The tmp name carries a timestamp, so it is distinct on every attempt and
+    // a failure that skipped the unlink would add a file to the cache
+    // directory each time the network dropped.
     expect(fsPromises.unlink).toHaveBeenCalled();
   });
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, expectTypeOf, beforeEach } from 'vitest';
 import type { ThemeName } from '../src/theme';
 
-// No mock of ../src/config here, deliberately. A hand-written stand-in used to sit
-// at this point in the file and every runtime assertion below read that stand-in's
-// own defaults back out, so real defects in src/config.ts passed. electron-conf/main
-// is mocked globally in test/setup.ts, so the real module loads and runs unmodified.
+// No mock of ../src/config here, deliberately. A hand-written stand-in would
+// sit at this point in the file and every runtime assertion below would read
+// that stand-in's own defaults back out, so a real defect in src/config.ts
+// would pass. electron-conf/main is mocked globally in test/setup.ts, so the
+// real module loads and runs unmodified.
 import {
   getStorefront, setStorefront,
   getLanguage, setLanguage,
@@ -29,8 +30,11 @@ import { Conf } from 'electron-conf/main';
 import { DEFAULT_SERVICE_ID } from '../src/musicService';
 import type { ClassicalStartPageId, MusicServiceId } from '../src/musicService';
 
-// Type assertions verify that each getter return type matches its StoreSchema key type.
-// These are compile-time checks via expectTypeOf.
+// Each assertion pins a getter return type or a setter parameter type against
+// its StoreSchema key type, so a key whose type drifts fails at the boundary
+// rather than at whichever caller happens to read it. expectTypeOf checks
+// nothing at run time: Vitest transpiles without type-checking, so these only
+// fail under `npx tsc -p tsconfig.test.json --noEmit`, which `just lint` runs.
 
 describe('Config store type assertions', () => {
   it('getStorefront returns string | undefined', () => {

--- a/test/i18n-consistency.test.ts
+++ b/test/i18n-consistency.test.ts
@@ -12,8 +12,8 @@ type RecordEntry = [name: string, record: Record<string, string>];
  * The module exports translation records alongside functions, so an object
  * export is a record and a function export is not. Deriving the list this way
  * puts a new record under the guard with no edit to this file. Do not put the
- * names back in a hand-written list: the previous one covered 36 of the 43
- * records and left the whole tray media-control group unchecked.
+ * names back in a hand-written list: the previous one fell behind the records
+ * it was meant to cover and left the whole tray media-control group unchecked.
  */
 function isRecordEntry(entry: [string, unknown]): entry is RecordEntry {
   return typeof entry[1] === 'object' && entry[1] !== null;

--- a/test/i18n-consistency.test.ts
+++ b/test/i18n-consistency.test.ts
@@ -11,9 +11,9 @@ type RecordEntry = [name: string, record: Record<string, string>];
 /**
  * The module exports translation records alongside functions, so an object
  * export is a record and a function export is not. Deriving the list this way
- * puts a new record under the guard with no edit to this file, which a
- * hand-written list did not: it had drifted to 36 of the 43 records, leaving
- * the whole tray media-control group unchecked.
+ * puts a new record under the guard with no edit to this file. Do not put the
+ * names back in a hand-written list: the previous one covered 36 of the 43
+ * records and left the whole tray media-control group unchecked.
  */
 function isRecordEntry(entry: [string, unknown]): entry is RecordEntry {
   return typeof entry[1] === 'object' && entry[1] !== null;

--- a/test/integrationCleanup.test.ts
+++ b/test/integrationCleanup.test.ts
@@ -1,10 +1,10 @@
 // test/integrationCleanup.test.ts
 //
 // Enforces the AGENTS.md claim that every listener is cleaned up on will-quit.
-// The claim had drifted in three places before this file existed: macos-dock
-// registered three anonymous listeners and had no will-quit handler at all,
-// wedgeDetector stopped its timer and left its listeners attached, and main.ts
-// discarded the teardown closure initTrayStateManager returns.
+// Nothing else in the suite notices when it breaks, and it breaks quietly:
+// anonymous listeners cannot be removed at all, a module can stop its timer
+// and leave its listeners attached, and a teardown closure is discarded by
+// calling the function that returns it as a bare statement.
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -193,8 +193,8 @@ describe('player listener cleanup', () => {
     }
   });
 
-  // Fixtures for the sweep itself. The first one is the point of the region
-  // check: it passed a whole-file search for the removal, and must not pass now.
+  // Fixtures for the sweep itself. The first is the point of the region check:
+  // a whole-file search for the removal accepts it, and the sweep must not.
   describe('the sweep itself', () => {
     const REGISTER = "player.on('playbackStateDidChange', onPlaybackStateDidChange);";
     const REMOVE = "player.removeListener('playbackStateDidChange', onPlaybackStateDidChange);";
@@ -279,8 +279,9 @@ describe('player listener cleanup', () => {
       ]);
     });
 
-    // The sweep once read `player.on(` only, so any other registration spelling
-    // was invisible to it and slipped past a file that reads as coverage.
+    // `addListener` is the same registration under another name, so a sweep
+    // matching `player.on(` alone passes a module that registers this way
+    // while reading as coverage.
     it('rejects an addListener registration with no removal', () => {
       const source = `
         export function init(): void {
@@ -359,8 +360,8 @@ describe('player listener cleanup', () => {
   it('main.ts invokes the teardown initTrayStateManager returns', () => {
     const source = fs.readFileSync(path.join(SRC_DIR, 'main.ts'), 'utf-8');
 
-    // A bare call statement discards the closure, which is how the tray pause
-    // timer and its three listeners survived quitting.
+    // A bare call statement discards the closure, leaving the tray pause timer
+    // and its three player listeners attached for the life of the process.
     expect(
       /^\s*initTrayStateManager\(/m.test(source),
       'main.ts calls initTrayStateManager() as a statement, discarding its teardown closure',

--- a/test/lastfm.test.ts
+++ b/test/lastfm.test.ts
@@ -547,7 +547,7 @@ describe('revoked session', () => {
     await flush();
 
     // Pause and resume re-arms the timer past the threshold, which is the one
-    // path that used to resubmit a track the API had already refused.
+    // path that can resubmit a track the API has already refused.
     player.emitPlaybackState(PlaybackState.Paused);
     await vi.advanceTimersByTimeAsync(30_000);
     player.emitPlaybackState(PlaybackState.Playing);
@@ -628,8 +628,8 @@ function loggedLines(): string {
  * before they reach Last.fm, which is what puts a play on the queue, and auth
  * answers so a second account can be linked while the first drain is out.
  *
- * The new account's own now-playing update carries their queue out, so on fixed
- * code two drains are left out: the old account's and theirs.
+ * The new account's own now-playing update carries their queue out, so two
+ * drains are left out: the old account's and theirs.
  *
  * The caller seeds `queue.pending` beforehand: that is what the first request
  * drains.
@@ -1271,9 +1271,9 @@ describe('queued scrobbles', () => {
 
   it('reports a batch Last.fm kept nothing from, and still clears it', async () => {
     // Filtering is not an error. Last.fm answers status ok with no error field,
-    // so a batch it stored nothing from settles on the success path and used to
-    // log exactly as one it stored whole: fifty plays never reached the user's
-    // profile and the log said they had gone out.
+    // so a batch it stored nothing from settles on the success path beside one
+    // it stored whole. Without the counts, the log reads the same either way
+    // and fifty plays never reaching the user's profile are invisible.
     queue.pending = Array.from({ length: 50 }, (_, i) => ({
       artist: 'New Order',
       track: `Track ${i}`,

--- a/test/macosDock.test.ts
+++ b/test/macosDock.test.ts
@@ -2,8 +2,8 @@
 //
 // The dock menu is built from getTrayStrings(), so every expectation reads the
 // same i18n module the integration does rather than an English literal. The
-// idle header is the case worth pinning: it once carried the Pause label, which
-// reads as a transport control rather than as a state.
+// idle header is the case worth pinning: the Pause label there reads as a
+// transport control rather than as a statement of what is playing.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { app } from 'electron';
 

--- a/test/mocks/player.ts
+++ b/test/mocks/player.ts
@@ -9,8 +9,6 @@
 // It extends the real Player rather than reimplementing the interface: Player
 // holds private fields, so a structural stand-in is not assignable to
 // IntegrationContext without a cast.
-//
-// Import it directly: import { FakePlayer } from './mocks/player';
 import { Player, PlaybackSnapshot, PlaybackState, NowPlayingPayload } from '../../src/player';
 
 export class FakePlayer extends Player {

--- a/test/mpris.test.ts
+++ b/test/mpris.test.ts
@@ -143,9 +143,9 @@ describe('MPRIS OpenUri', () => {
     expect(win.loadURL).toHaveBeenCalledWith('https://classical.music.apple.com/gb/album/foo');
   });
 
-  // Every registered host is accepted whatever the active service is. The check
-  // once compared against the active service's host, so with Classical selected
-  // every music.apple.com URI an MPRIS client sent was dropped.
+  // Every registered host is accepted whatever the active service is. A check
+  // against the active service's host instead would drop every music.apple.com
+  // URI an MPRIS client sends while Classical is selected.
   it('loads a music.apple.com URI while Classical is the active service', () => {
     setMusicService('classical');
     initPlayerInterface().OpenUri('https://music.apple.com/gb/album/foo');
@@ -170,8 +170,8 @@ describe('MPRIS OpenUri', () => {
 });
 
 // MPRIS has three PlaybackStatus values and MusicKit has ten states, so the
-// mapping is lossy by design. Stopped (4) reached MPRIS as 'Paused' until
-// WW-128, which left a client showing a pause button for a player that had
+// mapping is lossy by design. Stopped (4) is the row that matters: mapping it
+// to 'Paused' leaves a client showing a pause button for a player that has
 // stopped. AGENTS.md also forbids an early-return guard for the transient
 // states, so those are pinned here rather than left to read as an accident.
 describe('MPRIS PlaybackStatus mapping', () => {
@@ -283,8 +283,9 @@ describe('MPRIS metadata', () => {
 });
 
 // MusicKit never populates attributes.url on a library item, so a payload that
-// carries one is the catalogue case and every library track reached MPRIS with
-// no xesam:url at all. getShareUrl() rebuilds it from the playParams ids.
+// carries one is the catalogue case and without a fallback every library track
+// reaches MPRIS with no xesam:url at all. getShareUrl() rebuilds it from the
+// playParams ids.
 describe('MPRIS xesam:url fallback', () => {
   it('rebuilds the song URL from catalogId when the payload carries no url', () => {
     const iface = initPlayerInterface();
@@ -319,10 +320,9 @@ describe('MPRIS volume', () => {
     vi.useFakeTimers();
   });
 
-  // The setter cached the new value and told the renderer, but emitted
-  // nothing, so only the client that made the change knew about it. A second
-  // MPRIS client kept showing the old level until something else moved the
-  // volume.
+  // A setter that caches the new value and tells the renderer without emitting
+  // leaves only the client that made the change knowing about it, so a second
+  // MPRIS client shows the old level until something else moves the volume.
   it('emits PropertiesChanged for a volume set over the interface', () => {
     const iface = initPlayerInterface();
     iface.Volume = 0.4;
@@ -340,9 +340,9 @@ describe('MPRIS volume', () => {
   });
 
   // A drag sets several values inside one echo round trip. With a single
-  // pending slot holding only the newest, the 0.5 and 0.6 echoes each looked
-  // like an in-app change and overwrote the cached volume, so the reported
-  // level finished one echo behind the real one.
+  // pending slot holding only the newest, the 0.5 and 0.6 echoes each read as
+  // an in-app change and overwrite the cached volume, leaving the reported
+  // level one echo behind the real one.
   it('reports the final value of a burst of sets', () => {
     const iface = initPlayerInterface();
     iface.Volume = 0.5;
@@ -358,10 +358,11 @@ describe('MPRIS volume', () => {
     expect(emissions).toEqual([{ Volume: 0.7 }]);
   });
 
-  // A long drag can put more sets in flight than the queue holds. Dropping the
-  // oldest entry made its echo look like an in-app change, and the later
-  // matched echoes never put the cached value back, so the volume finished at
-  // the fourth value of the drag and stayed there.
+  // A long drag can put more sets in flight than the queue holds. Evicting the
+  // oldest entry to make room makes its echo read as an in-app change, and the
+  // later matched echoes never put the cached value back, so the volume sticks
+  // at a value the drag left behind. A full queue therefore drops the value
+  // being added instead.
   it('reports the final value of a burst longer than the pending queue', () => {
     const iface = initPlayerInterface();
     const values = Array.from({ length: 12 }, (_, index) => (index + 1) * 0.05);

--- a/test/musicKitHook.test.ts
+++ b/test/musicKitHook.test.ts
@@ -57,8 +57,9 @@ function createMusicKit(
     ...overrides,
   };
   if (volumeThrows) {
-    // Models a getter throwing while MusicKit re-initialises. This is the read
-    // that sits above the marker assignment in the original code.
+    // Models a getter throwing while MusicKit re-initialises. The eager volume
+    // read inside attachToInstance() is the most likely thrower, so this drives
+    // the part-attached path the marker and attachSafely() exist to contain.
     Object.defineProperty(instance, 'volume', {
       get() { throw new Error('volume unavailable during re-initialisation'); },
       configurable: true,
@@ -255,10 +256,10 @@ describe('musicKitHook', () => {
   });
 
   // The 5-second monitor re-attaches whenever __sidraHookedMk does not match
-  // the live instance. The marker used to be assigned last, so anything that
-  // threw inside attachToInstance left it stale and every cycle added another
-  // full set of listeners: the #153 / #154 failure, reached by a different
-  // route. These three pin the marker being claimed first.
+  // the live instance, so attachToInstance() must claim the marker as its first
+  // statement. Claimed last, anything that throws in between leaves it stale and
+  // every cycle adds another full set of MusicKit listeners. These three pin the
+  // marker being claimed first.
   it('attaches each MusicKit listener once when the IPC bridge is missing', () => {
     const { musicKit, runMonitorCycles } = createHarness({ bridgeMissing: true });
 

--- a/test/navigationBar.test.ts
+++ b/test/navigationBar.test.ts
@@ -10,9 +10,11 @@ const navBarSource = fs.readFileSync(
   'utf-8',
 );
 
-// The asset is not standalone-executable: src/main.ts substitutes the token when
-// it reads the file. These labels are deliberately not English, so a label that
-// reaches a button proves it came from here and not from a default in the asset.
+// The asset is not standalone-executable JavaScript: loadAssets() in src/main.ts
+// substitutes the label token when it reads the file, so this test has to do the
+// same before it runs it. These labels are deliberately not English, so a label
+// that reaches a button proves it came from here and not from a default in the
+// asset.
 const LABELS = { back: 'Zurück', forward: 'Vorwärts', reload: 'Neu laden' };
 
 const navBarScript = navBarSource.replace(NAV_LABELS_TOKEN, () => JSON.stringify(LABELS));

--- a/test/pauseTimer.test.ts
+++ b/test/pauseTimer.test.ts
@@ -1,3 +1,7 @@
+// The tray and the macOS dock arm this timer on a pause and clear Now Playing
+// when it expires. cancel() and destroy() are separate for a reason: the
+// playback path cancels, and teardown on will-quit destroys, because an expiry
+// after teardown calls into a dock that no longer exists.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createPauseTimer } from '../src/pauseTimer';
 
@@ -41,7 +45,6 @@ describe('createPauseTimer', () => {
     vi.advanceTimersByTime(800);
     expect(onExpiry).not.toHaveBeenCalled();
 
-    // Restart resets the timeout
     timer.start();
     vi.advanceTimersByTime(800);
     expect(onExpiry).not.toHaveBeenCalled();
@@ -66,7 +69,8 @@ describe('createPauseTimer', () => {
     const onExpiry = vi.fn();
     const timer = createPauseTimer(1000, onExpiry);
 
-    // Should not throw
+    // The bare call is the subject: the playback path cancels on every state
+    // change, most of which armed no timer.
     timer.cancel();
     expect(onExpiry).not.toHaveBeenCalled();
   });

--- a/test/player.test.ts
+++ b/test/player.test.ts
@@ -181,7 +181,9 @@ describe('Player playbackSnapshot', () => {
   });
 });
 
-// Validation tests for handle* methods with invalid payloads.
+// Every handle* method takes its argument straight off an IPC channel, where
+// nothing is typed, so a malformed payload must be dropped rather than emitted:
+// integrations read these events as though the declared type held.
 describe('Player handle* payload validation', () => {
   it('handlePlaybackStateDidChange ignores string payload', () => {
     const player = new Player();

--- a/test/serviceSwitch.test.ts
+++ b/test/serviceSwitch.test.ts
@@ -99,9 +99,9 @@ describe('serviceSwitch', () => {
   });
 });
 
-// The itms:// path in main.ts is this function plus a URL. main.ts runs app.whenReady()
-// at import and cannot be loaded here, so the branch it used to hold lives in the module
-// under test and is driven directly.
+// The itms:// path in main.ts is this function plus a URL. The service branch lives
+// here rather than in main.ts, which runs app.whenReady() at import and cannot be
+// loaded under Vitest, so driving the function directly covers the whole path.
 describe('routeToMusicService', () => {
   const tray = new Tray('/tmp/sidra-test/icon.png');
   const loadURL = vi.fn((_url: string) => { calls.push('loadURL'); });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,4 +1,5 @@
-// test/setup.ts
+// Loaded by Vitest before every test file, so a stand-in registered here is
+// shared by the whole suite.
 import { vi } from 'vitest';
 
 // Mock electron modules - these are unavailable outside the Electron runtime.
@@ -106,7 +107,8 @@ vi.mock('electron-conf/main', () => {
       get(key: string) { return data.get(key); }
       set(key: string, value: unknown) { data.set(key, value); }
       clear() { data.clear(); }
-      // Expose for test manipulation
+      // One map backs every Conf instance, exposed so test/config.test.ts can
+      // seed and clear what the getters read.
       static _data = data;
     },
   };

--- a/test/storefront.test.ts
+++ b/test/storefront.test.ts
@@ -1,4 +1,3 @@
-// test/storefront.test.ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import './mocks/storefront-deps';
 
@@ -201,8 +200,9 @@ describe('buildAppleMusicURL - classical service', () => {
   });
 
   it('falls back to home when a removed library start page is still persisted', () => {
-    // 'library' was persisted before WW-92 dropped the page: the type no longer admits it,
-    // the store still holds it.
+    // Classical has no library route on the web, so the type no longer admits the id.
+    // A store written by an older build still holds it, and it must resolve to home
+    // rather than building a URL that 404s.
     mockedGetClassicalStartPage.mockReturnValue('library' as ClassicalStartPageId);
     const url = buildAppleMusicURL();
     expect(url).toBe('https://classical.music.apple.com/gb');

--- a/test/styleFix.test.ts
+++ b/test/styleFix.test.ts
@@ -1,3 +1,9 @@
+// Keeps an unscoped player enlargement rule out of styleFix.css. A bare
+// amp-chrome-player selector reaches the player on every page of both services,
+// so a declaration there that grows the element resizes the player bar
+// everywhere rather than in the one view it was written for. The check reads the
+// shipped stylesheet off disk, because no assertion can see the rule without a
+// renderer.
 import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';

--- a/test/themes.test.ts
+++ b/test/themes.test.ts
@@ -21,9 +21,10 @@ const CSS_RGBA_RE = /^rgba\((\d+),(\d+),(\d+),([0-9.]+)\)$/;
 /** WCAG 2.x AA floor for body text. */
 const CONTRAST_FLOOR = 4.5;
 
-// Catppuccin Latte ships subtext0 at #6c6f85, which lands at 4.37:1. Latte is
-// the one palette that was checked on screen, and WW-101 leaves every
-// Catppuccin value untouched, so it holds its shipped ratio.
+// Catppuccin Latte ships subtext0 at #6c6f85, which lands at 4.37:1. It is the
+// one documented exception to the floor: the Catppuccin values are Catppuccin's
+// own and are kept byte for byte, and Latte was checked on screen. A new palette
+// gets no entry here.
 const SECONDARY_FLOORS: Record<string, number> = {
   'catppuccin light': 4.37,
 };
@@ -208,9 +209,10 @@ describe('buildThemeCss', () => {
         expect(css).not.toContain('::-webkit-scrollbar');
       });
 
-      // The accent group was dropped from :root, leaving the * block as its
-      // only declaration site. cssVar reads the first match, so a resolved
-      // value here proves the root still reaches one.
+      // The * block is the only declaration site for the accent group, because
+      // the shadow DOM of amp-* elements does not inherit from :root. cssVar
+      // reads the first match, so a resolved value here proves the root element
+      // still reaches one despite the lower specificity.
       it('resolves the accent variables from the * block', () => {
         for (const { block, colours } of schemeBlocks) {
           expect(cssVar(block, 'keyColor')).toBe(colours.accent);

--- a/test/tray.test.ts
+++ b/test/tray.test.ts
@@ -129,14 +129,16 @@ import { startAuth as startLastfmAuth, disconnect as disconnectLastfm, isConfigu
 import { FakePlayer } from './mocks/player';
 import { MUSIC_SERVICES, type AnyStartPageId, type ClassicalStartPageId, type MusicServiceId } from '../src/musicService';
 
-// Helper: extract the template array from the last Menu.buildFromTemplate call
+// The last build is the one that reached the tray: several tests rebuild the
+// menu more than once and assert against the state the final rebuild saw.
 function getLastTemplate(): Electron.MenuItemConstructorOptions[] {
   const calls = vi.mocked(Menu.buildFromTemplate).mock.calls;
   expect(calls.length).toBeGreaterThan(0);
   return calls[calls.length - 1][0] as Electron.MenuItemConstructorOptions[];
 }
 
-// Helper: find a menu item by label substring
+// Matching is on a substring because every submenu parent carries its current
+// value in the label, as in 'Start Page: New'.
 function findItem(template: Electron.MenuItemConstructorOptions[], labelSubstring: string): Electron.MenuItemConstructorOptions | undefined {
   return template.find((item) => typeof item.label === 'string' && item.label.includes(labelSubstring));
 }
@@ -653,8 +655,9 @@ describe('createTray - menu template inspection', () => {
     });
 
     it('falls back to Home when a stored library page is no longer offered', () => {
-      // 'library' was persisted before WW-92 dropped the page; the store can still
-      // hold it, the type no longer admits it.
+      // Classical has no library route on the web, so the type no longer admits
+      // the id. A store written by an older build still holds it, and the menu
+      // must tick Home rather than ticking nothing at all.
       vi.mocked(getClassicalStartPage).mockReturnValue('library' as string as ClassicalStartPageId);
       createTray();
       const template = getLastTemplate();
@@ -988,8 +991,10 @@ describe('createTray - menu template inspection', () => {
     });
 
     it('resolves a different icon for the Hide state and the Show state', () => {
-      // Both entries once shared a single icon key, so each state is checked for
-      // the icon it needs and against the icon the other state needs.
+      // Hide and Show are one menu entry built from the window's visibility, so
+      // each state is checked both for the icon it needs and against the icon
+      // the other state needs. A single shared icon key passes the first check
+      // alone.
       const iconPaths = (visible: boolean): string[] => {
         mockWin.isVisible.mockReturnValue(visible);
         vi.mocked(nativeImage.createFromPath).mockClear();
@@ -1255,7 +1260,8 @@ describe('createTray - menu template inspection', () => {
         const trackItem = findItem(template, 'Test Track');
         expect(trackItem).toBeDefined();
         expect(trackItem!.icon).toBeDefined();
-        // Artwork icon is loaded via nativeImage.createFromPath with resize
+        // The downloaded artwork, not a themed menu glyph: the path is what
+        // tells the two apart, since both arrive as a NativeImage.
         expect(vi.mocked(nativeImage.createFromPath)).toHaveBeenCalledWith('/tmp/artwork.png');
       });
 
@@ -1373,7 +1379,8 @@ describe('createTray - menu template inspection', () => {
         const albumItem = findItem(template, 'Test Album');
         expect(albumItem).toBeDefined();
         expect(albumItem!.icon).toBeDefined();
-        // Verify getMenuIcon was called with 'record-vinyl' by checking the resolved path
+        // createTray() picks the icon internally, so the resolved path is the
+        // only observable proof of which one it chose.
         expect(vi.mocked(nativeImage.createFromPath)).toHaveBeenCalledWith(
           expect.stringContaining('record-vinyl.png'),
         );
@@ -1431,7 +1438,6 @@ describe('theme change menu refresh', () => {
     const buildCountBefore = vi.mocked(Menu.buildFromTemplate).mock.calls.length;
     const contextMenuCountBefore = setContextMenuFn.mock.calls.length;
 
-    // Extract and invoke the theme callback
     const themeCall = vi.mocked(nativeTheme.on).mock.calls.find(([event]) => event === 'updated');
     expect(themeCall).toBeDefined();
     const callback = themeCall![1] as () => void;
@@ -1706,14 +1712,13 @@ describe('initTrayStateManager', () => {
       player.setPlaybackState(PlaybackState.Paused);
       handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Paused });
 
-      // Timer is now pending. Cleanup should clear it.
       cleanup();
 
-      // Advance past the 30s timeout - should not trigger any state clearing
+      // Past the 30s expiry: a timer that survived teardown would rebuild the
+      // menu here, against a tray the app is finished with.
       vi.mocked(Menu.buildFromTemplate).mockClear();
       vi.advanceTimersByTime(35_000);
 
-      // No additional menu rebuild from the timer callback
       expect(vi.mocked(Menu.buildFromTemplate)).not.toHaveBeenCalled();
     });
 
@@ -1737,25 +1742,22 @@ describe('initTrayStateManager', () => {
       player.setPlaybackState(PlaybackState.Playing);
       handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Playing });
 
-      // Transition to paused
       player.setPlaybackState(PlaybackState.Paused);
       handlerFor('playbackStateDidChange')({ status: true, state: PlaybackState.Paused });
 
-      // Advance 29s - should not have cleared yet
       vi.mocked(Menu.buildFromTemplate).mockClear();
       const setToolTipFn = mockTray.setToolTip as ReturnType<typeof vi.fn>;
       setToolTipFn.mockClear();
 
+      // One second short of the expiry, the track is still on the tray.
       vi.advanceTimersByTime(29_000);
-      // The tooltip should not have been cleared to the product name yet
       expect(setToolTipFn).not.toHaveBeenCalled();
 
-      // Advance past 30s, then past the rebuild window
+      // Past the expiry and past the rebuild window: the tooltip goes back to
+      // the product name and the menu drops the Now Playing rows.
       vi.advanceTimersByTime(2_000);
 
-      // Now the tooltip should be reset (updateTrayTooltip(tray, null) sets product name)
       expect(setToolTipFn).toHaveBeenCalled();
-      // And the menu should be rebuilt
       expect(vi.mocked(Menu.buildFromTemplate)).toHaveBeenCalled();
     });
 
@@ -1805,7 +1807,6 @@ describe('initTrayStateManager', () => {
       setToolTipFn.mockClear();
       vi.advanceTimersByTime(35_000);
 
-      // No timeout-triggered tooltip reset
       expect(setToolTipFn).not.toHaveBeenCalled();
     });
   });
@@ -1859,23 +1860,23 @@ describe('initTrayStateManager', () => {
 
       player.setPlaybackState(PlaybackState.Playing);
 
-      // Fire first track
       const firstPromise = handlerFor('nowPlayingItemDidChange')(payload1) as Promise<void>;
 
-      // Fire second track before first artwork resolves
+      // The second track lands while the first artwork is still in flight.
       vi.mocked(downloadArtwork).mockResolvedValueOnce('/tmp/art2.png');
       await handlerFor('nowPlayingItemDidChange')(payload2);
 
-      // Clear the mock calls from the second track handler
+      // Settle the second track's own rebuild, so what follows is the first
+      // track's alone.
       vi.advanceTimersByTime(COALESCE_MS);
       vi.mocked(Menu.buildFromTemplate).mockClear();
 
-      // Resolve first artwork download - should be discarded (stale)
+      // The stale artwork arrives last and must not put the previous track back
+      // on a tray that has moved on.
       resolveFirst!('/tmp/art1.png');
       await firstPromise;
       vi.advanceTimersByTime(COALESCE_MS);
 
-      // No additional menu rebuild from the stale first track
       expect(vi.mocked(Menu.buildFromTemplate)).not.toHaveBeenCalled();
     });
   });

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -1,4 +1,3 @@
-// test/update.test.ts
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('../src/config', () => ({

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -1,4 +1,6 @@
-// test/url.test.ts
+// Covers the storefront fallback chain buildAppleMusicURL() resolves against:
+// the persisted code first, then the one derived from the system locale.
+// test/storefront.test.ts covers the same builder with a storefront always set.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import './mocks/storefront-deps';
 

--- a/test/wedgeDetector.test.ts
+++ b/test/wedgeDetector.test.ts
@@ -43,8 +43,9 @@ describe('wedgeDetector', () => {
   it('fires skip after STALL_THRESHOLD_MS of stalled playback', () => {
     player.handlePlaybackStateDidChange({ status: true, state: PlaybackState.Playing });
 
-    // The stall threshold is 5000ms and the check runs on a 1000ms interval, so
-    // the first check that can see the stall lands at 6000ms.
+    // The check runs on a 1000ms interval and proceeds once the elapsed time is
+    // no longer below the 5000ms threshold, so the 5000ms tick fires the skip.
+    // Advance past it to keep the test off the boundary.
     vi.advanceTimersByTime(6000);
 
     expect(mockWin.webContents.send).toHaveBeenCalledWith(

--- a/test/wedgeDetector.test.ts
+++ b/test/wedgeDetector.test.ts
@@ -41,10 +41,10 @@ describe('wedgeDetector', () => {
   });
 
   it('fires skip after STALL_THRESHOLD_MS of stalled playback', () => {
-    // Start playing
     player.handlePlaybackStateDidChange({ status: true, state: PlaybackState.Playing });
 
-    // Advance past the stall threshold (5000ms) plus one check interval (1000ms)
+    // The stall threshold is 5000ms and the check runs on a 1000ms interval, so
+    // the first check that can see the stall lands at 6000ms.
     vi.advanceTimersByTime(6000);
 
     expect(mockWin.webContents.send).toHaveBeenCalledWith(
@@ -76,21 +76,18 @@ describe('wedgeDetector', () => {
   it('respects MAX_SKIP_ATTEMPTS (3)', () => {
     player.handlePlaybackStateDidChange({ status: true, state: PlaybackState.Playing });
 
-    // Each skip resets lastAdvanceTime, so we need 5s + check intervals per skip.
-    // After each skip, the detector resets lastAdvanceTime = Date.now().
-    // Skip 1
+    // Each skip resets lastAdvanceTime, so the stall has to build up again and
+    // every attempt costs another 6000ms.
     vi.advanceTimersByTime(6000);
     expect(mockWin.webContents.send).toHaveBeenCalledTimes(1);
 
-    // Skip 2
     vi.advanceTimersByTime(6000);
     expect(mockWin.webContents.send).toHaveBeenCalledTimes(2);
 
-    // Skip 3
     vi.advanceTimersByTime(6000);
     expect(mockWin.webContents.send).toHaveBeenCalledTimes(3);
 
-    // Skip 4 should not happen - max reached
+    // The cap is what stops a queue that will not play being skipped end to end.
     vi.advanceTimersByTime(6000);
     expect(mockWin.webContents.send).toHaveBeenCalledTimes(3);
   });
@@ -112,19 +109,17 @@ describe('wedgeDetector', () => {
   it('track change resets skip counter', () => {
     player.handlePlaybackStateDidChange({ status: true, state: PlaybackState.Playing });
 
-    // Trigger 2 skips
     vi.advanceTimersByTime(6000);
     vi.advanceTimersByTime(6000);
     expect(mockWin.webContents.send).toHaveBeenCalledTimes(2);
 
-    // Track changes - resets skip counter
+    // A new track is a fresh recovery budget: the cap bounds the attempts spent
+    // on one track, not on the session.
     player.handleNowPlayingItemDidChange({ name: 'New Track', durationInMillis: 180000 });
 
-    // Should be able to skip again (counter reset to 0)
     vi.advanceTimersByTime(6000);
     expect(mockWin.webContents.send).toHaveBeenCalledTimes(3);
 
-    // And again
     vi.advanceTimersByTime(6000);
     expect(mockWin.webContents.send).toHaveBeenCalledTimes(4);
   });
@@ -133,7 +128,6 @@ describe('wedgeDetector', () => {
     player.handlePlaybackStateDidChange({ status: true, state: PlaybackState.Playing });
     vi.advanceTimersByTime(2000);
 
-    // Pause
     player.handlePlaybackStateDidChange({ status: true, state: PlaybackState.Paused });
 
     vi.advanceTimersByTime(10000);
@@ -142,16 +136,13 @@ describe('wedgeDetector', () => {
   });
 
   it('does not fire skip near end of track (within END_SAFETY_MARGIN_MS)', () => {
-    // Set a track with known duration
     player.handleNowPlayingItemDidChange({ name: 'Track', durationInMillis: 200000 });
     player.handlePlaybackStateDidChange({ status: true, state: PlaybackState.Playing });
 
-    // Position near the end of the track (within 10s safety margin)
-    // durationMs = 200000, END_SAFETY_MARGIN_MS = 10000
-    // Condition: (durationMs - lastPositionUs / 1000) < END_SAFETY_MARGIN_MS
-    // lastPositionUs is in microseconds based on variable name, but looking at the code
-    // it receives the playbackTimeDidChange payload directly.
-    // The check is: (200000 - payload / 1000) < 10000 => payload > 190000000
+    // A track about to finish reports the same still playhead as a stall, so the
+    // last END_SAFETY_MARGIN_MS of it are out of scope. The detector compares
+    // durationMs against the position in microseconds: with a 200s track and a
+    // 10s margin, anything past 190,000,000 is inside it.
     player.handlePlaybackTimeDidChange(191000000);
 
     vi.advanceTimersByTime(10000);

--- a/test/windowsTaskbar.test.ts
+++ b/test/windowsTaskbar.test.ts
@@ -1,4 +1,3 @@
-// test/windowsTaskbar.test.ts
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import path from 'path';
 import type { BrowserWindow } from 'electron';


### PR DESCRIPTION
Sweeps every source, test, asset, and build script for comment quality. Corrects comments that had drifted from the code beside them, replaces hardcoded line-number references with semantic anchors, rewrites past-tense regression prose and ticket numbers as present-tense design language, adds doc comments to exported symbols that lacked them, and removes narration that only restates the code. No logic changed: the only two non-comment line edits are trailing-comment wording on otherwise identical statements in the MPRIS integration and the tray. Behavioural concerns spotted during the pass are flagged separately for review, not fixed here.

Verified with `just lint` (both TypeScript programs and actionlint) and `just test` (945 tests across 30 files).
