### PR TITLE
fix(main): disable Chromium spellcheck

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -324,6 +324,7 @@ function createMainWindow(ses: Electron.Session): { win: BrowserWindow; winReady
       preload: path.join(__dirname, 'preload.js'),
       nodeIntegration: false,
       contextIsolation: true,
+      spellcheck: false,
       plugins: true,
       sandbox: true,
     },

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -272,6 +272,7 @@ describe('main bootstrap', () => {
         partition: 'persist:sidra',
         nodeIntegration: false,
         contextIsolation: true,
+        spellcheck: false,
         plugins: true,
         sandbox: true,
       }),


### PR DESCRIPTION
Disable Chromium spellcheck so Apple Music keeps application suggestions.
Cover the BrowserWindow option in the main-window test.

Verified with `just test`, `just lint`, and CDP checks.

Refs: WW-201
