### PR TITLE
fix(ci): open a pull request the toolchain workflow can land

### DIFF
--- a/.github/workflows/update-electron-toolchain.yml
+++ b/.github/workflows/update-electron-toolchain.yml
@@ -32,7 +32,15 @@ jobs:
       - name: Update package metadata
         run: node scripts/update-electron-toolchain.cjs
       - name: Refresh lockfile
-        run: npm install --package-lock-only --ignore-scripts
+        # Electron is named on its own first. A plain refresh keeps the commit a
+        # git dependency already resolved to, so a changed tag left package.json
+        # on the new release and package-lock.json on the old one, and every pull
+        # request this workflow opened carried the two disagreeing. The spec is
+        # read back from package.json, so the tag is written in one place only.
+        run: |
+          npm install --package-lock-only --ignore-scripts \
+            "electron@$(node -p "require('./package.json').devDependencies.electron")"
+          npm install --package-lock-only --ignore-scripts
       - name: Create pull request
         env:
           BRANCH: ci/update-electron-toolchain
@@ -54,8 +62,14 @@ jobs:
           git fetch origin "$BRANCH:refs/remotes/origin/$BRANCH" || true
           git push --force-with-lease --set-upstream origin "$BRANCH"
 
-          if gh pr view "$BRANCH" --json url --jq .url >/dev/null 2>&1; then
-            gh pr edit "$BRANCH" \
+          # Matched on open pull requests only, and edited by number. "gh pr view
+          # <branch>" and "gh pr edit <branch>" both match a merged or closed pull
+          # request for the same branch, so once one merged, every later run edited
+          # that dead pull request and never opened a new one.
+          pr_number="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+
+          if [ -n "$pr_number" ]; then
+            gh pr edit "$pr_number" \
               --title "build(deps): update Electron toolchain" \
               --body "Update CastLabs Electron, electron-builder, and electron-updater to current stable releases."
           else


### PR DESCRIPTION
Two faults kept the weekly Electron toolchain update invisible. `gh pr view "$BRANCH"` matches a pull request in any state, so once the previous toolchain pull request (#146) merged, every later run edited that merged pull request instead of opening a new one, confirmed in workflow run 30738845088. Separately, `npm install --package-lock-only --ignore-scripts` does not re-resolve a git dependency when only the tag changes, so `package.json` and `package-lock.json` ended up pinned to different Electron tags. This fixes both: matching on open pull requests only via `gh pr list --head "$BRANCH" --state open` and editing by the captured number, and naming Electron explicitly on install so the tag is written in one place and read back from `package.json`.

Verified with `actionlint` and a local test confirming the named-install form is idempotent.
