### PR TITLE
perf: speed up Linux MPRIS, tray, and launch UX

### DIFF
--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -27,6 +27,21 @@
      * @param {number} positionUs - Position in microseconds
      * @returns {void}
      */
+    /**
+     * Drop a pending throttled position without sending. Used when re-hooking
+     * MusicKit so a timer from the previous instance cannot publish a stale
+     * playhead after attach.
+     * @returns {void}
+     */
+    function resetPositionIpcThrottle() {
+      if (positionIpcTimer !== null) {
+        clearTimeout(positionIpcTimer);
+        positionIpcTimer = null;
+      }
+      pendingPositionUs = null;
+      lastPositionIpcAt = 0;
+    }
+
     function flushPositionIpc(positionUs) {
       if (positionIpcTimer !== null) {
         clearTimeout(positionIpcTimer);
@@ -203,9 +218,13 @@
        * @param {{ item: object | null }} event - MusicKit nowPlayingItemDidChange event
        */
       mk.addEventListener('nowPlayingItemDidChange', ({ item }) => {
-        flushPositionIpc(mk.currentPlaybackTime * 1_000_000);
+        // Drop a throttled tick first so it cannot race after metadata and look
+        // like a seek on the previous track. Metadata then position keeps MPRIS
+        // Seeked associated with the new trackid.
+        resetPositionIpcThrottle();
         if (!item) {
           sendToMain('nowPlayingItemDidChange', null);
+          flushPositionIpc(mk.currentPlaybackTime * 1_000_000);
           clearPositionState();
           return;
         }
@@ -235,6 +254,7 @@
           // built from config can name a host the track was never on.
           sourceHost: window.location.hostname,
         });
+        flushPositionIpc(mk.currentPlaybackTime * 1_000_000);
       });
 
       /**
@@ -333,6 +353,9 @@
       // Stopping the previous poll comes first, so a throw in either attach
       // below cannot leave a second timer polling the replaced instance.
       stopVolumePoll();
+      // Drop a throttled position from the previous singleton before listening
+      // on the replacement; otherwise the timer can publish a stale playhead.
+      resetPositionIpcThrottle();
       attachPlaybackListeners(mk);
       attachVolume(mk);
 

--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -13,6 +13,53 @@
     /** @type {number | null} Timer ID for the volume polling fallback. */
     let volumePollTimer = null;
 
+    /** Minimum gap between position IPC sends (MediaSession is not throttled). */
+    const POSITION_IPC_THROTTLE_MS = 250;
+    /** @type {number} Last time a playbackTimeDidChange IPC was sent. */
+    let lastPositionIpcAt = 0;
+    /** @type {number | null} Pending position (µs) waiting for the throttle window. */
+    let pendingPositionUs = null;
+    /** @type {ReturnType<typeof setTimeout> | null} */
+    let positionIpcTimer = null;
+
+    /**
+     * Send the latest playback position to main, clearing any pending throttle.
+     * @param {number} positionUs - Position in microseconds
+     * @returns {void}
+     */
+    function flushPositionIpc(positionUs) {
+      if (positionIpcTimer !== null) {
+        clearTimeout(positionIpcTimer);
+        positionIpcTimer = null;
+      }
+      pendingPositionUs = null;
+      lastPositionIpcAt = Date.now();
+      sendToMain('playbackTimeDidChange', positionUs);
+    }
+
+    /**
+     * Throttle position IPC so main/MPRIS are not flooded every MusicKit tick.
+     * MediaSession reporting stays on every tick (see reportPositionState).
+     * @param {number} positionUs - Position in microseconds
+     * @returns {void}
+     */
+    function sendPositionIpcThrottled(positionUs) {
+      const now = Date.now();
+      const elapsed = now - lastPositionIpcAt;
+      if (elapsed >= POSITION_IPC_THROTTLE_MS) {
+        flushPositionIpc(positionUs);
+        return;
+      }
+
+      pendingPositionUs = positionUs;
+      if (positionIpcTimer !== null) return;
+      positionIpcTimer = setTimeout(() => {
+        positionIpcTimer = null;
+        if (pendingPositionUs === null) return;
+        flushPositionIpc(pendingPositionUs);
+      }, POSITION_IPC_THROTTLE_MS - elapsed);
+    }
+
     /**
      * Send to the main process, tolerating an absent bridge.
      *
@@ -131,6 +178,19 @@
        * @param {{ state: number }} event - MusicKit playbackStateDidChange event
        */
       mk.addEventListener('playbackStateDidChange', ({ state }) => {
+        // Flush a pending position so pause/stop edges stay accurate for
+        // wedge detection and MPRIS Seeked. Transient states (loading,
+        // seeking, …) keep the throttle so they do not flood main.
+        const ps = MusicKit.PlaybackStates;
+        if (
+          state === ps.paused ||
+          state === ps.stopped ||
+          state === ps.ended ||
+          state === ps.completed ||
+          state === ps.none
+        ) {
+          flushPositionIpc(mk.currentPlaybackTime * 1_000_000);
+        }
         sendToMain('playbackStateDidChange', {
           status: state === MusicKit.PlaybackStates.playing,
           state,
@@ -143,6 +203,7 @@
        * @param {{ item: object | null }} event - MusicKit nowPlayingItemDidChange event
        */
       mk.addEventListener('nowPlayingItemDidChange', ({ item }) => {
+        flushPositionIpc(mk.currentPlaybackTime * 1_000_000);
         if (!item) {
           sendToMain('nowPlayingItemDidChange', null);
           clearPositionState();
@@ -179,12 +240,14 @@
       /**
        * Forward playback position (in microseconds) to the main process and
        * refresh the media session position state.
+       *
+       * MediaSession is updated every tick; IPC is throttled (~250ms) with a
+       * flush on pause/stop/track change so Seeked and wedge detection stay
+       * correct without flooding the main process.
        */
       mk.addEventListener('playbackTimeDidChange', () => {
-        sendToMain('playbackTimeDidChange',
-          mk.currentPlaybackTime * 1_000_000
-        );
         reportPositionState(mk);
+        sendPositionIpcThrottled(mk.currentPlaybackTime * 1_000_000);
       });
 
       /** Forward repeat mode changes to the main process. */

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -388,6 +388,7 @@ Chromium has a built-in MPRIS bridge (via `navigator.mediaSession`) that must be
 // In main.ts, before app.whenReady()
 if (process.platform === 'linux') {
   app.commandLine.appendSwitch('enable-features', 'UseOzonePlatform,WaylandWindowDecorations');
+  app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
   app.commandLine.appendSwitch('disable-features', 'MediaSessionService,WaylandWpColorManagerV1,AudioServiceOutOfProcess');
   app.setDesktopName('sidra.desktop');
 }

--- a/src/integrations/mpris/index.ts
+++ b/src/integrations/mpris/index.ts
@@ -251,12 +251,42 @@ class MediaPlayer2Player extends Interface {
   }
 
   /**
-   * Coalesces property changes into one `PropertiesChanged` signal. dbus-next
-   * emits nothing of its own accord, so a cached property that changes without
-   * passing through here is one no client ever learns about.
+   * Flushes every pending `PropertiesChanged` property at once. Cleared of its
+   * debounce timer first so a later Metadata/Volume coalesce cannot sit on top
+   * of a PlaybackStatus that already went out.
+   */
+  private _flushPendingChanges(): void {
+    if (this._debounceTimer) {
+      clearTimeout(this._debounceTimer);
+      this._debounceTimer = null;
+    }
+    if (Object.keys(this._pendingChanges).length === 0) return;
+    try {
+      Interface.emitPropertiesChanged(this, this._pendingChanges, []);
+    } catch (err: unknown) {
+      mprisLog.warn('failed to emit PropertiesChanged:', errorMessage(err));
+    }
+    this._pendingChanges = {};
+  }
+
+  /**
+   * Emits control-plane properties immediately (PlaybackStatus, LoopStatus,
+   * Shuffle). Play/pause latency on the desktop shell matters more than
+   * coalescing those with Metadata.
+   */
+  private _emitPropertiesNow(properties: Record<string, unknown>): void {
+    Object.assign(this._pendingChanges, properties);
+    this._flushPendingChanges();
+  }
+
+  /**
+   * Coalesces noisy property changes into one `PropertiesChanged` signal.
+   * dbus-next emits nothing of its own accord, so a cached property that
+   * changes without passing through here is one no client ever learns about.
    *
-   * `Position` must never be among the properties: the MPRIS spec excludes it,
-   * and clients read the property or follow `Seeked` instead.
+   * Used for Metadata and Volume. `Position` must never be among the
+   * properties: the MPRIS spec excludes it, and clients read the property or
+   * follow `Seeked` instead.
    */
   private _schedulePropertyEmission(properties: Record<string, unknown>): void {
     Object.assign(this._pendingChanges, properties);
@@ -265,14 +295,7 @@ class MediaPlayer2Player extends Interface {
     }
     this._debounceTimer = setTimeout(() => {
       this._debounceTimer = null;
-      if (Object.keys(this._pendingChanges).length > 0) {
-        try {
-          Interface.emitPropertiesChanged(this, this._pendingChanges, []);
-        } catch (err: unknown) {
-          mprisLog.warn('failed to emit PropertiesChanged:', errorMessage(err));
-        }
-        this._pendingChanges = {};
-      }
+      this._flushPendingChanges();
     }, this._debounceMs);
   }
 
@@ -296,11 +319,15 @@ class MediaPlayer2Player extends Interface {
       status = 'Stopped';
     }
 
-    if (status !== this._playbackStatus) {
-      this._lastPositionTimestamp = Date.now();
-    }
+    // Skip a no-op emission when MusicKit walks through several transient
+    // states that all map to the same MPRIS value (e.g. Loading → Seeking →
+    // Waiting → Stopped). The mapping still runs for every state; only the
+    // D-Bus signal is suppressed when nothing a client can see has changed.
+    if (status === this._playbackStatus) return;
+
+    this._lastPositionTimestamp = Date.now();
     this._playbackStatus = status;
-    this._schedulePropertyEmission({ PlaybackStatus: status });
+    this._emitPropertiesNow({ PlaybackStatus: status });
   }
 
   /**
@@ -326,6 +353,13 @@ class MediaPlayer2Player extends Interface {
 
     const metadata = buildMetadata(payload);
     const trackId = buildTrackId(payload.trackId ?? 'unknown');
+    // Defer https artwork until the cache attempt finishes so clients do not
+    // see HTTPS then file:// in two PropertiesChanged signals a moment apart.
+    // Local or other schemes stay on the first emission.
+    const httpsArtwork = payload.artworkUrl?.startsWith('https://') ? payload.artworkUrl : null;
+    if (httpsArtwork) {
+      delete metadata['mpris:artUrl'];
+    }
 
     this._metadata = metadata;
     this._currentTrackId = trackId;
@@ -336,19 +370,22 @@ class MediaPlayer2Player extends Interface {
     this._position = 0;
     this.Seeked(0);
 
-    if (payload.artworkUrl && payload.artworkUrl.startsWith('https://')) {
-      downloadArtwork(payload.artworkUrl).then((localPath) => {
-        if (!localPath) return;
+    if (httpsArtwork) {
+      downloadArtwork(httpsArtwork).then((localPath) => {
         // The download outlives a fast track change, and a late one would
         // otherwise put the previous cover on the track now playing.
         if (this._currentTrackId !== trackId) return;
-        const fileUri = `file://${localPath}`;
-        metadata['mpris:artUrl'] = new Variant('s', fileUri);
+        const artUrl = localPath ? `file://${localPath}` : httpsArtwork;
+        metadata['mpris:artUrl'] = new Variant('s', artUrl);
         this._metadata = metadata;
         this._schedulePropertyEmission({ Metadata: metadata });
-        mprisLog.debug('mpris:artUrl updated to local file:', fileUri);
+        mprisLog.debug('mpris:artUrl updated:', artUrl);
       }).catch((err: unknown) => {
         mprisLog.warn('artwork caching failed:', errorMessage(err));
+        if (this._currentTrackId !== trackId) return;
+        metadata['mpris:artUrl'] = new Variant('s', httpsArtwork);
+        this._metadata = metadata;
+        this._schedulePropertyEmission({ Metadata: metadata });
       });
     }
   }
@@ -367,16 +404,18 @@ class MediaPlayer2Player extends Interface {
       return;
     }
 
+    if (loopStatus === this._loopStatus) return;
     this._loopStatus = loopStatus;
-    this._schedulePropertyEmission({ LoopStatus: loopStatus });
+    this._emitPropertiesNow({ LoopStatus: loopStatus });
   }
 
   updateShuffleMode(payload: number | null): void {
     if (payload == null) return;
 
     const shuffle = payload === 1;
+    if (shuffle === this._shuffle) return;
     this._shuffle = shuffle;
-    this._schedulePropertyEmission({ Shuffle: shuffle });
+    this._emitPropertiesNow({ Shuffle: shuffle });
   }
 
   updateVolume(payload: number | null): void {
@@ -397,6 +436,7 @@ class MediaPlayer2Player extends Interface {
     }
 
     const rounded = Math.round(payload * 100) / 100;
+    if (rounded === this._volume) return;
     this._volume = rounded;
     this._schedulePropertyEmission({ Volume: rounded });
   }

--- a/src/integrations/mpris/index.ts
+++ b/src/integrations/mpris/index.ts
@@ -545,7 +545,12 @@ class MediaPlayer2Player extends Interface {
       mprisLog.warn('invalid LoopStatus value:', value);
       return;
     }
-    this._loopStatus = value;
+    // Emit here: the MusicKit echo hits updateRepeatMode with the same value
+    // and early-returns, so clients would never see PropertiesChanged otherwise.
+    if (value !== this._loopStatus) {
+      this._loopStatus = value;
+      this._emitPropertiesNow({ LoopStatus: value });
+    }
     this._send('player:setRepeat', mode);
   }
 
@@ -554,7 +559,11 @@ class MediaPlayer2Player extends Interface {
   }
 
   set Shuffle(value: boolean) {
-    this._shuffle = value;
+    // Same as LoopStatus: cache + emit on the setter; the echo is a no-op.
+    if (value !== this._shuffle) {
+      this._shuffle = value;
+      this._emitPropertiesNow({ Shuffle: value });
+    }
     const mode = value ? 1 : 0;
     this._send('player:setShuffle', mode);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,6 +69,9 @@ if (process.platform === 'win32') {
 // --- Platform switches: must run before app.whenReady() ---
 if (process.platform === 'linux') {
   app.commandLine.appendSwitch('enable-features', 'UseOzonePlatform,WaylandWindowDecorations');
+  // Prefer native Wayland when available, else fall back to X11/XWayland.
+  // UseOzonePlatform alone often still lands on XWayland.
+  app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
   // MediaSessionService off: Sidra registers its own MPRIS service, and
   // Chromium's would be a second, conflicting registration on the same bus.
   // AudioServiceOutOfProcess off: it moves audio back in-process, which is
@@ -265,8 +268,10 @@ async function initSession(): Promise<Electron.Session> {
   const ses = session.fromPartition('persist:sidra');
   await Promise.all([
     components.whenReady(),
+    // Clear stale service workers only. Dropping the HTTP cache on every
+    // launch forced a cold Apple Music load; SWs are the half that goes stale.
     ses.clearData({
-      dataTypes: ['serviceWorkers', 'cache'],
+      dataTypes: ['serviceWorkers'],
       origins: allServices().map(svc => svc.origin),
     }),
   ]);
@@ -326,6 +331,10 @@ function createMainWindow(ses: Electron.Session): { win: BrowserWindow; winReady
       contextIsolation: true,
       plugins: true,
       sandbox: true,
+      // Keep MusicKit timers alive when the window is hidden (close-to-tray).
+      backgroundThrottling: false,
+      // No editable surface outside Apple's page; saves a little renderer cost.
+      spellcheck: false,
     },
   });
 

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -118,12 +118,27 @@ function isMacOSTahoeOrLater(): boolean {
 // Volume-drag rebuilds reuse the same icons, so cache by theme + basename.
 const menuIconCache = new Map<string, Electron.NativeImage | undefined>();
 // Artwork is rebuilt with the same local path across coalesced menu updates.
+// Bounded: a long listening session would otherwise retain every cover ever shown.
+const ARTWORK_ICON_CACHE_MAX = 4;
 const artworkIconCache = new Map<string, Electron.NativeImage | undefined>();
 
 /** Clears cached menu/artwork NativeImages (theme change, or tests). */
 export function invalidateTrayImageCaches(): void {
   menuIconCache.clear();
   artworkIconCache.clear();
+}
+
+function rememberArtworkIcon(cacheKey: string, value: Electron.NativeImage | undefined): void {
+  // Refresh insertion order so a reused cover is treated as newest.
+  if (artworkIconCache.has(cacheKey)) {
+    artworkIconCache.delete(cacheKey);
+  }
+  artworkIconCache.set(cacheKey, value);
+  while (artworkIconCache.size > ARTWORK_ICON_CACHE_MAX) {
+    const oldest = artworkIconCache.keys().next().value;
+    if (oldest === undefined) break;
+    artworkIconCache.delete(oldest);
+  }
 }
 
 /**
@@ -517,7 +532,7 @@ function buildArtworkIcon(artworkPath: string | null, isLinux: boolean): Electro
 
   const src = nativeImage.createFromPath(artworkPath);
   if (src.isEmpty()) {
-    artworkIconCache.set(cacheKey, undefined);
+    rememberArtworkIcon(cacheKey, undefined);
     return undefined;
   }
 
@@ -536,7 +551,7 @@ function buildArtworkIcon(artworkPath: string | null, isLinux: boolean): Electro
     resolved = img;
   }
 
-  artworkIconCache.set(cacheKey, resolved);
+  rememberArtworkIcon(cacheKey, resolved);
   return resolved;
 }
 

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -114,6 +114,18 @@ function isMacOSTahoeOrLater(): boolean {
   return !isNaN(major) && major >= 26;
 }
 
+// Linux/Windows menu PNGs are loaded and resized on every tray rebuild.
+// Volume-drag rebuilds reuse the same icons, so cache by theme + basename.
+const menuIconCache = new Map<string, Electron.NativeImage | undefined>();
+// Artwork is rebuilt with the same local path across coalesced menu updates.
+const artworkIconCache = new Map<string, Electron.NativeImage | undefined>();
+
+/** Clears cached menu/artwork NativeImages (theme change, or tests). */
+export function invalidateTrayImageCaches(): void {
+  menuIconCache.clear();
+  artworkIconCache.clear();
+}
+
 /**
  * Icon for a menu action, or undefined when the platform or the action has
  * none. Callers spread the result conditionally, because Electron renders a
@@ -145,9 +157,16 @@ export function getMenuIcon(action: MenuIconKey): Electron.NativeImage | undefin
   if (!baseName) return undefined;
 
   const variant = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+  const cacheKey = `${variant}:${baseName}`;
+  if (menuIconCache.has(cacheKey)) {
+    return menuIconCache.get(cacheKey);
+  }
+
   const iconPath = path.join(menuIconsDir, variant, `${baseName}.png`);
   const img = nativeImage.createFromPath(iconPath);
-  return img.isEmpty() ? undefined : img;
+  const resolved = img.isEmpty() ? undefined : img;
+  menuIconCache.set(cacheKey, resolved);
+  return resolved;
 }
 
 function getLinuxTrayIconPath(): string {
@@ -490,22 +509,35 @@ function buildUpdateMenuItems(): Electron.MenuItemConstructorOptions[] {
 /** Artwork icon for the track row, multi-representation for HiDPI. */
 function buildArtworkIcon(artworkPath: string | null, isLinux: boolean): Electron.NativeImage | undefined {
   if (!artworkPath) return undefined;
-  const src = nativeImage.createFromPath(artworkPath);
-  if (src.isEmpty()) return undefined;
 
+  const cacheKey = `${isLinux ? 'linux' : 'other'}:${artworkPath}`;
+  if (artworkIconCache.has(cacheKey)) {
+    return artworkIconCache.get(cacheKey);
+  }
+
+  const src = nativeImage.createFromPath(artworkPath);
+  if (src.isEmpty()) {
+    artworkIconCache.set(cacheKey, undefined);
+    return undefined;
+  }
+
+  let resolved: Electron.NativeImage;
   if (isLinux) {
     // libdbusmenu serialises a single image and the host shell rescales;
     // preserve the on-disk path so libappindicator does not stage a
     // temp-file copy unreachable to the host indicator daemon under snap.
-    return src.resize({ width: 24, height: 24 });
+    resolved = src.resize({ width: 24, height: 24 });
+  } else {
+    const img = nativeImage.createEmpty();
+    const sizes: [number, number][] = [[1.0, 18], [1.25, 23], [1.5, 27], [1.75, 32], [2.0, 36]];
+    for (const [scaleFactor, size] of sizes) {
+      img.addRepresentation({ scaleFactor, buffer: src.resize({ width: size, height: size }).toPNG() });
+    }
+    resolved = img;
   }
 
-  const img = nativeImage.createEmpty();
-  const sizes: [number, number][] = [[1.0, 18], [1.25, 23], [1.5, 27], [1.75, 32], [2.0, 36]];
-  for (const [scaleFactor, size] of sizes) {
-    img.addRepresentation({ scaleFactor, buffer: src.resize({ width: size, height: size }).toPNG() });
-  }
-  return img;
+  artworkIconCache.set(cacheKey, resolved);
+  return resolved;
 }
 
 /**
@@ -745,6 +777,7 @@ export function createTray(): Tray {
 
   if (process.platform === 'linux') {
     nativeTheme.on('updated', () => {
+      invalidateTrayImageCaches();
       const newIconPath = getLinuxTrayIconPath();
       trayLog.info('theme changed, switching tray icon:', newIconPath);
       tray.setImage(newIconPath);
@@ -753,6 +786,7 @@ export function createTray(): Tray {
     });
   } else if (process.platform === 'win32') {
     nativeTheme.on('updated', () => {
+      invalidateTrayImageCaches();
       trayLog.info('theme changed, rebuilding context menu');
       tray.setContextMenu(buildContextMenu(tray));
     });

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -78,6 +78,11 @@ const bootstrap = vi.hoisted(() => {
       silly: vi.fn(),
     },
     tray: {},
+    session: {
+      clearData: vi.fn(() => Promise.resolve()),
+      setUserAgent: vi.fn(),
+      webRequest: { onBeforeSendHeaders: vi.fn() },
+    },
   };
 });
 
@@ -110,11 +115,7 @@ vi.mock('electron', () => ({
   },
   session: {
     defaultSession: { setUserAgent: vi.fn() },
-    fromPartition: vi.fn(() => ({
-      clearData: vi.fn(() => Promise.resolve()),
-      setUserAgent: vi.fn(),
-      webRequest: { onBeforeSendHeaders: vi.fn() },
-    })),
+    fromPartition: vi.fn(() => bootstrap.session),
   },
   Tray: class {},
   webFrameMain: { fromId: vi.fn() },
@@ -274,6 +275,8 @@ describe('main bootstrap', () => {
         contextIsolation: true,
         plugins: true,
         sandbox: true,
+        backgroundThrottling: false,
+        spellcheck: false,
       }),
     }));
     expect(bootstrap.mainWindow.loadURL).toHaveBeenCalledWith(
@@ -281,6 +284,11 @@ describe('main bootstrap', () => {
       { userAgent: expect.stringContaining('Chrome/148.0.0.0') },
     );
     expect(bootstrap.log.warn).toHaveBeenCalledWith('initial navigation loadURL failed:', 'offline');
+
+    expect(bootstrap.session.clearData).toHaveBeenCalledWith({
+      dataTypes: ['serviceWorkers'],
+      origins: ['https://music.apple.com'],
+    });
 
     const didFinishLoad = bootstrap.mainWebListeners.get('did-finish-load');
     expect(didFinishLoad).toBeDefined();
@@ -294,5 +302,21 @@ describe('main bootstrap', () => {
     expect(bootstrap.integrations.wedgeDetector).toHaveBeenCalledOnce();
     expect(bootstrap.integrations.trayState).toHaveBeenCalledOnce();
     expect(bootstrap.appOn).toHaveBeenCalledWith('will-quit', expect.any(Function));
+  });
+
+  it('applies Linux Wayland ozone switches before ready', async () => {
+    setPlatform('linux');
+    const { app } = await import('electron');
+    await import('../src/main');
+
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith(
+      'enable-features',
+      'UseOzonePlatform,WaylandWindowDecorations',
+    );
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('ozone-platform-hint', 'auto');
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith(
+      'disable-features',
+      'MediaSessionService,WaylandWpColorManagerV1,AudioServiceOutOfProcess',
+    );
   });
 });

--- a/test/mpris.test.ts
+++ b/test/mpris.test.ts
@@ -63,6 +63,8 @@ interface PlayerInterface {
   OpenUri(uri: string): void;
   Seeked(position: number): number;
   Volume: number;
+  LoopStatus: string;
+  Shuffle: boolean;
   readonly PlaybackStatus: string;
   readonly Metadata: Record<string, VariantValue>;
   readonly Position: number;
@@ -241,6 +243,31 @@ describe('MPRIS PlaybackStatus mapping', () => {
     expect(iface.PlaybackStatus).toBe('Stopped');
     // One PropertiesChanged for the Playing → Stopped edge; the rest are no-ops.
     expect(emissions).toEqual([{ PlaybackStatus: 'Stopped' }]);
+  });
+});
+
+describe('MPRIS LoopStatus and Shuffle setters', () => {
+  it('emits LoopStatus from the setter so clients do not wait on a no-op echo', () => {
+    const iface = initPlayerInterface();
+    iface.LoopStatus = 'Track';
+    expect(iface.LoopStatus).toBe('Track');
+    expect(emissions).toEqual([{ LoopStatus: 'Track' }]);
+    expect(win.webContents.send).toHaveBeenCalledWith('player:setRepeat', 1);
+
+    // Echo of the same value must not emit again.
+    player.emit('repeatModeDidChange', 1);
+    expect(emissions).toEqual([{ LoopStatus: 'Track' }]);
+  });
+
+  it('emits Shuffle from the setter so clients do not wait on a no-op echo', () => {
+    const iface = initPlayerInterface();
+    iface.Shuffle = true;
+    expect(iface.Shuffle).toBe(true);
+    expect(emissions).toEqual([{ Shuffle: true }]);
+    expect(win.webContents.send).toHaveBeenCalledWith('player:setShuffle', 1);
+
+    player.emit('shuffleModeDidChange', 1);
+    expect(emissions).toEqual([{ Shuffle: true }]);
   });
 });
 

--- a/test/mpris.test.ts
+++ b/test/mpris.test.ts
@@ -2,15 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { BrowserWindow } from 'electron';
 
 import { setMusicService } from '../src/config';
+import { downloadArtwork } from '../src/artwork';
 import { PlaybackState } from '../src/player';
 import type { IntegrationContext, NowPlayingPayload } from '../src/player';
 import * as mpris from '../src/integrations/mpris';
 import { FakePlayer } from './mocks/player';
 
-// updateNowPlaying() hands every https:// artwork URL to downloadArtwork(),
-// which fetches over the network and writes to the cache directory. Resolving
-// null leaves mpris:artUrl at the value buildMetadata() produced, so the
-// metadata assertions read what the builder wrote and nothing else.
+// updateNowPlaying() hands every https:// artwork URL to downloadArtwork().
+// Resolving null falls back to the remote URL after the first Metadata
+// emission (which omits mpris:artUrl until the cache attempt finishes).
 vi.mock('../src/artwork', () => ({
   downloadArtwork: vi.fn(() => Promise.resolve(null)),
 }));
@@ -216,6 +216,32 @@ describe('MPRIS PlaybackStatus mapping', () => {
       expect(iface.PlaybackStatus).toBe('Stopped');
     }
   });
+
+  it('emits PlaybackStatus immediately without waiting for the Metadata debounce', () => {
+    vi.useFakeTimers();
+    const iface = initPlayerInterface();
+    player.emitPlaybackState(PlaybackState.Playing);
+    expect(iface.PlaybackStatus).toBe('Playing');
+    expect(emissions).toEqual([{ PlaybackStatus: 'Playing' }]);
+    // Still before the 1s Metadata/Volume coalesce window.
+    vi.advanceTimersByTime(999);
+    expect(emissions).toEqual([{ PlaybackStatus: 'Playing' }]);
+  });
+
+  it('does not re-emit when transient states map to the same PlaybackStatus', () => {
+    const iface = initPlayerInterface();
+    // Leave the default Stopped so the next Stopped mapping is a real change.
+    player.emitPlaybackState(PlaybackState.Playing);
+    emissions = [];
+
+    player.emitPlaybackState(PlaybackState.Loading);
+    player.emitPlaybackState(PlaybackState.Seeking);
+    player.emitPlaybackState(PlaybackState.Waiting);
+    player.emitPlaybackState(PlaybackState.Stopped);
+    expect(iface.PlaybackStatus).toBe('Stopped');
+    // One PropertiesChanged for the Playing → Stopped edge; the rest are no-ops.
+    expect(emissions).toEqual([{ PlaybackStatus: 'Stopped' }]);
+  });
 });
 
 describe('MPRIS metadata', () => {
@@ -243,9 +269,14 @@ describe('MPRIS metadata', () => {
   // cosmetic fault: a client reading xesam:artist expects an array of strings
   // and mpris:length an int64. The exact key set is asserted too, because an
   // extra key with a made-up name is as wrong as a missing one.
-  it('builds every field of a full payload with the right signatures', () => {
+  it('builds every field of a full payload with the right signatures', async () => {
     const iface = initPlayerInterface();
     player.emitNowPlaying(FULL_TRACK);
+
+    // https artwork is omitted until downloadArtwork settles (here: null → remote).
+    expect(iface.Metadata['mpris:artUrl']).toBeUndefined();
+    await Promise.resolve();
+    await Promise.resolve();
 
     expect(flatten(iface.Metadata)).toEqual({
       'mpris:trackid': ['o', '/org/sidra/track/1440857781'],
@@ -261,6 +292,31 @@ describe('MPRIS metadata', () => {
       'xesam:composer': ['as', ['Bernard Sumner']],
       'xesam:contentCreated': ['s', '1983-03-07'],
     });
+  });
+
+  it('publishes file:// artwork once after download, without an HTTPS first pass', async () => {
+    vi.useFakeTimers();
+    let resolveDownload!: (value: string | null) => void;
+    vi.mocked(downloadArtwork).mockReturnValueOnce(
+      new Promise((resolve) => { resolveDownload = resolve; }),
+    );
+    const iface = initPlayerInterface();
+    player.emitNowPlaying(FULL_TRACK);
+
+    expect(iface.Metadata['mpris:artUrl']).toBeUndefined();
+    vi.advanceTimersByTime(1000);
+    expect(emissions).toHaveLength(1);
+    expect((emissions[0].Metadata as Record<string, VariantValue>)['mpris:artUrl']).toBeUndefined();
+
+    resolveDownload('/tmp/sidra-art.jpg');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(iface.Metadata['mpris:artUrl'].value).toBe('file:///tmp/sidra-art.jpg');
+
+    vi.advanceTimersByTime(1000);
+    expect(emissions).toHaveLength(2);
+    expect((emissions[1].Metadata as Record<string, VariantValue>)['mpris:artUrl'].value)
+      .toBe('file:///tmp/sidra-art.jpg');
   });
 
   // mpris:length is an 'x' field, and the marshaller turns one into a BigInt.
@@ -410,9 +466,15 @@ describe('MPRIS volume', () => {
     vi.advanceTimersByTime(2000);
     expect(emissions).toEqual([{ Volume: 0.5 }]);
 
+    // Same value as the cache is a no-op; a different in-app change must emit.
     player.emit('volumeDidChange', 0.5);
     vi.advanceTimersByTime(1000);
-    expect(emissions).toEqual([{ Volume: 0.5 }, { Volume: 0.5 }]);
+    expect(emissions).toEqual([{ Volume: 0.5 }]);
+
+    player.emit('volumeDidChange', 0.3);
+    vi.advanceTimersByTime(1000);
+    expect(emissions).toEqual([{ Volume: 0.5 }, { Volume: 0.3 }]);
+    expect(iface.Volume).toBe(0.3);
   });
 });
 

--- a/test/musicKitHook.test.ts
+++ b/test/musicKitHook.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import vm from 'node:vm';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hookScript = fs.readFileSync(
   path.join(__dirname, '..', 'assets', 'musicKitHook.js'),
@@ -124,13 +124,16 @@ function createHarness({
   }
   const context = vm.createContext({
     clearInterval: vi.fn(),
+    clearTimeout,
     console,
+    Date,
     navigator,
     setInterval: vi.fn((callback: () => void, delay: number) => {
       intervals.push({ callback, delay });
       intervalCallbacks.push(callback);
       return intervalCallbacks.length;
     }),
+    setTimeout,
     window,
   });
 
@@ -146,7 +149,18 @@ function createHarness({
       if (getInstanceThrows) throw new Error('MusicKit is re-initialising');
       return liveInstance;
     },
-    PlaybackStates: { playing: 2 },
+    PlaybackStates: {
+      none: 0,
+      loading: 1,
+      playing: 2,
+      paused: 3,
+      stopped: 4,
+      ended: 5,
+      seeking: 6,
+      waiting: 7,
+      stalled: 8,
+      completed: 9,
+    },
   };
   if (musicKitThrowsAtInjection) {
     Object.assign(context, { MusicKit: musicKitApi });
@@ -329,6 +343,77 @@ describe('musicKitHook', () => {
       duration: 180,
       playbackRate: 1,
       position: 42,
+    });
+  });
+
+  describe('position IPC throttle', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('throttles playbackTimeDidChange IPC while updating MediaSession every tick', () => {
+      const { bridgeSend, mediaSession, musicKit, musicKitListeners } = createHarness({
+        musicKitOverrides: {
+          currentPlaybackDuration: 180,
+          currentPlaybackTime: 1,
+        },
+      });
+
+      musicKitListeners.get('playbackTimeDidChange')?.();
+      musicKit.currentPlaybackTime = 2;
+      musicKitListeners.get('playbackTimeDidChange')?.();
+      musicKit.currentPlaybackTime = 3;
+      musicKitListeners.get('playbackTimeDidChange')?.();
+
+      expect(mediaSession.setPositionState).toHaveBeenCalledTimes(3);
+      expect(bridgeSend.mock.calls.filter((call) => call[0] === 'playbackTimeDidChange')).toHaveLength(1);
+      expect(bridgeSend).toHaveBeenCalledWith('playbackTimeDidChange', 1_000_000);
+
+      vi.advanceTimersByTime(250);
+      expect(bridgeSend.mock.calls.filter((call) => call[0] === 'playbackTimeDidChange')).toHaveLength(2);
+      expect(bridgeSend).toHaveBeenLastCalledWith('playbackTimeDidChange', 3_000_000);
+    });
+
+    it('flushes a pending position IPC on pause', () => {
+      const { bridgeSend, musicKit, musicKitListeners } = createHarness({
+        musicKitOverrides: {
+          currentPlaybackDuration: 180,
+          currentPlaybackTime: 1,
+        },
+      });
+
+      musicKitListeners.get('playbackTimeDidChange')?.();
+      musicKit.currentPlaybackTime = 5;
+      musicKitListeners.get('playbackTimeDidChange')?.();
+      expect(bridgeSend.mock.calls.filter((call) => call[0] === 'playbackTimeDidChange')).toHaveLength(1);
+
+      musicKitListeners.get('playbackStateDidChange')?.({ state: 3 });
+      expect(bridgeSend).toHaveBeenCalledWith('playbackTimeDidChange', 5_000_000);
+      expect(bridgeSend).toHaveBeenCalledWith('playbackStateDidChange', {
+        status: false,
+        state: 3,
+      });
+    });
+
+    it('flushes a pending position IPC on track change', () => {
+      const { bridgeSend, musicKit, musicKitListeners } = createHarness({
+        musicKitOverrides: {
+          currentPlaybackDuration: 180,
+          currentPlaybackTime: 1,
+        },
+      });
+
+      musicKitListeners.get('playbackTimeDidChange')?.();
+      musicKit.currentPlaybackTime = 8;
+      musicKitListeners.get('playbackTimeDidChange')?.();
+
+      musicKitListeners.get('nowPlayingItemDidChange')?.({ item: null });
+      expect(bridgeSend).toHaveBeenCalledWith('playbackTimeDidChange', 8_000_000);
+      expect(bridgeSend).toHaveBeenCalledWith('nowPlayingItemDidChange', null);
     });
   });
 

--- a/test/musicKitHook.test.ts
+++ b/test/musicKitHook.test.ts
@@ -399,7 +399,7 @@ describe('musicKitHook', () => {
       });
     });
 
-    it('flushes a pending position IPC on track change', () => {
+    it('flushes a pending position IPC on track change after metadata', () => {
       const { bridgeSend, musicKit, musicKitListeners } = createHarness({
         musicKitOverrides: {
           currentPlaybackDuration: 180,
@@ -414,6 +414,33 @@ describe('musicKitHook', () => {
       musicKitListeners.get('nowPlayingItemDidChange')?.({ item: null });
       expect(bridgeSend).toHaveBeenCalledWith('playbackTimeDidChange', 8_000_000);
       expect(bridgeSend).toHaveBeenCalledWith('nowPlayingItemDidChange', null);
+
+      // Metadata before position so MPRIS Seeked is not attributed to the old track.
+      const channels = bridgeSend.mock.calls.map((call) => call[0] as string);
+      expect(channels.lastIndexOf('nowPlayingItemDidChange'))
+        .toBeLessThan(channels.lastIndexOf('playbackTimeDidChange'));
+    });
+
+    it('drops a pending position IPC when MusicKit is replaced', () => {
+      const { bridgeSend, musicKit, musicKitListeners, replaceInstance, runMonitorCycles } = createHarness({
+        musicKitOverrides: {
+          currentPlaybackDuration: 180,
+          currentPlaybackTime: 1,
+        },
+      });
+
+      musicKitListeners.get('playbackTimeDidChange')?.();
+      musicKit.currentPlaybackTime = 9;
+      musicKitListeners.get('playbackTimeDidChange')?.();
+      expect(bridgeSend.mock.calls.filter((call) => call[0] === 'playbackTimeDidChange')).toHaveLength(1);
+
+      replaceInstance();
+      runMonitorCycles(1);
+      vi.advanceTimersByTime(250);
+
+      // The throttled 9s tick belonged to the previous singleton and must not send.
+      expect(bridgeSend.mock.calls.filter((call) => call[0] === 'playbackTimeDidChange')).toHaveLength(1);
+      expect(bridgeSend).not.toHaveBeenCalledWith('playbackTimeDidChange', 9_000_000);
     });
   });
 

--- a/test/tray.test.ts
+++ b/test/tray.test.ts
@@ -119,7 +119,7 @@ vi.mock('../src/paths', () => ({
 
 import { BrowserWindow, Menu, Tray, nativeImage, nativeTheme } from 'electron';
 import { getUpdateInfo } from '../src/update';
-import { truncateMenuLabel, sanitiseLinuxLabel, cancelTrayRebuild, createTray, getMenuIcon, updateNowPlayingState, updateTrayTooltip, rebuildTrayMenu, initTrayStateManager, setGetMainWindowCallback, setSwitchServiceCallback, type MenuIconKey } from '../src/tray';
+import { truncateMenuLabel, sanitiseLinuxLabel, cancelTrayRebuild, createTray, getMenuIcon, invalidateTrayImageCaches, updateNowPlayingState, updateTrayTooltip, rebuildTrayMenu, initTrayStateManager, setGetMainWindowCallback, setSwitchServiceCallback, type MenuIconKey } from '../src/tray';
 import { getCloseToTrayEnabled, setTheme, getMusicService, setMusicService, getClassicalStartPage, getLastfmEnabled, setLastfmEnabled, getLastfmSessionKey, getLastfmUsername } from '../src/config';
 import { downloadArtwork } from '../src/artwork';
 import { PlaybackState } from '../src/player';
@@ -155,6 +155,7 @@ function resetTrayMocks(): void {
   vi.mocked(process.getSystemVersion).mockReturnValue('15.0.0');
   vi.mocked(nativeImage.createFromPath).mockClear();
   vi.mocked(nativeImage.createFromNamedImage).mockClear();
+  invalidateTrayImageCaches();
   setGetMainWindowCallback(() => null);
   setSwitchServiceCallback(() => {});
   updateNowPlayingState({ payload: null, artworkPath: null, isPlaying: false, volume: 0 });
@@ -1486,6 +1487,32 @@ describe('getMenuIcon', () => {
         resize: vi.fn(function (this: { isEmpty: () => boolean }) { return this; }),
       } as unknown as Electron.NativeImage);
       expect(getMenuIcon('about')).toBeUndefined();
+    });
+
+    it('loads each themed PNG from disk only once across repeated lookups', () => {
+      Object.defineProperty(nativeTheme, 'shouldUseDarkColors', { value: true, configurable: true });
+      getMenuIcon('about');
+      getMenuIcon('about');
+      getMenuIcon('about');
+      expect(vi.mocked(nativeImage.createFromPath)).toHaveBeenCalledTimes(1);
+    });
+
+    it('reloads themed PNGs after a theme update invalidates the cache', () => {
+      Object.defineProperty(nativeTheme, 'shouldUseDarkColors', { value: true, configurable: true });
+      createTray();
+      // Warm the cache, then clear the spy so only a post-invalidate reload counts.
+      getMenuIcon('about');
+      vi.mocked(nativeImage.createFromPath).mockClear();
+
+      const themeHandler = vi.mocked(nativeTheme.on).mock.calls.find(
+        (call) => call[0] === 'updated',
+      )?.[1] as (() => void) | undefined;
+      expect(themeHandler).toBeDefined();
+      themeHandler!();
+
+      // Without invalidation the rebuild would reuse cached NativeImages and
+      // createFromPath would stay at zero.
+      expect(vi.mocked(nativeImage.createFromPath)).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Emit play/pause immediately, throttle position IPC, cache tray images, prefer native Wayland, and keep the HTTP cache across launches.
