### PR TITLE
chore(diagnostics): add privacy-safe process health logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ The `10_15_7` macOS version freeze is intentional - Chrome itself freezes this v
 - All main-world renderer→main IPC flows through the `SEND_CHANNELS` allowlist in `src/preload.ts`. Blocked channels log a warning. Private isolated-preload channels do not use `AMWrapper`
 - No Node.js APIs exposed to the renderer
 - External URLs validated for `http:`/`https:` protocol before opening. `openExternalUrl()` in `src/utils/openExternal.ts` is the one guard, used by `setWindowOpenHandler`, the tray update link and the update notification, so a hardening change is made once. It hands `shell.openExternal()` the parsed `URL`, never the string that came in: Chromium re-parses the argument with its own parser, so passing the raw string would open a URL nothing checked. Both refusals are logged; a silent one leaves a dead menu item with no record of why. Last.fm's `openInBrowser()` is the one caller outside it, and it takes a `URL` the integration built itself
+- Keep process-health and command-provenance diagnostics observational. Log only fixed, allow-listed `key=value` fields. Reduce `preloadPath` to its basename. Exclude user-supplied values, full URLs, other paths, media metadata, error messages, stacks, titles, artists, playlist names, usernames, tokens, credentials, request data, and command arguments. Process-health listeners must never reload, retry, close, quit, or take any other recovery action
 
 **TypeScript**
 - `strict: true` in `tsconfig.json`; zero `any` annotations, `@ts-ignore`, or `@ts-expect-error` in `src/`

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -215,10 +215,24 @@ Current dependency roles:
 
 `electron-log` handles all application logging. Use structured log levels consistently:
 
-- `log.info` - startup, integration lifecycle (enabled/disabled), MusicKit hook confirmation
-- `log.warn` - recoverable issues (Discord RPC disconnection, notification artwork fetch failure)
-- `log.error` - unrecoverable issues (D-Bus connection failure, Widevine CDM unavailable)
-- `log.debug` - IPC event flow, state transitions (noisy, off by default)
+- `log.info` - startup, integration lifecycle (enabled/disabled), MusicKit hook confirmation, and MPRIS command provenance except successful `Volume` commands
+- `log.warn` - recoverable issues, process health warnings, and wedge command provenance
+- `log.error` - failures that end a required process, including a renderer process loss
+- `log.debug` - IPC event flow, state transitions, and successful MPRIS `Volume` command provenance (noisy, off by default)
+
+The `main` scope records these process events with fixed, allow-listed fields:
+
+| Event | Level | Message |
+|---|---|---|
+| `unresponsive` | `warn` | `event=unresponsive processType=renderer` |
+| `responsive` | `info` | `event=responsive processType=renderer` |
+| `render-process-gone` | `error` | `event=render-process-gone processType=renderer reason=<reason> exitCode=<exitCode>` |
+| `preload-error` | `warn` | `event=preload-error processType=renderer preloadPath=<basename> errorName=<standard name\|UnknownError>` |
+| `child-process-gone` | `warn` | `event=child-process-gone processType=<type> reason=<reason> exitCode=<exitCode> [serviceName=<JSON string>]` |
+
+`preloadPath` contains only the basename. The fixed `errorName` allowlist contains `AggregateError`, `Error`, `EvalError`, `RangeError`, `ReferenceError`, `SyntaxError`, `TypeError`, and `URIError`. Every other value becomes `UnknownError`. Diagnostic logs exclude user-supplied arguments, full URLs, other paths, metadata, messages, stacks, titles, artists, playlist names, usernames, tokens, and credentials.
+
+Diagnostic logging only records existing outcomes. It leaves recovery, dependencies, feature flags, process switches, timers, queues, coalescing, notification gates, and playback behaviour unchanged.
 
 ---
 
@@ -290,6 +304,8 @@ Integrations send commands to the renderer via a two-stage bridge:
 The `window.location.origin` target keeps the bridge service-agnostic: it passes the sandbox same-origin check on both `music.apple.com` and `classical.music.apple.com` without a hardcoded origin.
 
 The command bridge uses the `RECEIVE_CHANNELS` allowlist in `src/preload.ts` and the `COMMANDS` allowlist in `assets/musicKitHook.js`, which must stay in sync. `src/types/hook.d.ts` declares `SendChannel` and `ReceiveChannel` union types used by `src/preload.ts` (`Set<SendChannel>`, `Set<ReceiveChannel>`), enforcing channel sync at compile time. Contract tests in `test/player.test.ts` verify alignment via `expectTypeOf`.
+
+The MPRIS and wedge dispatch sites log command provenance without command arguments. `result=sent` means that Sidra invoked the local action. `result=dropped` means that the required main window was unavailable. The result does not confirm that the renderer completed the command.
 
 | Control | Method | Triggered by |
 |---|---|---|
@@ -515,6 +531,8 @@ Full `org.mpris.MediaPlayer2.Player` property and method checklist. All must wor
 | `Stop()` | `window.__sidra.pause()` (not `mk.stop()`, which clears the queue and violates MPRIS spec) |
 | `Seek(Offset)` | `mk.seekToTime(currentTime + offsetMicros / 1e6)` |
 | `SetPosition(id, pos)` | `mk.seekToTime(posMicros / 1e6)` |
+
+MPRIS command provenance uses `source=mpris method=<method> [channel=<channel>] result=sent|dropped`. A successful `Volume` command logs at `debug`. A dropped `Volume` command and all other results log at `info`. `LoopStatus`, `Shuffle`, `Volume`, `Next`, `Previous`, `Pause`, `PlayPause`, `Stop`, `Play`, `Seek`, and `SetPosition` include their renderer channel. `Raise` and `OpenUri` can report either result. `Quit` reports `sent`. All three omit `channel`. Rejected values and URIs use generic warnings without request data.
 
 ### Signals
 
@@ -1124,7 +1142,7 @@ electron-updater manifest filenames are hardcoded and cannot be changed:
 | Navigation bar | `assets/navigationBar.js` injected post-load | Back/forward/reload buttons in sidebar; localised aria-labels substituted for `__SIDRA_NAV_LABELS__` at read time |
 | Auth iframe filtering | `authStyleFix.css` + `webFrameMain.executeJavaScript()` | Hides unsupported passkey and "Sign in with iPhone" desktop flows |
 | Zoom factor preference | `zoomFactor` in `electron-conf` | 1.0x to 2.0x via tray submenu |
-| Wedge detector | `src/wedgeDetector.ts` | Auto-skip on playback stall |
+| Wedge detector | `src/wedgeDetector.ts` | Auto-skip on playback stall. Each attempt logs at `warn` with `source=wedge channel=player:next reason=playback-stalled attempt=<current>/3 result=sent|dropped` |
 | Artwork cache | `src/artwork.ts` | UUID-based filenames, 7-day expiry, atomic writes |
 | Pause timer utility | `src/pauseTimer.ts` | `createPauseTimer()` shared by tray, dock, Discord |
 | Update checking (non-auto-update) | `src/update.ts` | GitHub API check for deb/rpm/Nix/DMG platforms |

--- a/src/integrations/mpris/index.ts
+++ b/src/integrations/mpris/index.ts
@@ -29,6 +29,32 @@ const mprisLog = log.scope('mpris');
 
 const MPRIS_PATH = '/org/mpris/MediaPlayer2';
 
+type MprisMethod =
+  | 'LoopStatus'
+  | 'Shuffle'
+  | 'Volume'
+  | 'Next'
+  | 'Previous'
+  | 'Pause'
+  | 'PlayPause'
+  | 'Stop'
+  | 'Play'
+  | 'Seek'
+  | 'SetPosition'
+  | 'OpenUri'
+  | 'Raise'
+  | 'Quit';
+
+function logCommand(method: MprisMethod, result: 'sent' | 'dropped', channel?: ReceiveChannel): void {
+  const channelField = channel === undefined ? '' : ` channel=${channel}`;
+  const message = `source=mpris method=${method}${channelField} result=${result}`;
+  if (method === 'Volume' && result === 'sent') {
+    mprisLog.debug(message);
+    return;
+  }
+  mprisLog.info(message);
+}
+
 /**
  * The `org.mpris.MediaPlayer2` root interface: how Sidra identifies itself to
  * media clients, and the two window actions the spec puts here.
@@ -74,11 +100,15 @@ class MediaPlayer2 extends Interface {
     if (win) {
       win.show();
       win.focus();
+      logCommand('Raise', 'sent');
+    } else {
+      logCommand('Raise', 'dropped');
     }
   }
 
   Quit(): void {
     app.quit();
+    logCommand('Quit', 'sent');
   }
 }
 
@@ -243,10 +273,13 @@ class MediaPlayer2Player extends Interface {
     this._getMainWindow = getMainWindow;
   }
 
-  private _send(channel: ReceiveChannel, ...args: unknown[]): void {
+  private _send(method: MprisMethod, channel: ReceiveChannel, ...args: unknown[]): void {
     const win = this._getMainWindow();
     if (win) {
       win.webContents.send(channel, ...args);
+      logCommand(method, 'sent', channel);
+    } else {
+      logCommand(method, 'dropped', channel);
     }
   }
 
@@ -502,11 +535,11 @@ class MediaPlayer2Player extends Interface {
     };
     const mode = loopToMusicKit[value];
     if (mode === undefined) {
-      mprisLog.warn('invalid LoopStatus value:', value);
+      mprisLog.warn('invalid LoopStatus value');
       return;
     }
     this._loopStatus = value;
-    this._send('player:setRepeat', mode);
+    this._send('LoopStatus', 'player:setRepeat', mode);
   }
 
   get Shuffle(): boolean {
@@ -516,7 +549,7 @@ class MediaPlayer2Player extends Interface {
   set Shuffle(value: boolean) {
     this._shuffle = value;
     const mode = value ? 1 : 0;
-    this._send('player:setShuffle', mode);
+    this._send('Shuffle', 'player:setShuffle', mode);
   }
 
   get Volume(): number {
@@ -543,42 +576,42 @@ class MediaPlayer2Player extends Interface {
       this._pendingVolumes = [];
       this._volumeSafetyTimer = null;
     }, this._volumeSafetyMs);
-    this._send('player:setVolume', clamped);
+    this._send('Volume', 'player:setVolume', clamped);
   }
 
   // --- Methods ---
 
   Next(): void {
-    this._send('player:next');
+    this._send('Next', 'player:next');
   }
 
   Previous(): void {
-    this._send('player:previous');
+    this._send('Previous', 'player:previous');
   }
 
   Pause(): void {
-    this._send('player:pause');
+    this._send('Pause', 'player:pause');
   }
 
   PlayPause(): void {
-    this._send('player:playPause');
+    this._send('PlayPause', 'player:playPause');
   }
 
   Stop(): void {
     // Pause, never MusicKit's stop(): stop() clears the queue, and the MPRIS
     // spec requires Play() after Stop() to resume from the start of the track.
-    this._send('player:pause');
+    this._send('Stop', 'player:pause');
   }
 
   Play(): void {
-    this._send('player:play');
+    this._send('Play', 'player:play');
   }
 
   Seek(offset: bigint): void {
     // offset is in microseconds; dbus-next delivers int64 as BigInt
     const targetUs = this._position + Number(offset);
     const targetSeconds = Math.max(0, targetUs) / 1_000_000;
-    this._send('player:seek', targetSeconds);
+    this._send('Seek', 'player:seek', targetSeconds);
   }
 
   SetPosition(trackId: string, position: bigint): void {
@@ -588,7 +621,7 @@ class MediaPlayer2Player extends Interface {
       return;
     }
     const targetSeconds = Number(position) / 1_000_000;
-    this._send('player:seek', targetSeconds);
+    this._send('SetPosition', 'player:seek', targetSeconds);
   }
 
   /**
@@ -600,18 +633,21 @@ class MediaPlayer2Player extends Interface {
     try {
       const parsed = new URL(uri);
       if (getServiceByHost(parsed.hostname) === undefined || parsed.protocol !== 'https:') {
-        mprisLog.warn('OpenUri rejected:', uri);
+        mprisLog.warn('OpenUri rejected');
         return;
       }
     } catch {
-      mprisLog.warn('OpenUri rejected malformed URI:', uri);
+      mprisLog.warn('OpenUri rejected malformed URI');
       return;
     }
     const win = this._getMainWindow();
     if (win) {
-      win.loadURL(uri).catch((err: Error) => {
-        mprisLog.warn('failed to open URI:', err.message);
+      win.loadURL(uri).catch(() => {
+        mprisLog.warn('failed to open accepted URI');
       });
+      logCommand('OpenUri', 'sent');
+    } else {
+      logCommand('OpenUri', 'dropped');
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,16 @@ const SPLASH_WIDTH_PX = 300;
 const SPLASH_HEIGHT_PX = 350;
 const MAIN_WINDOW_WIDTH_PX = 1280;
 const MAIN_WINDOW_HEIGHT_PX = 800;
+const PRELOAD_ERROR_NAMES = new Set([
+  'AggregateError',
+  'Error',
+  'EvalError',
+  'RangeError',
+  'ReferenceError',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+]);
 
 // --- Logging: initialise before anything else ---
 log.initialize();
@@ -61,6 +71,15 @@ if (envLevel && VALID_LEVELS.has(envLevel as LogLevel)) {
 const mainLog = log.scope('main');
 const splashLog = log.scope('splash');
 mainLog.info(`${app.name} ${app.getVersion()}`);
+
+app.on('child-process-gone', (_event, details) => {
+  const serviceName = details.serviceName === undefined
+    ? ''
+    : ` serviceName=${JSON.stringify(details.serviceName)}`;
+  mainLog.warn(
+    `event=child-process-gone processType=${details.type} reason=${details.reason} exitCode=${details.exitCode}${serviceName}`,
+  );
+});
 
 // --- App identity: must be set before app.whenReady() on Windows, or neither
 // desktop notifications nor the GSMTC media identity attach to Sidra ---
@@ -495,6 +514,24 @@ function setupAuthFrameInjection(win: BrowserWindow, script: string): void {
 }
 
 function setupWindowEvents(win: BrowserWindow, markCssReady: () => void): void {
+  win.webContents.on('unresponsive', () => {
+    mainLog.warn('event=unresponsive processType=renderer');
+  });
+  win.webContents.on('responsive', () => {
+    mainLog.info('event=responsive processType=renderer');
+  });
+  win.webContents.on('render-process-gone', (_event, details) => {
+    mainLog.error(
+      `event=render-process-gone processType=renderer reason=${details.reason} exitCode=${details.exitCode}`,
+    );
+  });
+  win.webContents.on('preload-error', (_event, preloadPath, error) => {
+    const errorName = PRELOAD_ERROR_NAMES.has(error.name) ? error.name : 'UnknownError';
+    mainLog.warn(
+      `event=preload-error processType=renderer preloadPath=${path.basename(preloadPath)} errorName=${errorName}`,
+    );
+  });
+
   // Prevent the web page title from overriding the window title
   win.on('page-title-updated', (event) => {
     event.preventDefault();

--- a/src/wedgeDetector.ts
+++ b/src/wedgeDetector.ts
@@ -43,9 +43,13 @@ function checkForWedge(getWin: () => BrowserWindow | null): void {
 
   skipAttempts++;
   lastAdvanceTime = Date.now();
-  wedgeLog.warn(`playback stalled, skipping forward (attempt ${skipAttempts}/${MAX_SKIP_ATTEMPTS})`);
+  const win = getWin();
+  const result = win ? 'sent' : 'dropped';
+  wedgeLog.warn(
+    `source=wedge channel=player:next reason=playback-stalled attempt=${skipAttempts}/${MAX_SKIP_ATTEMPTS} result=${result}`,
+  );
 
-  getWin()?.webContents.send('player:next' satisfies ReceiveChannel);
+  win?.webContents.send('player:next' satisfies ReceiveChannel);
 }
 
 /**

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -70,6 +70,7 @@ const bootstrap = vi.hoisted(() => {
     resetForDocumentReplacement,
     browserWindow: vi.fn(),
     ipcOn: vi.fn(),
+    appQuit: vi.fn(),
     appOn: vi.fn((event: string, listener: Listener) => {
       appListeners.set(event, listener);
     }),
@@ -93,7 +94,7 @@ vi.mock('electron', () => ({
     getPath: vi.fn((name: string) => `/tmp/sidra-test/${name}`),
     whenReady: vi.fn(() => Promise.resolve()),
     on: bootstrap.appOn,
-    quit: vi.fn(),
+    quit: bootstrap.appQuit,
     requestSingleInstanceLock: vi.fn(() => true),
     setAppUserModelId: vi.fn(),
     setAsDefaultProtocolClient: vi.fn(() => true),
@@ -376,5 +377,144 @@ describe('main bootstrap', () => {
     expect(bootstrap.resetForDocumentReplacement).toHaveBeenCalledOnce();
     expect(bootstrap.resetForDocumentReplacement.mock.invocationCallOrder[0])
       .toBeLessThan(vi.mocked(handleStorefrontNavigation).mock.invocationCallOrder.at(-1)!);
+  });
+
+  it('logs process lifecycle events without private event data', async () => {
+    const privatePath = '/home/alice/.config/sidra/access-token-secret/preload.js';
+    const privateUrl = 'https://music.apple.com/gb/album/private?token=secret-token';
+    const privateStack = `Error: secret-token\n    at ${privatePath}:1:1`;
+    const privateMetadata = { title: 'Private Track', url: privateUrl };
+
+    await startMain();
+
+    const childProcessGoneCall = bootstrap.appOn.mock.calls
+      .findIndex(([event]) => event === 'child-process-gone');
+    expect(bootstrap.appOn.mock.invocationCallOrder[childProcessGoneCall])
+      .toBeLessThan(bootstrap.browserWindow.mock.invocationCallOrder[0]);
+
+    bootstrap.log.info.mockClear();
+    bootstrap.log.warn.mockClear();
+    bootstrap.log.error.mockClear();
+
+    const unresponsive = bootstrap.mainWebListeners.get('unresponsive');
+    const responsive = bootstrap.mainWebListeners.get('responsive');
+    const renderProcessGone = bootstrap.mainWebListeners.get('render-process-gone');
+    const preloadError = bootstrap.mainWebListeners.get('preload-error');
+    const childProcessGone = bootstrap.appListeners.get('child-process-gone');
+
+    expect(unresponsive).toBeDefined();
+    expect(responsive).toBeDefined();
+    expect(renderProcessGone).toBeDefined();
+    expect(preloadError).toBeDefined();
+    expect(childProcessGone).toBeDefined();
+
+    unresponsive?.({ url: privateUrl, token: 'secret-token' });
+    responsive?.({ url: privateUrl, metadata: privateMetadata });
+    renderProcessGone?.({}, {
+      reason: 'crashed',
+      exitCode: 133,
+      url: privateUrl,
+      token: 'secret-token',
+      metadata: privateMetadata,
+      arguments: ['--secret-token'],
+    });
+
+    const error = new Error(`failed for ${privateUrl}`);
+    error.name = 'TypeError';
+    error.stack = privateStack;
+    preloadError?.({}, privatePath, error);
+
+    childProcessGone?.({}, {
+      type: 'Utility',
+      reason: 'crashed',
+      exitCode: 9,
+      serviceName: 'Audio Service',
+      name: privateUrl,
+      token: 'secret-token',
+      metadata: privateMetadata,
+      arguments: ['--secret-token'],
+    });
+    childProcessGone?.({}, {
+      type: 'GPU',
+      reason: 'oom',
+      exitCode: 137,
+      name: privateUrl,
+    });
+
+    expect(bootstrap.log.warn).toHaveBeenNthCalledWith(
+      1,
+      'event=unresponsive processType=renderer',
+    );
+    expect(bootstrap.log.info).toHaveBeenCalledOnce();
+    expect(bootstrap.log.info).toHaveBeenCalledWith('event=responsive processType=renderer');
+    expect(bootstrap.log.error).toHaveBeenCalledOnce();
+    expect(bootstrap.log.error).toHaveBeenCalledWith(
+      'event=render-process-gone processType=renderer reason=crashed exitCode=133',
+    );
+    expect(bootstrap.log.warn).toHaveBeenNthCalledWith(
+      2,
+      'event=preload-error processType=renderer preloadPath=preload.js errorName=TypeError',
+    );
+    expect(bootstrap.log.warn).toHaveBeenNthCalledWith(
+      3,
+      'event=child-process-gone processType=Utility reason=crashed exitCode=9 serviceName="Audio Service"',
+    );
+    expect(bootstrap.log.warn).toHaveBeenNthCalledWith(
+      4,
+      'event=child-process-gone processType=GPU reason=oom exitCode=137',
+    );
+
+    const logCalls = JSON.stringify([
+      ...bootstrap.log.info.mock.calls,
+      ...bootstrap.log.warn.mock.calls,
+      ...bootstrap.log.error.mock.calls,
+    ]);
+    expect(logCalls).not.toContain(privatePath);
+    expect(logCalls).not.toContain(privateUrl);
+    expect(logCalls).not.toContain('secret-token');
+    expect(logCalls).not.toContain(privateStack);
+    expect(logCalls).not.toContain('Private Track');
+    expect(logCalls).not.toContain('--secret-token');
+    expect(bootstrap.webContents.reload).not.toHaveBeenCalled();
+    expect(bootstrap.mainWindow.close).not.toHaveBeenCalled();
+    expect(bootstrap.appQuit).not.toHaveBeenCalled();
+    expect(bootstrap.mainWindow.loadURL).toHaveBeenCalledOnce();
+  });
+
+  it('replaces an unsafe preload error name with a fixed fallback', async () => {
+    const privateUrl = 'https://music.apple.com/private?token=preload-secret';
+    const privateName = `CustomError\r\n${privateUrl}\0token=preload-secret`;
+    const privateMessage = `failed to load ${privateUrl}\tpreload-secret`;
+    const privateStack = `${privateName}: ${privateMessage}\n    at /private/preload.js:1:1`;
+
+    await startMain();
+
+    bootstrap.log.info.mockClear();
+    bootstrap.log.warn.mockClear();
+    bootstrap.log.error.mockClear();
+
+    const preloadError = bootstrap.mainWebListeners.get('preload-error');
+    expect(preloadError).toBeDefined();
+
+    const error = new Error(privateMessage);
+    error.name = privateName;
+    error.stack = privateStack;
+    preloadError?.({}, '/private/preload.js', error);
+
+    expect(bootstrap.log.warn).toHaveBeenCalledOnce();
+    expect(bootstrap.log.warn).toHaveBeenCalledWith(
+      'event=preload-error processType=renderer preloadPath=preload.js errorName=UnknownError',
+    );
+    expect(bootstrap.log.info).not.toHaveBeenCalled();
+    expect(bootstrap.log.error).not.toHaveBeenCalled();
+
+    const loggedValues = [
+      ...bootstrap.log.info.mock.calls,
+      ...bootstrap.log.warn.mock.calls,
+      ...bootstrap.log.error.mock.calls,
+    ].flat().map(String);
+    for (const privateValue of [privateName, privateMessage, privateStack, privateUrl, 'preload-secret']) {
+      expect(loggedValues.every(value => !value.includes(privateValue))).toBe(true);
+    }
   });
 });

--- a/test/mpris.test.ts
+++ b/test/mpris.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { app } from 'electron';
 import type { BrowserWindow } from 'electron';
+import log from 'electron-log/main';
 
 import { setMusicService } from '../src/config';
 import { PlaybackState } from '../src/player';
@@ -55,17 +57,27 @@ const busStub = {
 };
 
 interface WindowStub {
+  show: ReturnType<typeof vi.fn>;
+  focus: ReturnType<typeof vi.fn>;
   loadURL: ReturnType<typeof vi.fn>;
   webContents: { send: ReturnType<typeof vi.fn> };
 }
 
 interface PlayerInterface {
   OpenUri(uri: string): void;
+  Next(): void;
+  Previous(): void;
+  Pause(): void;
+  PlayPause(): void;
+  Stop(): void;
+  Play(): void;
+  Seek(offset: bigint): void;
+  SetPosition(trackId: string, position: bigint): void;
   Seeked(position: number): number;
   Volume: number;
   readonly PlaybackStatus: string;
-  readonly LoopStatus: string;
-  readonly Shuffle: boolean;
+  LoopStatus: string;
+  Shuffle: boolean;
   readonly Metadata: Record<string, VariantValue>;
   readonly Position: number;
   readonly CanGoNext: boolean;
@@ -74,6 +86,12 @@ interface PlayerInterface {
   readonly CanPause: boolean;
   readonly CanSeek: boolean;
   readonly CanControl: boolean;
+}
+
+interface RootInterface {
+  Raise(): void;
+  Quit(): void;
+  readonly SupportedUriSchemes: string[];
 }
 
 /**
@@ -100,18 +118,42 @@ let player: FakePlayer;
  * export. Driving the real methods and properties this way needs no production
  * change.
  */
-function initPlayerInterface(): PlayerInterface {
+function initInterfaces(getMainWindow: () => BrowserWindow | null = () => win as unknown as BrowserWindow): {
+  root: RootInterface;
+  player: PlayerInterface;
+} {
   const ctx: IntegrationContext = {
     player,
-    getMainWindow: () => win as unknown as BrowserWindow,
+    getMainWindow,
   };
   mpris.init(ctx);
   expect(busStub.export).toHaveBeenCalledTimes(2);
-  return busStub.export.mock.calls[1][1] as PlayerInterface;
+  return {
+    root: busStub.export.mock.calls[0][1] as RootInterface,
+    player: busStub.export.mock.calls[1][1] as PlayerInterface,
+  };
+}
+
+function initPlayerInterface(): PlayerInterface {
+  return initInterfaces().player;
+}
+
+function mprisLogText(): string {
+  const scopedLog = log.scope('mpris');
+  return [scopedLog.info, scopedLog.warn, scopedLog.error, scopedLog.debug]
+    .flatMap((method) => vi.mocked(method).mock.calls)
+    .flat()
+    .join(' ');
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  Object.assign(log.scope('mpris'), {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  });
   vi.spyOn(dbus, 'sessionBus').mockReturnValue(busStub);
   vi.spyOn(dbus.interface.Interface, 'emitPropertiesChanged').mockImplementation((iface, changed, invalidated) => {
     emissions.push(changed);
@@ -126,7 +168,12 @@ beforeEach(() => {
   emissions = [];
   setMusicService('music');
   // loadURL must return a promise: production attaches a .catch() to it.
-  win = { loadURL: vi.fn(() => Promise.resolve()), webContents: { send: vi.fn() } };
+  win = {
+    show: vi.fn(),
+    focus: vi.fn(),
+    loadURL: vi.fn(() => Promise.resolve()),
+    webContents: { send: vi.fn() },
+  };
   player = new FakePlayer();
 });
 
@@ -140,6 +187,142 @@ afterEach(() => {
   expect(positionBreaches).toEqual([]);
 });
 
+const COMMAND_CASES: ReadonlyArray<{
+  method: string;
+  channel: string;
+  args: unknown[];
+  invoke: (iface: PlayerInterface) => void;
+}> = [
+  {
+    method: 'LoopStatus',
+    channel: 'player:setRepeat',
+    args: [1],
+    invoke: (iface) => { iface.LoopStatus = 'Track'; },
+  },
+  {
+    method: 'Shuffle',
+    channel: 'player:setShuffle',
+    args: [1],
+    invoke: (iface) => { iface.Shuffle = true; },
+  },
+  {
+    method: 'Volume',
+    channel: 'player:setVolume',
+    args: [0.42],
+    invoke: (iface) => { iface.Volume = 0.42; },
+  },
+  { method: 'Next', channel: 'player:next', args: [], invoke: (iface) => iface.Next() },
+  { method: 'Previous', channel: 'player:previous', args: [], invoke: (iface) => iface.Previous() },
+  { method: 'Pause', channel: 'player:pause', args: [], invoke: (iface) => iface.Pause() },
+  { method: 'PlayPause', channel: 'player:playPause', args: [], invoke: (iface) => iface.PlayPause() },
+  { method: 'Stop', channel: 'player:pause', args: [], invoke: (iface) => iface.Stop() },
+  { method: 'Play', channel: 'player:play', args: [], invoke: (iface) => iface.Play() },
+  { method: 'Seek', channel: 'player:seek', args: [2.5], invoke: (iface) => iface.Seek(2_500_000n) },
+  {
+    method: 'SetPosition',
+    channel: 'player:seek',
+    args: [7.25],
+    invoke: (iface) => {
+      player.emitNowPlaying({ trackId: 'track-1' });
+      iface.SetPosition('/org/sidra/track/track_1', 7_250_000n);
+    },
+  },
+];
+
+describe('MPRIS command provenance', () => {
+  it.each(COMMAND_CASES)('maps $method to $channel with its exact arguments', ({ method, channel, args, invoke }) => {
+    vi.useFakeTimers();
+    const iface = initPlayerInterface();
+
+    invoke(iface);
+
+    expect(win.webContents.send).toHaveBeenCalledOnce();
+    expect(win.webContents.send).toHaveBeenCalledWith(channel, ...args);
+    const commandLog = method === 'Volume' ? log.scope('mpris').debug : log.scope('mpris').info;
+    expect(commandLog).toHaveBeenCalledWith(
+      `source=mpris method=${method} channel=${channel} result=sent`,
+    );
+  });
+
+  it.each(COMMAND_CASES)('logs $method as dropped when no window exists', ({ method, channel, invoke }) => {
+    vi.useFakeTimers();
+    const iface = initInterfaces(() => null).player;
+
+    invoke(iface);
+
+    expect(win.webContents.send).not.toHaveBeenCalled();
+    expect(log.scope('mpris').info).toHaveBeenCalledWith(
+      `source=mpris method=${method} channel=${channel} result=dropped`,
+    );
+  });
+
+  it('logs method-only provenance for Raise and Quit', () => {
+    const { root } = initInterfaces();
+
+    root.Raise();
+    root.Quit();
+
+    expect(win.show).toHaveBeenCalledOnce();
+    expect(win.focus).toHaveBeenCalledOnce();
+    expect(app.quit).toHaveBeenCalledOnce();
+    expect(log.scope('mpris').info).toHaveBeenCalledWith('source=mpris method=Raise result=sent');
+    expect(log.scope('mpris').info).toHaveBeenCalledWith('source=mpris method=Quit result=sent');
+  });
+
+  it('logs Raise as dropped when no window exists', () => {
+    const { root } = initInterfaces(() => null);
+
+    root.Raise();
+
+    expect(win.show).not.toHaveBeenCalled();
+    expect(win.focus).not.toHaveBeenCalled();
+    expect(log.scope('mpris').info).toHaveBeenCalledWith('source=mpris method=Raise result=dropped');
+  });
+
+  it('logs a sent Volume burst at debug without per-value info records', () => {
+    vi.useFakeTimers();
+    const iface = initPlayerInterface();
+
+    iface.Volume = 0.2;
+    iface.Volume = 0.4;
+    iface.Volume = 0.6;
+
+    const provenance = 'source=mpris method=Volume channel=player:setVolume result=sent';
+    expect(win.webContents.send.mock.calls).toEqual([
+      ['player:setVolume', 0.2],
+      ['player:setVolume', 0.4],
+      ['player:setVolume', 0.6],
+    ]);
+    expect(log.scope('mpris').debug).toHaveBeenCalledTimes(3);
+    expect(log.scope('mpris').debug).toHaveBeenCalledWith(provenance);
+    expect(log.scope('mpris').info).not.toHaveBeenCalledWith(provenance);
+  });
+
+  it('does not log accepted or rejected SetPosition request data', () => {
+    const iface = initPlayerInterface();
+    const acceptedTrackId = 'private-track-accepted';
+    const rejectedTrackId = 'private-track-rejected';
+    player.emitNowPlaying({ trackId: acceptedTrackId });
+
+    iface.SetPosition('/org/sidra/track/private_track_accepted', 12_345_678n);
+
+    expect(win.webContents.send).toHaveBeenCalledWith('player:seek', 12.345678);
+    expect(mprisLogText()).toContain('source=mpris method=SetPosition channel=player:seek result=sent');
+    expect(mprisLogText()).not.toContain(acceptedTrackId);
+    expect(mprisLogText()).not.toContain('12345678');
+
+    vi.mocked(log.scope('mpris').info).mockClear();
+    win.webContents.send.mockClear();
+    iface.SetPosition(rejectedTrackId, 98_765_432n);
+
+    expect(win.webContents.send).not.toHaveBeenCalled();
+    expect(mprisLogText()).toContain('SetPosition trackId mismatch, ignoring');
+    expect(mprisLogText()).not.toContain('method=SetPosition');
+    expect(mprisLogText()).not.toContain(rejectedTrackId);
+    expect(mprisLogText()).not.toContain('98765432');
+  });
+});
+
 describe('MPRIS OpenUri', () => {
   it('advertises HTTPS URI support', () => {
     initPlayerInterface();
@@ -150,6 +333,7 @@ describe('MPRIS OpenUri', () => {
   it('loads a music.apple.com URI', () => {
     initPlayerInterface().OpenUri('https://music.apple.com/gb/album/foo');
     expect(win.loadURL).toHaveBeenCalledWith('https://music.apple.com/gb/album/foo');
+    expect(log.scope('mpris').info).toHaveBeenCalledWith('source=mpris method=OpenUri result=sent');
   });
 
   it('loads a classical.music.apple.com URI', () => {
@@ -180,6 +364,36 @@ describe('MPRIS OpenUri', () => {
     const playerIface = initPlayerInterface();
     expect(() => playerIface.OpenUri('not a url')).not.toThrow();
     expect(win.loadURL).not.toHaveBeenCalled();
+  });
+
+  it('does not log accepted or rejected URI request data', () => {
+    const iface = initPlayerInterface();
+    const acceptedUri = 'https://music.apple.com/gb/album/private?token=accepted-secret';
+    const rejectedUri = 'https://example.com/private?token=rejected-secret';
+
+    iface.OpenUri(acceptedUri);
+
+    expect(win.loadURL).toHaveBeenCalledWith(acceptedUri);
+    expect(mprisLogText()).toContain('source=mpris method=OpenUri result=sent');
+    expect(mprisLogText()).not.toContain(acceptedUri);
+    expect(mprisLogText()).not.toContain('accepted-secret');
+
+    vi.mocked(log.scope('mpris').info).mockClear();
+    win.loadURL.mockClear();
+    iface.OpenUri(rejectedUri);
+
+    expect(win.loadURL).not.toHaveBeenCalled();
+    expect(mprisLogText()).toContain('OpenUri rejected');
+    expect(mprisLogText()).not.toContain('method=OpenUri');
+    expect(mprisLogText()).not.toContain(rejectedUri);
+    expect(mprisLogText()).not.toContain('rejected-secret');
+  });
+
+  it('logs an accepted URI as dropped when no window exists', () => {
+    initInterfaces(() => null).player.OpenUri('https://music.apple.com/gb/album/foo');
+
+    expect(win.loadURL).not.toHaveBeenCalled();
+    expect(log.scope('mpris').info).toHaveBeenCalledWith('source=mpris method=OpenUri result=dropped');
   });
 });
 

--- a/test/wedgeDetector.test.ts
+++ b/test/wedgeDetector.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BrowserWindow } from 'electron';
+import type electronLog from 'electron-log/main';
 
 import { Player, PlaybackState } from '../src/player';
 import type { IntegrationContext } from '../src/player';
 
 type WedgeDetector = typeof import('../src/wedgeDetector');
+type ScopedLog = ReturnType<typeof electronLog.scope>;
 
 // Every listener and counter in the module is module-scoped, and init() now
 // refuses a second call, so a shared instance cannot be re-initialised between
@@ -17,8 +19,10 @@ async function loadWedgeDetector(): Promise<WedgeDetector> {
 describe('wedgeDetector', () => {
   let player: Player;
   let mockWin: { webContents: { send: ReturnType<typeof vi.fn> } };
+  let mainWindow: BrowserWindow | null;
   let getMainWindow: () => BrowserWindow | null;
   let wedgeDetector: WedgeDetector;
+  let wedgeLog: ScopedLog;
 
   beforeEach(async () => {
     vi.useFakeTimers();
@@ -28,11 +32,14 @@ describe('wedgeDetector', () => {
         send: vi.fn(),
       },
     };
-    getMainWindow = () => mockWin as unknown as BrowserWindow;
+    mainWindow = mockWin as unknown as BrowserWindow;
+    getMainWindow = () => mainWindow;
 
     wedgeDetector = await loadWedgeDetector();
+    wedgeLog = (await import('electron-log/main')).default.scope('wedge');
     const ctx: IntegrationContext = { player, getMainWindow };
     wedgeDetector.init(ctx);
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
@@ -60,6 +67,28 @@ describe('wedgeDetector', () => {
     vi.advanceTimersByTime(4000);
 
     expect(mockWin.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('logs sent command provenance when stalled playback is skipped', () => {
+    player.handlePlaybackStateDidChange({ status: true, state: PlaybackState.Playing });
+
+    vi.advanceTimersByTime(6000);
+
+    expect(wedgeLog.warn).toHaveBeenCalledWith(
+      'source=wedge channel=player:next reason=playback-stalled attempt=1/3 result=sent',
+    );
+  });
+
+  it('logs dropped command provenance when the main window is missing', () => {
+    mainWindow = null;
+    player.handlePlaybackStateDidChange({ status: true, state: PlaybackState.Playing });
+
+    vi.advanceTimersByTime(6000);
+
+    expect(mockWin.webContents.send).not.toHaveBeenCalled();
+    expect(wedgeLog.warn).toHaveBeenCalledWith(
+      'source=wedge channel=player:next reason=playback-stalled attempt=1/3 result=dropped',
+    );
   });
 
   it('does not fire skip when position advances', () => {


### PR DESCRIPTION
Add fixed, allow-listed process-health and command-provenance logs so field reports can distinguish renderer, MPRIS, and command-delivery conditions without recording user data. The logs support diagnosis of the playback stall without changing playback recovery behaviour.

Verified with `just test` (1,130 tests), `just lint`, both TypeScript checks, `git diff --check`, a security review, and a performance review. Live Electron process failures and real MPRIS commands were not tested.

Refs: #219
