### PR TITLE
feat(controller): add standard Gamepad navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ The `10_15_7` macOS version freeze is intentional - Chrome itself freezes this v
 
 **Electron security**
 - `contextIsolation: true`, `nodeIntegration: false` on all windows
-- All renderer→main IPC flows through the `SEND_CHANNELS` allowlist in `src/preload.ts`; blocked channels log a warning
+- All main-world renderer→main IPC flows through the `SEND_CHANNELS` allowlist in `src/preload.ts`. Blocked channels log a warning. Private isolated-preload channels do not use `AMWrapper`
 - No Node.js APIs exposed to the renderer
 - External URLs validated for `http:`/`https:` protocol before opening. `openExternalUrl()` in `src/utils/openExternal.ts` is the one guard, used by `setWindowOpenHandler`, the tray update link and the update notification, so a hardening change is made once. It hands `shell.openExternal()` the parsed `URL`, never the string that came in: Chromium re-parses the argument with its own parser, so passing the raw string would open a URL nothing checked. Both refusals are logged; a silent one leaves a dead menu item with no record of why. Last.fm's `openInBrowser()` is the one caller outside it, and it takes a `URL` the integration built itself
 
@@ -57,6 +57,15 @@ The `10_15_7` macOS version freeze is intentional - Chrome itself freezes this v
 - `playbackTimeDidChange` handlers store position only - never trigger a debounced send (see architecture notes)
 - The tray, the macOS dock and the Windows taskbar reach the renderer through `sendCommand()` in `src/commandBridge.ts`, never through a callback captured at menu-build time. `main.ts` calls `initCommandBridge()` once, after the window exists, and every caller reads the sender inside its click handler, so a menu built before that call still works. A click landing before the window exists logs a warning instead of doing nothing in silence
 - All event listeners and resources cleaned up on `will-quit`, enforced by `test/integrationCleanup.test.ts`. It reads every `src/integrations/*/index.ts` plus `src/wedgeDetector.ts` and `src/tray.ts` off disk and fails when a `player.on()` has no matching `removeListener`, so a new integration directory is covered without touching the test. Register listeners as named references: an inline function cannot be removed and fails the same check
+
+**Controller navigation**
+- `controller:action` and `controller:reset` are private preload channels. Keep them out of `AMWrapper`, `SendChannel`, `ReceiveChannel`, both bridge allowlists, `window.postMessage()`, and `assets/musicKitHook.js`
+- The sandboxed preload must compile to one runtime file whose only `require()` is `electron`. Keep controller runtime logic in `src/preload.ts`. Use type-only imports and `satisfies` for the channel literals
+- Map standard Gamepad buttons 12-15 and 0 to native `Up`, `Down`, `Left`, `Right`, and `Enter` key-down/key-up pairs in `src/controllerIPC.ts`. Button 1 uses `goBackIfPossible()`. Do not send key names or arbitrary input from the renderer
+- Poll only while a standard controller exists and the page is visible, active, and focused. Use one demand-driven `requestAnimationFrame` loop. Directions repeat after 400 ms and every 100 ms. Select and Back do not repeat
+- Suppress held input until release on the initial sample, every main-frame navigation, blur, a hidden document, `pagehide`, and a frame gap above 1,000 ms. Send `controller:reset` from `did-start-navigation`
+- Both services use the same isolated preload path. Do not add Apple DOM selectors or main-world injection for controller navigation
+- Controller support covers navigation only. Keep media controls and settings outside this feature. Do not add a dependency, setting, locale string, or runtime asset for it
 
 **Tests**
 - Tests cover pure logic and event forwarding; shared mock fixtures live in `test/mocks/` to avoid duplication. `appLifecycle.ts` fires the recorded `will-quit` handlers, `platform.ts` overrides `process.platform` through a captured descriptor, and `notify.ts` stands in for `src/notify` with the D-Bus daemon gate a test can open or close. `test/notify.test.ts` covers the real gate and must not import that fake

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Sidra takes the opposite approach: wrap `music.apple.com` directly, stay out of 
 - 🔔 **Desktop notifications** - track changes, native to each platform
 - 🌍 **32 languages** - localised storefront and interface
 - 🧭 **Back, Forward, and Reload** - injected into both Apple Music and Apple Music Classical
+- 🎮 **Controller navigation** - use a standard controller to move through and select items in both services
 - 🖱️ **Scroll to change volume** - point at the player bar volume control and scroll; 5% a notch
 - 🎼 **Apple Music Classical** - switch at runtime from the tray **Player** submenu:
   - Start pages are Home, Browse, Playlists, Search, or your last page; Apple Music's are Home, New, Radio, All Playlists, or your last page
@@ -60,6 +61,18 @@ Sidra takes the opposite approach: wrap `music.apple.com` directly, stay out of 
 <p align="center">
   <img src="assets/source/sidra-screenshot.png" alt="Sidra screenshot" width="100%">
 </p>
+
+### Controller navigation
+
+Sidra supports controllers that expose the browser's standard Gamepad mapping. The controls work in Apple Music and Apple Music Classical:
+
+| Controller input | Action |
+|---|---|
+| D-pad | Move up, down, left, or right |
+| A button | Select the focused item |
+| B button | Go back when navigation history permits |
+
+Hold a D-pad direction to repeat it. The A and B buttons act once per press. Controller input does not control media playback or settings.
 
 ### Mini Player
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -13,6 +13,7 @@ The codebase is tightly focused and as lean as possible. Five runtime dependenci
 - [Source Structure](#source-structure)
 - [Dependencies](#dependencies)
 - [IPC Event Flow](#ipc-event-flow)
+- [Controller Navigation](#controller-navigation)
 - [MusicKit Hook Script](#musickit-hook-script)
 - [Platform Media Controls](#platform-media-controls)
 - [MPRIS Specification](#mpris-specification)
@@ -44,7 +45,7 @@ The codebase is tightly focused and as lean as possible. Five runtime dependenci
 | Language | TypeScript | Type safety, ecosystem match |
 | Renderer content | `music.apple.com` and `classical.music.apple.com` | Zero UI code; Apple maintains it |
 | MusicKit hook | Injected JS script post-page-load | Hooks `MusicKit.getInstance()` events |
-| Preload | `contextBridge` IPC bridge | Standard Electron security pattern |
+| Preload | Isolated IPC bridge and Gamepad polling | Renderer bridge and controller navigation without Node.js exposure |
 | MPRIS (Linux) | `dbus-next` directly | Full control, clean service name |
 | Windows controls | Chromium `mediaSession` → GSMTC | Built-in bridge, identity via `setAppUserModelId` |
 | Windows taskbar | `win.setThumbarButtons()` + `win.setOverlayIcon()` | Thumbnail toolbar and overlay badge |
@@ -77,7 +78,7 @@ The codebase is tightly focused and as lean as possible. Five runtime dependenci
 │  │  │ ├─ Notifier    │  │      │                             │   │
 │  │  │ └─ Taskbar/Dock│  │      │  ┌──────────────┐           │   │
 │  │  └───────┬────────┘  │      │  │  preload.ts  │           │   │
-│  │          │           │      │  │ (IPC bridge) │           │   │
+│  │          │           │      │  │ IPC + Gamepad│           │   │
 │  │  ┌───────▼────────┐  │      │  └──────────────┘           │   │
 │  │  │ electron-conf  │  │      └─────────────────────────────┘   │
 │  │  └────────────────┘  │                                        │
@@ -91,6 +92,8 @@ The codebase is tightly focused and as lean as possible. Five runtime dependenci
     └────────────┘
 ```
 
+The sandboxed isolated preload owns standard Gamepad polling for both services. It sends private controller actions to the main process, which dispatches native key pairs or uses guarded navigation history. This path does not enter Apple's main world or query Apple's DOM.
+
 ---
 
 ## Source Structure
@@ -99,7 +102,9 @@ The codebase is tightly focused and as lean as possible. Five runtime dependenci
 sidra/
 ├── src/
 │   ├── main.ts                    - bootstrap, Widevine wait, window, IPC hub
-│   ├── preload.ts                 - contextBridge IPC exposure (AMWrapper)
+│   ├── preload.ts                 - contextBridge exposure plus isolated standard Gamepad polling
+│   ├── controller.ts              - private controller actions, channel constants, and guards
+│   ├── controllerIPC.ts           - action validation, native key input, and guarded Back navigation
 │   ├── config.ts                  - electron-conf wrapper
 │   ├── i18n.ts                    - locale detection, JSON loader, and re-exported translation records
 │   ├── paths.ts                   - getAssetPath() and getProductInfo() utilities
@@ -219,7 +224,7 @@ Current dependency roles:
 
 ## IPC Event Flow
 
-Events flow from the renderer (MusicKit hook script) to the main process (player.ts), which emits to all integrations.
+MusicKit events flow from the renderer hook to `player.ts`, which emits them to all integrations. Controller actions use a separate private path from the isolated preload to `controllerIPC.ts`.
 
 ### Renderer → Main (via `ipcRenderer.send`)
 
@@ -234,6 +239,8 @@ Events flow from the renderer (MusicKit hook script) to the main process (player
 | `nav:back` | (none) | Main process navigation |
 | `nav:forward` | (none) | Main process navigation |
 | `nav:reload` | (none) | Main process navigation |
+
+`controller:action` is not part of `SendChannel` or `SEND_CHANNELS`. The isolated preload sends this private channel directly, and `initControllerIPC()` accepts only the six `ControllerAction` values from the main window's `webContents`. It ignores controller input while the window is not focused.
 
 ### MusicKit.js Enum Values
 
@@ -293,6 +300,43 @@ The command bridge uses the `RECEIVE_CHANNELS` allowlist in `src/preload.ts` and
 | Set volume | `window.__sidra.setVolume(float)` | MPRIS volume property |
 | Set repeat mode | `window.__sidra.setRepeat(mode)` | MPRIS `LoopStatus` |
 | Set shuffle mode | `window.__sidra.setShuffle(mode)` | MPRIS `Shuffle` |
+
+---
+
+## Controller Navigation
+
+The same sandboxed `src/preload.ts` runs for Apple Music and Apple Music Classical. It uses the browser Gamepad API only for connected controllers whose `mapping` is `standard`.
+
+### Input mapping
+
+| Standard button | Controller action | Main-process result |
+|---|---|---|
+| 12 | `up` | `keyDown` then `keyUp` for `Up` |
+| 13 | `down` | `keyDown` then `keyUp` for `Down` |
+| 14 | `left` | `keyDown` then `keyUp` for `Left` |
+| 15 | `right` | `keyDown` then `keyUp` for `Right` |
+| 0 | `select` | `keyDown` then `keyUp` for `Enter` |
+| 1 | `back` | `navigationHistory.goBack()` only when `canGoBack()` returns true |
+
+The native fixed-key mapping lets Apple's existing keyboard navigation choose the focused element. Controller support does not add Apple DOM selectors, main-world injection, media controls, settings, translations, dependencies, or runtime assets.
+
+### Preload lifecycle
+
+Polling uses one `requestAnimationFrame` loop. The loop starts only when a standard controller is present and the page is visible, active, and focused. It stops when no standard controller remains or the page cannot accept input.
+
+A D-pad press repeats after 400 ms and then every 100 ms. Select and Back do not repeat. Each controller index has independent button state.
+
+The preload suppresses buttons that are held during its initial sample. It applies the same release-before-input rule after `controller:reset`, window blur, a hidden document, `pagehide`, or a frame gap above 1,000 ms. The main process sends `controller:reset` on every main-frame `did-start-navigation`, so navigation cannot carry a held press into a replacement document.
+
+The sandboxed preload must compile as one runtime file. Its only runtime `require()` is `electron`, so controller types use type-only imports and the channel literals in `preload.ts` use `satisfies` checks.
+
+### Private IPC
+
+`controller:action` carries one validated `ControllerAction` from the preload to the main process. `controller:reset` runs in the reverse direction. Neither channel is exposed through `window.AMWrapper`, routed through `window.postMessage()`, or added to the MusicKit hook allowlists.
+
+### Tests
+
+`test/controller.test.ts` checks the action union and channel guards. `test/controllerIPC.test.ts` checks sender and payload validation, focus gating, ordered key pairs, and guarded Back navigation. `test/preload.test.ts` checks the single-file preload, demand-driven polling, mappings, repeat timing, lifecycle resets, held-input suppression, controller isolation, and the private IPC boundary. `test/main.test.ts` checks IPC initialisation, shared guarded Back navigation, and main-frame navigation resets. These tests are automated. No physical controller validation is recorded.
 
 ---
 
@@ -609,6 +653,8 @@ Classical has no library route. Both services accept `last`, which restores the 
 `ALLOWED_NAVIGATION_HOSTS` is built from every service `host` plus its `authFrameHosts`, so adding a service widens the allowlist without a second edit. `isAllowedNavigationUrl()` takes a URL string, parses it, and compares `URL.hostname` exactly: a subdomain, a suffix, or a userinfo prefix of an allowed host is not an allowed host.
 
 The `will-navigate` handler in `src/main.ts` calls `event.preventDefault()` when the predicate returns false. Main-process `loadURL()` calls do not raise `will-navigate`, so launch, service switching and `itms://` routing are unaffected. The same predicate gates hook injection at both injection sites.
+
+The main-frame `did-start-navigation` handler also sends `controller:reset` to the isolated preload. The reset suppresses held controller input until release while the document changes.
 
 ### Persistence and URL building
 
@@ -1082,6 +1128,7 @@ electron-updater manifest filenames are hardcoded and cannot be changed:
 | Update checking (non-auto-update) | `src/update.ts` | GitHub API check for deb/rpm/Nix/DMG platforms |
 | Service worker cache clearing | `session.defaultSession.clearStorageData` | Clears on startup to prevent stale assets |
 | Last.fm scrobbling | `src/integrations/lastfm` + Last.fm API 2.0 | Opt-in; browser auth from the tray, per-user session key in `electron-conf` |
+| Controller navigation | Gamepad API in `preload.ts` + `controllerIPC.ts` | Standard mapping; D-pad, Select, and guarded Back in both services |
 
 #### Tray Menu Implementation Notes
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,0 +1,27 @@
+export type ControllerAction = 'up' | 'down' | 'left' | 'right' | 'select' | 'back';
+
+export const CONTROLLER_ACTION_CHANNEL = 'controller:action' as const;
+export const CONTROLLER_RESET_CHANNEL = 'controller:reset' as const;
+export type ControllerActionChannel = typeof CONTROLLER_ACTION_CHANNEL;
+export type ControllerResetChannel = typeof CONTROLLER_RESET_CHANNEL;
+
+const CONTROLLER_ACTIONS: readonly ControllerAction[] = [
+  'up',
+  'down',
+  'left',
+  'right',
+  'select',
+  'back',
+];
+
+export function isControllerAction(value: unknown): value is ControllerAction {
+  return typeof value === 'string' && CONTROLLER_ACTIONS.some((action) => action === value);
+}
+
+export function isControllerActionChannel(value: string): value is typeof CONTROLLER_ACTION_CHANNEL {
+  return value === CONTROLLER_ACTION_CHANNEL;
+}
+
+export function isControllerResetChannel(value: string): value is typeof CONTROLLER_RESET_CHANNEL {
+  return value === CONTROLLER_RESET_CHANNEL;
+}

--- a/src/controllerIPC.ts
+++ b/src/controllerIPC.ts
@@ -1,0 +1,42 @@
+import { BrowserWindow, ipcMain } from 'electron';
+import log from 'electron-log/main';
+import { CONTROLLER_ACTION_CHANNEL, isControllerAction, type ControllerAction } from './controller';
+
+const controllerLog = log.scope('controller');
+
+const ACTION_KEYS: Readonly<Record<Exclude<ControllerAction, 'back'>, string>> = {
+  up: 'Up',
+  down: 'Down',
+  left: 'Left',
+  right: 'Right',
+  select: 'Enter',
+};
+
+export function goBackIfPossible(win: BrowserWindow): void {
+  if (win.webContents.navigationHistory.canGoBack()) {
+    win.webContents.navigationHistory.goBack();
+  }
+}
+
+export function initControllerIPC(win: BrowserWindow): void {
+  ipcMain.on(CONTROLLER_ACTION_CHANNEL, (event, payload: unknown) => {
+    if (event.sender !== win.webContents) {
+      controllerLog.warn('rejected controller action from unexpected sender');
+      return;
+    }
+    if (!isControllerAction(payload)) {
+      controllerLog.warn('rejected invalid controller action');
+      return;
+    }
+    if (!win.isFocused()) return;
+
+    if (payload === 'back') {
+      goBackIfPossible(win);
+      return;
+    }
+
+    const keyCode = ACTION_KEYS[payload];
+    win.webContents.sendInputEvent({ type: 'keyDown', keyCode });
+    win.webContents.sendInputEvent({ type: 'keyUp', keyCode });
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,8 @@ import { initServiceSwitch, routeToMusicService, switchService } from './service
 import { initThemeCSS, injectThemeCss, setRebuildTrayCallback } from './theme';
 import { createTray, getMenuIcon, initTrayStateManager, rebuildTrayMenu, setApplyZoomCallback, setGetMainWindowCallback, setSwitchServiceCallback } from './tray';
 import { initCommandBridge } from './commandBridge';
+import { initControllerIPC, goBackIfPossible } from './controllerIPC';
+import { CONTROLLER_RESET_CHANNEL } from './controller';
 import { showAboutWindow } from './aboutWindow';
 import { checkForUpdates } from './update';
 import { isAutoUpdateSupported, initAutoUpdate } from './autoUpdate';
@@ -384,7 +386,7 @@ function setupWindowZoomAndNav(win: BrowserWindow): void {
   setApplyZoomCallback((factor) => win.webContents.setZoomFactor(factor));
 
   onSendChannels<NavSendChannel>({
-    'nav:back': () => win.webContents.navigationHistory.goBack(),
+    'nav:back': () => goBackIfPossible(win),
     'nav:forward': () => win.webContents.navigationHistory.goForward(),
     'nav:reload': () => {
       resetWedgeDetector();
@@ -431,9 +433,10 @@ function setupNavigationHandlers(win: BrowserWindow, assets: Assets): void {
       mainLog.warn('blocked navigation to disallowed host:', url);
     }
   });
-  win.webContents.on('did-start-navigation', (_event, url, _isInPlace, isMainFrame) => {
-    if (isMainFrame) {
-      mainLog.debug('did-start-navigation:', url);
+  win.webContents.on('did-start-navigation', (details) => {
+    if (details.isMainFrame) {
+      win.webContents.send(CONTROLLER_RESET_CHANNEL);
+      mainLog.debug('did-start-navigation:', details.url);
     }
   });
   win.webContents.on('did-navigate', (_event, url) => {
@@ -628,6 +631,7 @@ if (gotLock) {
     win = created.win;
     const winReady = created.winReady;
     initCommandBridge((channel, ...args) => win!.webContents.send(channel, ...args));
+    initControllerIPC(win);
     setGetMainWindowCallback(() => win);
     initServiceSwitch({
       getTray: () => appTray,

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,5 +1,137 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
+import type {
+  ControllerAction,
+  ControllerActionChannel,
+  ControllerResetChannel,
+} from './controller';
+
+const CONTROLLER_ACTION_CHANNEL = 'controller:action' satisfies ControllerActionChannel;
+const CONTROLLER_RESET_CHANNEL = 'controller:reset' satisfies ControllerResetChannel;
+
+const ACTION_BUTTONS: readonly [ControllerAction, number][] = [
+  ['up', 12],
+  ['down', 13],
+  ['left', 14],
+  ['right', 15],
+  ['select', 0],
+  ['back', 1],
+];
+
+const DIRECTION_ACTIONS = new Set<ControllerAction>(['up', 'down', 'left', 'right']);
+const INITIAL_REPEAT_DELAY_MS = 400;
+const REPEAT_INTERVAL_MS = 100;
+const FRAME_GAP_RESET_MS = 1000;
+
+interface ButtonState {
+  pressed: boolean;
+  suppressUntilRelease: boolean;
+  nextRepeatAt: number | null;
+}
+
+type PadState = Record<ControllerAction, ButtonState>;
+
+function createButtonState(): ButtonState {
+  return { pressed: false, suppressUntilRelease: false, nextRepeatAt: null };
+}
+
+function createPadState(): PadState {
+  return {
+    up: createButtonState(),
+    down: createButtonState(),
+    left: createButtonState(),
+    right: createButtonState(),
+    select: createButtonState(),
+    back: createButtonState(),
+  };
+}
+
+class ControllerState {
+  private readonly pads = new Map<number, PadState>();
+  private lastFrameAt: number | null = null;
+  private resetPending = true;
+
+  update(gamepads: readonly (Gamepad | null)[], now: number): ControllerAction[] {
+    if (this.lastFrameAt !== null && now - this.lastFrameAt > FRAME_GAP_RESET_MS) {
+      this.suppressHeldButtons();
+      this.resetPending = true;
+    }
+    this.lastFrameAt = now;
+
+    const activeIndexes = new Set<number>();
+    const actions: ControllerAction[] = [];
+
+    for (const gamepad of gamepads) {
+      if (!gamepad?.connected || gamepad.mapping !== 'standard') continue;
+      activeIndexes.add(gamepad.index);
+
+      const state = this.pads.get(gamepad.index) ?? createPadState();
+      this.pads.set(gamepad.index, state);
+
+      for (const [action, buttonIndex] of ACTION_BUTTONS) {
+        const button = state[action];
+        const pressed = gamepad.buttons[buttonIndex]?.pressed ?? false;
+
+        if (this.resetPending && pressed) button.suppressUntilRelease = true;
+
+        if (!pressed) {
+          button.pressed = false;
+          button.suppressUntilRelease = false;
+          button.nextRepeatAt = null;
+          continue;
+        }
+
+        if (button.suppressUntilRelease) {
+          button.pressed = true;
+          button.nextRepeatAt = null;
+          continue;
+        }
+
+        if (!button.pressed) {
+          actions.push(action);
+          button.pressed = true;
+          button.nextRepeatAt = DIRECTION_ACTIONS.has(action)
+            ? now + INITIAL_REPEAT_DELAY_MS
+            : null;
+          continue;
+        }
+
+        if (button.nextRepeatAt !== null && now >= button.nextRepeatAt) {
+          actions.push(action);
+          button.nextRepeatAt = now + REPEAT_INTERVAL_MS;
+        }
+      }
+    }
+
+    for (const index of this.pads.keys()) {
+      if (!activeIndexes.has(index)) this.pads.delete(index);
+    }
+
+    this.resetPending = false;
+    return actions;
+  }
+
+  remove(index: number): void {
+    this.pads.delete(index);
+  }
+
+  reset(): void {
+    this.suppressHeldButtons();
+    this.resetPending = true;
+    this.lastFrameAt = null;
+  }
+
+  private suppressHeldButtons(): void {
+    for (const pad of this.pads.values()) {
+      for (const [action] of ACTION_BUTTONS) {
+        const button = pad[action];
+        button.suppressUntilRelease = button.pressed;
+        button.nextRepeatAt = null;
+      }
+    }
+  }
+}
+
 /**
  * Builds a channel allowlist from a record keyed by the channel union, so the
  * allowlist and the union cannot drift: a missing key and an unknown key are
@@ -44,6 +176,105 @@ const RECEIVE_CHANNELS = channelSet<ReceiveChannel>({
   'player:setRepeat': true,
   'player:setShuffle': true,
 });
+
+const controllerState = new ControllerState();
+let controllerFrame: number | null = null;
+let pageIsActive = true;
+let windowIsFocused = document.hasFocus();
+
+function gamepads(): readonly (Gamepad | null)[] {
+  return navigator.getGamepads();
+}
+
+function hasStandardController(pads: readonly (Gamepad | null)[]): boolean {
+  return pads.some((pad) => pad?.connected === true && pad.mapping === 'standard');
+}
+
+function canPollController(): boolean {
+  return pageIsActive && windowIsFocused && document.visibilityState === 'visible';
+}
+
+function pollController(now: number): void {
+  controllerFrame = null;
+  const pads = gamepads();
+
+  for (const action of controllerState.update(pads, now)) {
+    ipcRenderer.send(CONTROLLER_ACTION_CHANNEL, action);
+  }
+
+  if (canPollController() && hasStandardController(pads)) {
+    controllerFrame = requestAnimationFrame(pollController);
+  }
+}
+
+function startControllerPolling(connectedPad?: Gamepad): void {
+  if (controllerFrame !== null || !canPollController()) return;
+  if (!hasStandardController(gamepads()) &&
+      !(connectedPad?.connected === true && connectedPad.mapping === 'standard')) return;
+
+  controllerFrame = requestAnimationFrame(pollController);
+}
+
+function stopControllerPolling(): void {
+  if (controllerFrame !== null) cancelAnimationFrame(controllerFrame);
+  controllerFrame = null;
+  controllerState.reset();
+}
+
+function handleControllerReset(): void {
+  controllerState.reset();
+}
+
+function handleWindowBlur(): void {
+  windowIsFocused = false;
+  stopControllerPolling();
+}
+
+function handleWindowFocus(): void {
+  windowIsFocused = true;
+  startControllerPolling();
+}
+
+function handleVisibilityChange(): void {
+  if (document.visibilityState === 'hidden') {
+    stopControllerPolling();
+    return;
+  }
+  startControllerPolling();
+}
+
+function handlePageHide(): void {
+  pageIsActive = false;
+  stopControllerPolling();
+}
+
+function handlePageShow(): void {
+  pageIsActive = true;
+  startControllerPolling();
+}
+
+function handleGamepadConnected(event: GamepadEvent): void {
+  if (!event.isTrusted) return;
+  startControllerPolling(event.gamepad);
+}
+
+function handleGamepadDisconnected(event: GamepadEvent): void {
+  if (!event.isTrusted) return;
+  controllerState.remove(event.gamepad.index);
+  if (controllerFrame === null && canPollController()) {
+    controllerFrame = requestAnimationFrame(pollController);
+  }
+}
+
+ipcRenderer.on(CONTROLLER_RESET_CHANNEL, handleControllerReset);
+window.addEventListener('blur', handleWindowBlur);
+window.addEventListener('focus', handleWindowFocus);
+window.addEventListener('gamepadconnected', handleGamepadConnected);
+window.addEventListener('gamepaddisconnected', handleGamepadDisconnected);
+window.addEventListener('pagehide', handlePageHide);
+window.addEventListener('pageshow', handlePageShow);
+document.addEventListener('visibilitychange', handleVisibilityChange);
+startControllerPolling();
 
 // The preload runs in the isolated world (contextIsolation: true), so it cannot
 // call window.__sidra directly - that object lives in the main world, set up by

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import {
+  CONTROLLER_ACTION_CHANNEL,
+  CONTROLLER_RESET_CHANNEL,
+  isControllerAction,
+  isControllerActionChannel,
+  isControllerResetChannel,
+} from '../src/controller';
+import type { ControllerAction } from '../src/controller';
+
+describe('controller channels and actions', () => {
+  it('keeps the action union exact', () => {
+    expectTypeOf<ControllerAction>().toEqualTypeOf<
+      'up' | 'down' | 'left' | 'right' | 'select' | 'back'
+    >();
+  });
+
+  it('validates actions and private channel literals at runtime', () => {
+    for (const action of ['up', 'down', 'left', 'right', 'select', 'back']) {
+      expect(isControllerAction(action)).toBe(true);
+    }
+    expect(isControllerAction('play')).toBe(false);
+    expect(isControllerAction(null)).toBe(false);
+    expect(CONTROLLER_ACTION_CHANNEL).toBe('controller:action');
+    expect(CONTROLLER_RESET_CHANNEL).toBe('controller:reset');
+    expect(isControllerActionChannel(CONTROLLER_ACTION_CHANNEL)).toBe(true);
+    expect(isControllerActionChannel(CONTROLLER_RESET_CHANNEL)).toBe(false);
+    expect(isControllerResetChannel(CONTROLLER_RESET_CHANNEL)).toBe(true);
+    expect(isControllerResetChannel(CONTROLLER_ACTION_CHANNEL)).toBe(false);
+  });
+});

--- a/test/controllerIPC.test.ts
+++ b/test/controllerIPC.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ipcMain } from 'electron';
+import log from 'electron-log/main';
+import { CONTROLLER_ACTION_CHANNEL } from '../src/controller';
+import { goBackIfPossible, initControllerIPC } from '../src/controllerIPC';
+
+type ControllerListener = (
+  event: Pick<Electron.IpcMainEvent, 'sender'>,
+  payload: unknown,
+) => void;
+
+function createWindow() {
+  const webContents = {
+    sendInputEvent: vi.fn(),
+    navigationHistory: {
+      canGoBack: vi.fn(() => false),
+      goBack: vi.fn(),
+    },
+  };
+  const win = {
+    webContents,
+    isFocused: vi.fn(() => true),
+  } as unknown as Electron.BrowserWindow;
+  return { win, webContents };
+}
+
+function registeredListener(): ControllerListener {
+  const call = vi.mocked(ipcMain.on).mock.calls.find(([channel]) =>
+    channel === CONTROLLER_ACTION_CHANNEL
+  );
+  expect(call).toBeDefined();
+  return call?.[1] as ControllerListener;
+}
+
+describe('controller IPC', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['up', 'Up'],
+    ['down', 'Down'],
+    ['left', 'Left'],
+    ['right', 'Right'],
+    ['select', 'Enter'],
+  ] as const)('maps %s to ordered key events for %s', (action, keyCode) => {
+    const { win, webContents } = createWindow();
+    initControllerIPC(win);
+
+    registeredListener()({ sender: win.webContents }, action);
+
+    expect(webContents.sendInputEvent.mock.calls).toEqual([
+      [{ type: 'keyDown', keyCode }],
+      [{ type: 'keyUp', keyCode }],
+    ]);
+  });
+
+  it('rejects actions from another sender', () => {
+    const { win, webContents } = createWindow();
+    initControllerIPC(win);
+
+    registeredListener()({ sender: {} as Electron.WebContents }, 'up');
+
+    expect(webContents.sendInputEvent).not.toHaveBeenCalled();
+    expect(log.scope('controller').warn).toHaveBeenCalledWith(
+      'rejected controller action from unexpected sender',
+    );
+  });
+
+  it.each(['invalid', { keyCode: 'Delete' }, null])('rejects invalid payload %j', payload => {
+    const { win, webContents } = createWindow();
+    initControllerIPC(win);
+
+    registeredListener()({ sender: win.webContents }, payload);
+
+    expect(webContents.sendInputEvent).not.toHaveBeenCalled();
+    expect(log.scope('controller').warn).toHaveBeenCalledWith(
+      'rejected invalid controller action',
+    );
+  });
+
+  it('ignores actions while the window is not focused', () => {
+    const { win, webContents } = createWindow();
+    vi.mocked(win.isFocused).mockReturnValue(false);
+    initControllerIPC(win);
+
+    registeredListener()({ sender: win.webContents }, 'select');
+
+    expect(webContents.sendInputEvent).not.toHaveBeenCalled();
+  });
+
+  it('routes back through guarded history navigation', () => {
+    const { win, webContents } = createWindow();
+    initControllerIPC(win);
+    const listener = registeredListener();
+
+    listener({ sender: win.webContents }, 'back');
+    expect(webContents.navigationHistory.goBack).not.toHaveBeenCalled();
+
+    webContents.navigationHistory.canGoBack.mockReturnValue(true);
+    listener({ sender: win.webContents }, 'back');
+    expect(webContents.navigationHistory.goBack).toHaveBeenCalledOnce();
+    expect(webContents.sendInputEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('goBackIfPossible', () => {
+  it('checks the history before it navigates', () => {
+    const { win, webContents } = createWindow();
+
+    goBackIfPossible(win);
+    expect(webContents.navigationHistory.goBack).not.toHaveBeenCalled();
+
+    webContents.navigationHistory.canGoBack.mockReturnValue(true);
+    goBackIfPossible(win);
+    expect(webContents.navigationHistory.goBack).toHaveBeenCalledOnce();
+  });
+});

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -67,6 +67,7 @@ const bootstrap = vi.hoisted(() => {
     splashWindow,
     integrations,
     browserWindow: vi.fn(),
+    ipcOn: vi.fn(),
     appOn: vi.fn((event: string, listener: Listener) => {
       appListeners.set(event, listener);
     }),
@@ -103,7 +104,7 @@ vi.mock('electron', () => ({
     whenReady: vi.fn(() => Promise.resolve()),
     status: vi.fn(() => ({})),
   },
-  ipcMain: { on: vi.fn() },
+  ipcMain: { on: bootstrap.ipcOn },
   Menu: {
     buildFromTemplate: vi.fn(),
     setApplicationMenu: vi.fn(),
@@ -183,6 +184,10 @@ vi.mock('../src/tray', () => ({
 }));
 
 vi.mock('../src/commandBridge', () => ({ initCommandBridge: vi.fn() }));
+vi.mock('../src/controllerIPC', () => ({
+  initControllerIPC: vi.fn(),
+  goBackIfPossible: vi.fn(),
+}));
 vi.mock('../src/aboutWindow', () => ({ showAboutWindow: vi.fn() }));
 vi.mock('../src/update', () => ({ checkForUpdates: vi.fn() }));
 vi.mock('../src/autoUpdate', () => ({ isAutoUpdateSupported: vi.fn(() => false), initAutoUpdate: vi.fn() }));
@@ -251,12 +256,16 @@ describe('main bootstrap', () => {
     }
   });
 
-  it('creates a locked-down window, wires integrations, and contains first navigation failure', async () => {
+  async function startMain(): Promise<void> {
     await import('../src/main');
     for (let i = 0; i < 10 && bootstrap.mainWindow.loadURL.mock.calls.length === 0; i++) {
       await Promise.resolve();
     }
     await Promise.resolve();
+  }
+
+  it('creates a locked-down window, wires integrations, and contains first navigation failure', async () => {
+    await startMain();
 
     expect(bootstrap.browserWindow).toHaveBeenNthCalledWith(1, expect.objectContaining({
       webPreferences: {
@@ -295,5 +304,45 @@ describe('main bootstrap', () => {
     expect(bootstrap.integrations.wedgeDetector).toHaveBeenCalledOnce();
     expect(bootstrap.integrations.trayState).toHaveBeenCalledOnce();
     expect(bootstrap.appOn).toHaveBeenCalledWith('will-quit', expect.any(Function));
+  });
+
+  it('initialises controller IPC once and reuses guarded back navigation', async () => {
+    const { goBackIfPossible, initControllerIPC } = await import('../src/controllerIPC');
+    await startMain();
+
+    expect(initControllerIPC).toHaveBeenCalledOnce();
+    expect(initControllerIPC).toHaveBeenCalledWith(bootstrap.mainWindow);
+
+    const backCall = bootstrap.ipcOn.mock.calls.find(([channel]) => channel === 'nav:back');
+    expect(backCall).toBeDefined();
+    backCall?.[1]();
+    expect(goBackIfPossible).toHaveBeenCalledWith(bootstrap.mainWindow);
+  });
+
+  it('resets controller state only for main-frame navigation', async () => {
+    await startMain();
+    const didStartNavigation = bootstrap.mainWebListeners.get('did-start-navigation');
+    expect(didStartNavigation).toBeDefined();
+
+    didStartNavigation?.({
+      url: 'https://music.apple.com/gb/new#dialog',
+      isSameDocument: true,
+      isMainFrame: true,
+    });
+    expect(bootstrap.webContents.send).toHaveBeenCalledWith('controller:reset');
+
+    didStartNavigation?.({
+      url: 'https://music.apple.com/gb/album/example',
+      isSameDocument: false,
+      isMainFrame: true,
+    });
+    expect(bootstrap.webContents.send).toHaveBeenCalledTimes(2);
+
+    didStartNavigation?.({
+      url: 'https://music.apple.com/gb/iframe',
+      isSameDocument: false,
+      isMainFrame: false,
+    });
+    expect(bootstrap.webContents.send).toHaveBeenCalledTimes(2);
   });
 });

--- a/test/preload.test.ts
+++ b/test/preload.test.ts
@@ -1,0 +1,474 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { IpcRendererEvent } from 'electron';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CONTROLLER_ACTION_CHANNEL,
+  CONTROLLER_RESET_CHANNEL,
+} from '../src/controller';
+
+type IpcListener = (event: IpcRendererEvent, ...args: unknown[]) => void;
+
+function gamepad(
+  index: number,
+  pressed: number[] = [],
+  options: { connected?: boolean; mapping?: GamepadMappingType; buttonCount?: number } = {},
+): Gamepad {
+  const buttons = Array.from({ length: options.buttonCount ?? 16 }, (_, buttonIndex): GamepadButton => ({
+    pressed: pressed.includes(buttonIndex),
+    touched: pressed.includes(buttonIndex),
+    value: pressed.includes(buttonIndex) ? 1 : 0,
+  }));
+
+  return {
+    axes: [],
+    buttons,
+    connected: options.connected ?? true,
+    id: `pad-${index}`,
+    index,
+    mapping: options.mapping ?? 'standard',
+    timestamp: 0,
+    vibrationActuator: {
+      playEffect: () => Promise.resolve('complete'),
+      reset: () => Promise.resolve('complete'),
+    },
+  };
+}
+
+async function loadPreload(initialPads: readonly (Gamepad | null)[] = []) {
+  vi.resetModules();
+
+  let pads = initialPads;
+  let focused = true;
+  let visibilityState: DocumentVisibilityState = 'visible';
+  let nextFrameId = 0;
+  const frames = new Map<number, FrameRequestCallback>();
+  const ipcListeners = new Map<string, IpcListener>();
+  const windowTarget = Object.assign(new EventTarget(), {
+    location: { origin: 'https://music.apple.com' },
+    postMessage: vi.fn(),
+  });
+  const windowListeners = new Map<string, EventListenerOrEventListenerObject>();
+  const addWindowEventListener = windowTarget.addEventListener.bind(windowTarget);
+  windowTarget.addEventListener = (type, callback, options) => {
+    if (callback !== null) windowListeners.set(type, callback);
+    addWindowEventListener(type, callback, options);
+  };
+  const documentTarget = new EventTarget();
+
+  Object.defineProperties(documentTarget, {
+    hasFocus: { value: () => focused },
+    visibilityState: { get: () => visibilityState },
+  });
+
+  const getGamepads = vi.fn(() => pads);
+  const requestFrame = vi.fn((callback: FrameRequestCallback) => {
+    const id = ++nextFrameId;
+    frames.set(id, callback);
+    return id;
+  });
+  const cancelFrame = vi.fn((id: number) => {
+    frames.delete(id);
+  });
+
+  vi.stubGlobal('window', windowTarget);
+  vi.stubGlobal('document', documentTarget);
+  vi.stubGlobal('navigator', { getGamepads });
+  vi.stubGlobal('requestAnimationFrame', requestFrame);
+  vi.stubGlobal('cancelAnimationFrame', cancelFrame);
+
+  const { contextBridge, ipcRenderer } = await import('electron');
+  Object.assign(ipcRenderer, { on: vi.fn() });
+  vi.mocked(ipcRenderer.on).mockImplementation((channel, listener) => {
+    ipcListeners.set(channel, listener);
+    return ipcRenderer;
+  });
+  vi.mocked(ipcRenderer.send).mockClear();
+  vi.mocked(contextBridge.exposeInMainWorld).mockClear();
+
+  await import('../src/preload');
+
+  function dispatchWindow(type: string, pad?: Gamepad): void {
+    const event = new Event(type);
+    if (pad) Object.defineProperty(event, 'gamepad', { value: pad });
+    windowTarget.dispatchEvent(event);
+  }
+
+  function dispatchTrustedGamepad(
+    type: 'gamepadconnected' | 'gamepaddisconnected',
+    pad: Gamepad,
+  ): void {
+    const listener = windowListeners.get(type);
+    if (!listener) throw new Error(`Expected a ${type} listener`);
+    const event = { gamepad: pad, isTrusted: true } as GamepadEvent;
+    if (typeof listener === 'function') listener(event);
+    else listener.handleEvent(event);
+  }
+
+  function dispatchVisibility(state: DocumentVisibilityState): void {
+    visibilityState = state;
+    documentTarget.dispatchEvent(new Event('visibilitychange'));
+  }
+
+  function runFrame(now: number): void {
+    const entry = frames.entries().next().value;
+    if (!entry) throw new Error('Expected a pending animation frame');
+    const [id, callback] = entry;
+    frames.delete(id);
+    callback(now);
+  }
+
+  return {
+    cancelFrame,
+    contextBridge,
+    dispatchTrustedGamepad,
+    dispatchVisibility,
+    dispatchWindow,
+    frames,
+    getGamepads,
+    ipcListeners,
+    ipcRenderer,
+    requestFrame,
+    runFrame,
+    setFocused(value: boolean) {
+      focused = value;
+    },
+    setPads(value: readonly (Gamepad | null)[]) {
+      pads = value;
+    },
+    windowTarget,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('controller polling in the preload', () => {
+  it('compiles without a relative runtime require', () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'sidra-preload-'));
+    try {
+      execFileSync(process.execPath, [
+        'node_modules/typescript/lib/tsc.js',
+        '-p',
+        'tsconfig.json',
+        '--outDir',
+        outputDirectory,
+        '--sourceMap',
+        'false',
+      ]);
+      const compiled = readFileSync(join(outputDirectory, 'preload.js'), 'utf8');
+      const requires = [...compiled.matchAll(/\brequire\((["'])([^"']+)\1\)/g)]
+        .map((match) => match[2]);
+
+      expect(requires).toEqual(['electron']);
+    } finally {
+      rmSync(outputDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it('does not poll until a standard controller connects', async () => {
+    const harness = await loadPreload();
+
+    expect(harness.frames.size).toBe(0);
+    harness.dispatchTrustedGamepad('gamepadconnected', gamepad(1, [], { mapping: '' }));
+    expect(harness.frames.size).toBe(0);
+
+    const pad = gamepad(1);
+    harness.dispatchTrustedGamepad('gamepadconnected', pad);
+    harness.dispatchTrustedGamepad('gamepadconnected', pad);
+    expect(harness.frames.size).toBe(1);
+  });
+
+  it('ignores untrusted controller connections', async () => {
+    const harness = await loadPreload();
+
+    harness.dispatchWindow('gamepadconnected', gamepad(0));
+
+    expect(harness.frames.size).toBe(0);
+  });
+
+  it('polls fresh values through one frame loop and sends actions privately', async () => {
+    const harness = await loadPreload([gamepad(0)]);
+
+    expect(harness.frames.size).toBe(1);
+    harness.runFrame(0);
+    harness.setPads([gamepad(0, [12])]);
+    harness.runFrame(10);
+
+    expect(harness.getGamepads).toHaveBeenCalledTimes(3);
+    expect(harness.ipcRenderer.send).toHaveBeenCalledWith(CONTROLLER_ACTION_CHANNEL, 'up');
+    expect(harness.frames.size).toBe(1);
+  });
+
+  it('stops on blur, resets held input, and resumes once on focus', async () => {
+    const harness = await loadPreload([gamepad(0, [12])]);
+    harness.runFrame(0);
+    vi.mocked(harness.ipcRenderer.send).mockClear();
+
+    harness.setFocused(false);
+    harness.dispatchWindow('blur');
+    expect(harness.cancelFrame).toHaveBeenCalledOnce();
+    expect(harness.frames.size).toBe(0);
+
+    harness.dispatchVisibility('visible');
+    expect(harness.frames.size).toBe(0);
+
+    harness.setFocused(true);
+    harness.dispatchWindow('focus');
+    harness.dispatchWindow('focus');
+    expect(harness.frames.size).toBe(1);
+    harness.runFrame(10);
+    expect(harness.ipcRenderer.send).not.toHaveBeenCalled();
+
+    harness.setPads([gamepad(0)]);
+    harness.runFrame(20);
+    harness.setPads([gamepad(0, [12])]);
+    harness.runFrame(30);
+    expect(harness.ipcRenderer.send).toHaveBeenCalledWith(CONTROLLER_ACTION_CHANNEL, 'up');
+  });
+
+  it.each([
+    ['visibility', 'visibilitychange'],
+    ['page lifecycle', 'pagehide'],
+  ] as const)('stops and resumes for the %s', async (_name, event) => {
+    const harness = await loadPreload([gamepad(0)]);
+
+    if (event === 'visibilitychange') harness.dispatchVisibility('hidden');
+    else harness.dispatchWindow('pagehide');
+    expect(harness.frames.size).toBe(0);
+
+    if (event === 'visibilitychange') harness.dispatchVisibility('visible');
+    else harness.dispatchWindow('pageshow');
+    expect(harness.frames.size).toBe(1);
+  });
+
+  it('samples a disconnect, removes stale state, and stops the loop', async () => {
+    const harness = await loadPreload([gamepad(0)]);
+    harness.runFrame(0);
+    harness.setPads([gamepad(0, [14])]);
+    harness.runFrame(10);
+    vi.mocked(harness.ipcRenderer.send).mockClear();
+
+    harness.setPads([]);
+    harness.dispatchTrustedGamepad(
+      'gamepaddisconnected',
+      gamepad(0, [], { connected: false }),
+    );
+    expect(harness.frames.size).toBe(1);
+
+    const reconnected = gamepad(0, [14]);
+    harness.setPads([reconnected]);
+    harness.dispatchTrustedGamepad('gamepadconnected', reconnected);
+    harness.runFrame(20);
+    expect(harness.ipcRenderer.send).toHaveBeenCalledWith(CONTROLLER_ACTION_CHANNEL, 'left');
+  });
+
+  it('ignores an untrusted disconnect while a button stays held', async () => {
+    const harness = await loadPreload([gamepad(0)]);
+    harness.runFrame(0);
+    harness.setPads([gamepad(0, [12])]);
+    harness.runFrame(10);
+    vi.mocked(harness.ipcRenderer.send).mockClear();
+
+    harness.dispatchWindow(
+      'gamepaddisconnected',
+      gamepad(0, [], { connected: false }),
+    );
+    harness.runFrame(20);
+
+    expect(harness.ipcRenderer.send).not.toHaveBeenCalled();
+  });
+
+  it('does not restart for a disconnect while the page is hidden', async () => {
+    const harness = await loadPreload([gamepad(0)]);
+    harness.dispatchVisibility('hidden');
+
+    harness.setPads([]);
+    harness.dispatchTrustedGamepad(
+      'gamepaddisconnected',
+      gamepad(0, [], { connected: false }),
+    );
+    expect(harness.frames.size).toBe(0);
+  });
+
+  it('handles reset IPC in the isolated preload', async () => {
+    const harness = await loadPreload([gamepad(0)]);
+    harness.runFrame(0);
+    harness.setPads([gamepad(0, [0])]);
+    harness.runFrame(10);
+    vi.mocked(harness.ipcRenderer.send).mockClear();
+
+    const reset = harness.ipcListeners.get(CONTROLLER_RESET_CHANNEL);
+    expect(reset).toBeDefined();
+    reset?.({} as IpcRendererEvent);
+    harness.runFrame(20);
+
+    expect(harness.ipcRenderer.send).not.toHaveBeenCalled();
+    expect(harness.windowTarget.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('keeps controller actions out of the public bridge', async () => {
+    const harness = await loadPreload();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const exposed = vi.mocked(harness.contextBridge.exposeInMainWorld).mock.calls
+      .find(([key]) => key === 'AMWrapper')?.[1] as {
+        ipcRenderer: { send(channel: string, data?: unknown): void };
+      };
+
+    exposed.ipcRenderer.send(CONTROLLER_ACTION_CHANNEL, 'up');
+    expect(harness.ipcRenderer.send).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      'AMWrapper: blocked send on unlisted channel "controller:action"',
+    );
+
+    exposed.ipcRenderer.send('playbackStateDidChange', true);
+    expect(harness.ipcRenderer.send).toHaveBeenCalledWith('playbackStateDidChange', true);
+  });
+
+  it('installs one polling loop for each isolated preload setup', async () => {
+    const first = await loadPreload([gamepad(0)]);
+    expect(first.requestFrame).toHaveBeenCalledOnce();
+
+    const second = await loadPreload([gamepad(0)]);
+    expect(second.requestFrame).toHaveBeenCalledOnce();
+    expect(second.frames.size).toBe(1);
+  });
+
+  it.each([
+    [12, 'up'],
+    [13, 'down'],
+    [14, 'left'],
+    [15, 'right'],
+    [0, 'select'],
+    [1, 'back'],
+  ] as const)('maps button %i to %s', async (button, action) => {
+    const harness = await loadPreload([gamepad(0)]);
+    harness.runFrame(0);
+    harness.setPads([gamepad(0, [button])]);
+    harness.runFrame(1);
+
+    expect(harness.ipcRenderer.send).toHaveBeenCalledWith(CONTROLLER_ACTION_CHANNEL, action);
+  });
+
+  it('suppresses buttons held when a new document preload starts', async () => {
+    const harness = await loadPreload([gamepad(0, [12])]);
+    harness.runFrame(0);
+    harness.runFrame(500);
+    expect(harness.ipcRenderer.send).not.toHaveBeenCalled();
+
+    harness.setPads([gamepad(0)]);
+    harness.runFrame(600);
+    harness.setPads([gamepad(0, [12])]);
+    harness.runFrame(700);
+    expect(harness.ipcRenderer.send).toHaveBeenCalledWith(CONTROLLER_ACTION_CHANNEL, 'up');
+  });
+
+  it('emits pressed edges and repeats only directions at fixed boundaries', async () => {
+    const harness = await loadPreload([gamepad(0)]);
+    harness.runFrame(0);
+    harness.setPads([gamepad(0, [12, 0, 1])]);
+    harness.runFrame(10);
+    harness.runFrame(409);
+    harness.runFrame(410);
+    harness.runFrame(509);
+    harness.runFrame(510);
+
+    const actions = vi.mocked(harness.ipcRenderer.send).mock.calls.map(([, action]) => action);
+    expect(actions).toEqual(['up', 'select', 'back', 'up', 'up']);
+
+    harness.setPads([gamepad(0)]);
+    harness.runFrame(520);
+    harness.setPads([gamepad(0, [0])]);
+    harness.runFrame(530);
+    expect(vi.mocked(harness.ipcRenderer.send).mock.calls.at(-1)?.[1]).toBe('select');
+  });
+
+  it('starts a fresh repeat interval after a delayed frame', async () => {
+    const harness = await loadPreload([gamepad(0)]);
+    harness.runFrame(0);
+    harness.setPads([gamepad(0, [12])]);
+    harness.runFrame(10);
+    harness.runFrame(910);
+    harness.runFrame(1009);
+    harness.runFrame(1010);
+
+    const actions = vi.mocked(harness.ipcRenderer.send).mock.calls.map(([, action]) => action);
+    expect(actions).toEqual(['up', 'up', 'up']);
+  });
+
+  it('treats missing buttons as released', async () => {
+    const harness = await loadPreload([gamepad(0)]);
+    harness.runFrame(0);
+    harness.setPads([gamepad(0, [15])]);
+    harness.runFrame(10);
+    harness.setPads([gamepad(0, [], { buttonCount: 2 })]);
+    harness.runFrame(20);
+    harness.setPads([gamepad(0, [15])]);
+    harness.runFrame(30);
+
+    const actions = vi.mocked(harness.ipcRenderer.send).mock.calls.map(([, action]) => action);
+    expect(actions).toEqual(['right', 'right']);
+  });
+
+  it('removes state for absent, disconnected, and non-standard pads', async () => {
+    const harness = await loadPreload([gamepad(0)]);
+    harness.runFrame(0);
+    harness.setPads([gamepad(0, [12]), gamepad(1, [15])]);
+    harness.runFrame(10);
+    vi.mocked(harness.ipcRenderer.send).mockClear();
+
+    harness.setPads([
+      null,
+      gamepad(0, [12], { connected: false }),
+      gamepad(1, [15], { mapping: '' }),
+    ]);
+    harness.runFrame(20);
+    expect(harness.frames.size).toBe(0);
+
+    const first = gamepad(0, [12]);
+    const second = gamepad(1, [15]);
+    harness.setPads([first, second]);
+    harness.dispatchTrustedGamepad('gamepadconnected', first);
+    harness.runFrame(30);
+    const actions = vi.mocked(harness.ipcRenderer.send).mock.calls.map(([, action]) => action);
+    expect(actions).toEqual(['up', 'right']);
+  });
+
+  it('suppresses held input after a frame gap above 1000 ms', async () => {
+    const harness = await loadPreload([gamepad(0)]);
+    harness.runFrame(0);
+    harness.setPads([gamepad(0, [13])]);
+    harness.runFrame(10);
+    harness.runFrame(1010);
+    harness.runFrame(2011);
+
+    const actions = vi.mocked(harness.ipcRenderer.send).mock.calls.map(([, action]) => action);
+    expect(actions).toEqual(['down', 'down']);
+
+    harness.setPads([gamepad(0)]);
+    harness.runFrame(2020);
+    harness.setPads([gamepad(0, [13])]);
+    harness.runFrame(2030);
+    expect(vi.mocked(harness.ipcRenderer.send).mock.calls.at(-1)?.[1]).toBe('down');
+  });
+
+  it('keeps input state independent for two pads', async () => {
+    const harness = await loadPreload([gamepad(0), gamepad(1)]);
+    harness.runFrame(0);
+    harness.setPads([gamepad(0, [14]), gamepad(1, [0])]);
+    harness.runFrame(10);
+    harness.setPads([gamepad(0, [14]), gamepad(1)]);
+    harness.runFrame(410);
+    harness.setPads([gamepad(0), gamepad(1, [0])]);
+    harness.runFrame(510);
+
+    const actions = vi.mocked(harness.ipcRenderer.send).mock.calls.map(([, action]) => action);
+    expect(actions).toEqual(['left', 'select', 'left', 'select']);
+  });
+});


### PR DESCRIPTION
Add controller navigation to both services through private preload IPC, mapping standard Gamepad controls to existing keyboard navigation and suppressing held input after page changes. The feature leaves media controls and settings unchanged.

Verified with just test (1,093 tests), just lint, git diff --check, the preload sandbox import check, and security validation. Physical Steam Deck and XInput testing did not run.

Refs: #218
