### PR TITLE
fix(lastfm): start playback accounting at opt-in

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -632,7 +632,7 @@ Themes are service-agnostic. `resolveTheme()` does not branch on the active serv
 1. `resetWedgeDetector()` clears `skipAttempts` and stops the timer. Stopping the timer suppresses a spurious skip-forward after the page re-initialises
 2. `setMusicService(id)` persists the new service
 3. `rebuildTrayMenu(tray)` runs when a tray exists
-4. `setThemeCssKey(null)` drops the tracked inserted-CSS key. The navigation below replaces the document, so the next injection must not call `removeInsertedCSS()` with a key from the old one
+4. `notifyDocumentReplacing()` queues a clear of the tracked inserted-CSS key. The queue orders it after any in-flight insert and before the next document's injection, so the next injection does not call `removeInsertedCSS()` with a key from the old document
 5. `loadURL(targetUrl ?? buildAppleMusicURL())`. The default resolves after step 2, so it reads the service just persisted
 
 `routeToMusicService(url)` handles `itms://` links. When the active service is not `music` it calls `switchService('music', url)`, otherwise it navigates directly. Passing the link into `switchService()` rather than navigating after it keeps the switch to one navigation.
@@ -690,11 +690,13 @@ Theme preference is stored in `electron-conf` as `theme` (`ThemeName`: `'apple-m
 
 ### Implementation
 
-`theme.ts` exposes `applyTheme(name: ThemeName)` and keeps the existing promise queue inside `initThemeCSS()` to serialise `removeInsertedCSS()/insertCSS()` operations. CSS sourcing now comes from `getThemeCss(name)`:
+`theme.ts` exposes `applyTheme(name: ThemeName)`. Both theme changes and page-load injections use the module-scope `themeCssOp` queue, so every `themeCssKey` mutation and every `removeInsertedCSS()` or `insertCSS()` call runs in order. `applyTheme()` removes the live sheet before inserting its replacement. `injectThemeCss()` does not remove a sheet, because a page load has replaced the document and invalidated the old key. CSS comes from `getThemeCss(name)`:
 
 - `'apple-music'` → `null` (remove any injected override)
 - bundled themes → lazily rendered via `buildThemeCss(...)` and cached in memory
 - `'custom'` → `userData/custom.css`, cached in memory; missing, unreadable, or whitespace-only files are treated as absent
+
+Each queued operation captures `documentGeneration`. A main-frame `did-navigate` event advances the generation, while `did-navigate-in-page` does not. Work for a replaced document is dropped and its tracked key is cleared. Inserts and removals check the generation again after each `await`, so a navigation cannot leave an untracked sheet on the new document.
 
 `custom.css` lifecycle:
 
@@ -777,7 +779,9 @@ The desktop token flow, because Last.fm offers no callback for a desktop app:
 - `scrobbleThresholdMs()` returns `null` for a track of 30 seconds or less; those never scrobble.
 - Anything longer scrobbles at half its duration or 4 minutes, whichever comes first, measured against accumulated play time rather than wall time since the track began.
 - `trackStartUnix` is captured at the first real play transition, so a track queued while paused carries an honest timestamp.
-- A track scrobbles once. A failed submission is dropped, never retried.
+- Each track makes one live scrobble request. A final API refusal is dropped. A transport failure or temporary Last.fm error persists the play in `lastfm.pendingScrobbles` instead.
+- The queue keeps the newest 50 plays and survives restarts. A successful now-playing or live scrobble request drains up to 50 queued plays as one indexed batch. No timer retries the queue.
+- Disconnecting clears the queue, so a later account cannot receive another account's plays.
 
 ### Error handling
 
@@ -1020,7 +1024,7 @@ electron-updater manifest filenames are hardcoded and cannot be changed:
 
 ### Configuration
 
-- `verifyUpdateCodeSignature: false` is required on Windows because the app is unsigned.
+- Windows builds are unsigned. `configureAutoUpdate()` detects `NsisUpdater` and replaces `verifyUpdateCodeSignature` with a verifier that resolves to `null`. Assigning `false` would not work because the electron-updater setter ignores falsy values. Remove this override when Windows builds are signed.
 - AppImage `artifactName` must omit the version component - use `${productName}-${os}-${arch}.${ext}`. Including the version causes filename changes that break desktop shortcuts after update.
 - Future package managers (Scoop, Chocolatey) must set `SIDRA_DISABLE_AUTO_UPDATE=1` in their install manifests to suppress the updater.
 
@@ -1070,7 +1074,7 @@ electron-updater manifest filenames are hardcoded and cannot be changed:
 | About window | Frameless `BrowserWindow` + `assets/about.html` | Localised labels via `about.json` |
 | Navigation bar | `assets/navigationBar.js` injected post-load | Back/forward/reload buttons in sidebar; localised aria-labels substituted for `__SIDRA_NAV_LABELS__` at read time |
 | Auth iframe filtering | `authStyleFix.css` + `webFrameMain.executeJavaScript()` | Hides unsupported passkey and "Sign in with iPhone" desktop flows |
-| Zoom factor preference | `zoom` in `electron-conf` | 1.0x to 2.0x via tray submenu |
+| Zoom factor preference | `zoomFactor` in `electron-conf` | 1.0x to 2.0x via tray submenu |
 | Wedge detector | `src/wedgeDetector.ts` | Auto-skip on playback stall |
 | Artwork cache | `src/artwork.ts` | UUID-based filenames, 7-day expiry, atomic writes |
 | Pause timer utility | `src/pauseTimer.ts` | `createPauseTimer()` shared by tray, dock, Discord |
@@ -1104,7 +1108,7 @@ electron-updater manifest filenames are hardcoded and cannot be changed:
 | Apple blocks Electron user agent | High | Low | Spoof Chrome UA on all requests |
 | Apple changes MusicKit.js API | Medium | Low | MusicKit.js is a public developer API with versioning |
 | Apple renames the `chrome-volume` class | Low | Medium | Scroll-to-change-volume stops responding; every other volume path is unaffected. The token is the only DOM detail the hook depends on, and no Svelte scope hash is matched, so an Apple rebuild alone does not break it |
-| CastLabs Electron lags Electron releases | Low | Medium | Only affects security patching cadence; v40.7.0+wvcus, tracking close to mainline |
+| CastLabs Electron lags Electron releases | Low | Medium | Only affects security patching cadence; v43.0.0+wvcus, tracking close to mainline |
 | Live radio stations crash | Medium | Confirmed | Known issue in apple-music-wrapper; investigate `did-crash` handler |
 | CSP blocks script injection | Low | Very low | `executeJavaScript()` bypasses page CSP in Electron |
 | Apple legal action | Medium | Very low | Multiple similar apps exist and have for years; requires Apple Music subscription |

--- a/docs/Sidra-vs-Cider-Comparison.md
+++ b/docs/Sidra-vs-Cider-Comparison.md
@@ -1,6 +1,6 @@
 # Sidra vs Cider: Apple Music desktop client comparison
 
-**Last updated:** 2026-05-23
+**Last updated:** 2026-08-02
 **Confidence note:** Cider v1 (open-source, AGPL-3.0) analysis is based on source code inspection of `ciderapp/Cider` on GitHub. Cider 2+ (proprietary) analysis is based on public issue trackers, devlogs, changelogs, and community reports - no source code review was possible. Sidra analysis is based on full source code review.
 
 ---
@@ -25,10 +25,10 @@
 
 ### Sidra
 
-Sidra loads `music.apple.com` directly inside CastLabs Electron (a Chromium fork with Widevine CDM support). A lightweight hook script (`musicKitHook.js`, injected after page load) taps MusicKit.js events and forwards them over Electron IPC to the main process. The main process distributes events to platform integrations (MPRIS, Discord, notifications, macOS Dock, Windows taskbar).
+Sidra loads `music.apple.com` and `classical.music.apple.com` directly inside CastLabs Electron (a Chromium fork with Widevine CDM support). A lightweight hook script (`musicKitHook.js`, injected after page load) taps MusicKit.js events and forwards them over Electron IPC to the main process. The main process distributes events to platform integrations (MPRIS, Discord, notifications, macOS Dock, Windows taskbar).
 
 ```
-music.apple.com (Apple's UI, unmodified)
+music.apple.com / classical.music.apple.com (Apple's UI, unmodified)
   -> MusicKit.js events
     -> musicKitHook.js (injected, read-only observer)
       -> IPC -> player.ts (EventEmitter)
@@ -37,7 +37,7 @@ music.apple.com (Apple's UI, unmodified)
 
 Audio flows from MusicKit.js through the HTMLMediaElement into Chromium's native media stack. Sidra never intercepts, re-routes, or processes the audio stream. Controls flow in reverse via `webContents.send()` through the preload bridge to `window.__sidra` methods.
 
-**Key architectural property:** Sidra is a thin shell around Apple's own web application. When Apple updates `music.apple.com`, Sidra inherits the changes automatically - no patch cycle required.
+**Key architectural property:** Sidra is a thin shell around Apple's own web applications. When Apple updates either service, Sidra inherits the changes automatically - no patch cycle required.
 
 ### Cider v1 (open source, archived)
 
@@ -251,8 +251,8 @@ Sidra's security posture, verified by a full security audit (Semgrep, Gitleaks, 
 | Spatial audio effect | No | Yes (custom convolution, not Dolby Atmos) |
 | Lossless (macOS/Windows) | Yes (EVS production VMP) | Claimed |
 | **Interface** | | |
-| UI | Apple's `music.apple.com` (maintained by Apple) | Custom Vue.js UI |
-| Themes | Catppuccin; Apple Music default | Extensive theming system |
+| UI | Apple's `music.apple.com` and `classical.music.apple.com` (maintained by Apple) | Custom Vue.js UI |
+| Themes | Apple Music default; Catppuccin; Dracula; Gruvbox; Nord; Rosé Pine; Solarized; custom CSS. Applies to both services | Extensive theming system |
 | Immersive/fullscreen mode | No | Yes (album art visualisation) |
 | Mini player | No | Yes |
 | Lyrics display | Via Apple's web UI | Custom lyrics view |
@@ -283,7 +283,7 @@ Sidra's security posture, verified by a full security audit (Semgrep, Gitleaks, 
 
 ### How each handles Apple Music updates
 
-**Sidra:** Loads `music.apple.com` directly. When Apple updates the web player - new features, UI changes, bug fixes, API changes - Sidra inherits them automatically with zero developer intervention. The only maintenance surface is the MusicKit.js event API that the hook script observes, which has been stable.
+**Sidra:** Loads `music.apple.com` and `classical.music.apple.com` directly. When Apple updates either web player - new features, UI changes, bug fixes, API changes - Sidra inherits them automatically with zero developer intervention. The only maintenance surface is the MusicKit.js event API that the hook script observes, which has been stable.
 
 Sidra also keeps Apple's authentication UI, but filters impossible desktop choices. Apple's passkey and "Sign in with iPhone" buttons rely on WebAuthn cross-device transport and Chromium's `//chrome` product UI for the QR-code modal. Electron only ships `//content`, so Sidra hides those options in the auth iframe and leaves the password flow visible.
 

--- a/nix/linux.nix
+++ b/nix/linux.nix
@@ -134,7 +134,7 @@ let
   ];
 
   fhs = buildFHSEnv {
-    name = pname;
+    inherit pname version;
     targetPkgs = _: libs;
 
     runScript = "${unpacked}/opt/sidra";

--- a/src/integrations/lastfm/index.ts
+++ b/src/integrations/lastfm/index.ts
@@ -779,6 +779,7 @@ function resetTrack(payload: NowPlayingPayload | null): void {
  * when a track is selected while paused and played later.
  */
 function markPlaybackStarted(): void {
+  if (!getLastfmEnabled()) return;
   if (trackStartUnix === 0) trackStartUnix = nowUnix();
   lastResumeAt = Date.now();
   sendNowPlaying();

--- a/test/lastfm.test.ts
+++ b/test/lastfm.test.ts
@@ -308,11 +308,9 @@ describe('scrobble submission', () => {
     player.emitNowPlaying(TRACK);
     player.emitPlaybackState(PlaybackState.Playing);
     play(player, 100_000);
-    player.emitPlaybackState(PlaybackState.Paused);
 
     session.enabled = true;
     lastfm.enable();
-    player.emitPlaybackState(PlaybackState.Playing);
     play(player, 100_000);
 
     expect(scrobbles()).toHaveLength(0);

--- a/test/lastfm.test.ts
+++ b/test/lastfm.test.ts
@@ -301,6 +301,29 @@ describe('scrobble submission', () => {
     expect(scrobbles()).toHaveLength(1);
   });
 
+  it('counts playback from opt-in when the track started while scrobbling was off', async () => {
+    session.enabled = false;
+    const { lastfm, player } = await startIntegration();
+
+    player.emitNowPlaying(TRACK);
+    player.emitPlaybackState(PlaybackState.Playing);
+    play(player, 100_000);
+    player.emitPlaybackState(PlaybackState.Paused);
+
+    session.enabled = true;
+    lastfm.enable();
+    player.emitPlaybackState(PlaybackState.Playing);
+    play(player, 100_000);
+
+    expect(scrobbles()).toHaveLength(0);
+
+    play(player, 100_000);
+
+    const submitted = scrobbles();
+    expect(submitted).toHaveLength(1);
+    expect(submitted[0].get('timestamp')).toBe(String(Number(START_UNIX) + 100));
+  });
+
   it('scrobbles each pass of a repeated track with its own timestamp', async () => {
     const { player } = await startIntegration();
 


### PR DESCRIPTION
fix(lastfm): start playback accounting at opt-in

Start Last.fm playback accounting when scrobbling is enabled after a track has
already begun. Expose the version in the Nix FHS environment and align the
specification and comparison docs with current service, theme, and updater
behaviour.

Verified with `just test` (35 files, 1,045 tests).
