### PR TITLE
fix: resolve playback lifecycle and metadata validation defects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    # update-electron-toolchain.yml updates these packages together.
     ignore:
       - dependency-name: electron
       - dependency-name: electron-builder

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -22,6 +22,7 @@ env:
     release/*.snap
     release/*.dmg
     release/*.exe
+    release/*.blockmap
     release/latest*.yml
 
 concurrency:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -53,10 +53,8 @@ jobs:
   lint-code:
     name: Lint Code 🧹
     needs: [version-gate]
-    # version-gate runs on tags only, so it is skipped on every other run, and
-    # always() is what lets this job proceed past that skip. lint-actions,
-    # test-config and test-code repeat this line because Actions cannot share
-    # an `if` between jobs. The build job has its own condition, below.
+    # always() permits a skipped version-gate on non-tag runs but the result
+    # check still blocks failures. Each dependent job needs its own condition.
     if: always() && (needs.version-gate.result == 'success' || needs.version-gate.result == 'skipped')
     runs-on: ubuntu-slim
     permissions:
@@ -112,8 +110,7 @@ jobs:
         run: node scripts/validate-build-config.cjs
         env:
           ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
-      # The audit gate covers registry dependencies that ship. A package that ships
-      # from devDependencies, as electron does, falls outside it.
+      # The audit excludes devDependencies, including the Electron runtime.
       - name: Audit dependencies
         run: npm audit --omit=dev
 
@@ -160,12 +157,8 @@ jobs:
     # EVS secrets exist only in release-evs, whose deployment policy admits
     # version tags. A pull request uses ci, which carries no EVS secrets.
     environment: ${{ startsWith(github.ref, 'refs/tags/') && 'release-evs' || 'ci' }}
-    # Every part of this is needed. Actions propagates the skipped version-gate
-    # down the needs graph, and the four jobs above override it with their own
-    # always(), so without always() here the skip reaches this job through them.
-    # The four success checks are needed alongside it, because always() also
-    # runs the job when a dependency failed. Do not delete this as redundant:
-    # someone did, and the whole build matrix was skipped and Sentinel failed.
+    # always() overrides the transitive skip from version-gate on non-tag runs.
+    # The success checks still block failed dependencies, which always() permits.
     if: >-
       always()
       && needs.lint-code.result == 'success'
@@ -176,14 +169,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # These flags decide the Linux targets, because a command-line target
-          # overrides the config. The list omits snap, which needs the separate
-          # root invocation below. Without these flags this step would build a
-          # snap unprivileged and the snap step would build it again.
-          # package.json build.linux.target is the fallback for a bare
-          # electron-builder run, which nothing here performs.
-          # `arch` names the artefact bundle and the cache key, so two Linux
-          # entries do not collide.
+          # CLI targets override build.linux.target in package.json. Exclude snap
+          # here because its separate root invocation would otherwise build it twice.
+          # `arch` separates the artefact bundles and caches for the Linux builds.
           - os: linux
             arch: amd64
             runner: ubuntu-24.04
@@ -232,12 +220,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y librsvg2-bin rpm
-      # The snap is mechanical packaging, unaffected by ordinary code changes,
-      # and its build is the longest step on the critical-path Linux leg. Skip
-      # it on pull requests; the weekly schedule and every tag build keep it
-      # covered, and publish-snap requires this job, so a broken snap still
-      # blocks a release rather than shipping. Both Linux entries build a snap;
-      # the Store holds one revision per arch.
+      # Skip the slow snap build on pull requests. Branch, weekly and tag runs
+      # check packaging, and publish-snap requires this build to pass.
+      # Each Linux architecture needs a separate Snap Store revision.
       - name: Install snapcraft
         if: matrix.os == 'linux' && github.event_name != 'pull_request'
         run: sudo snap install snapcraft --classic
@@ -374,10 +359,8 @@ jobs:
           # shellcheck disable=SC2016
           NIX_VERSION='${version}'
 
-          # The artifactName template in package.json decides these filenames and
-          # nothing in the repository restates it, so the published release is the
-          # only authority on them. Both the prefetch and the URL written into the
-          # Nix files come from the assets it lists.
+          # Read published filenames instead of duplicating package.json's
+          # artifactName template. Prefetch and Nix updates use the same asset URLs.
           assets=$(gh release view "${GITHUB_REF_NAME}" --json assets --jq '.assets')
 
           # Resolve one asset download URL, refusing zero matches or several.
@@ -392,16 +375,11 @@ jobs:
             printf '%s' "$urls"
           }
 
-          # Write the URL and its hash together, so the two can never disagree.
-          # The URL goes back version-templated, keeping the Nix files tied to
-          # package.json: a hash left stale then fails loudly instead of serving
-          # an older release under the new version number.
+          # Update each URL and hash together. Preserve ${version} in the URL so
+          # a stale hash fails instead of serving an older release as the new version.
           update_nix() {
             local file="$1" url="$2" hash="$3" key="${4:-}" nix_url range=""
-            # This is the only point at which the Nix files are written, so it
-            # is where a resolution that produced nothing has to stop. Do not
-            # rely on errexit alone to have caught that further up: a job that
-            # runs at release time only is checked by users, not by CI.
+            # Validate at the write boundary because callers can suppress errexit.
             if [[ -z "${url}" || "${hash}" != sha256-* ]]; then
               echo "::error::${file}: refusing to write url '${url}' and hash '${hash}'" >&2
               return 1
@@ -423,10 +401,8 @@ jobs:
             }
           }
 
-          # Two debs are built, one per arch, and nix/linux.nix holds a pair per
-          # system, so each is matched on its arch and written into its own block.
-          # The dmg is built for both arches and nix/darwin.nix covers
-          # aarch64-darwin alone, so that one is matched on its arch.
+          # Match each deb to its system block in nix/linux.nix.
+          # Both DMG architectures ship, but nix/darwin.nix packages only arm64.
           linux_amd64_url=$(asset_url 'linux-amd64\.deb$')
           linux_arm64_url=$(asset_url 'linux-arm64\.deb$')
           darwin_url=$(asset_url 'arm64\.dmg$')

--- a/.github/workflows/publish-snap-manual.yml
+++ b/.github/workflows/publish-snap-manual.yml
@@ -1,9 +1,6 @@
-# Manual snap publish - escape hatch for iterating on snap fixes without
-# cutting a full release. Do not delete. The tag-driven `publish-snap` job
-# in `builder.yml` is the normal path; this workflow exists for ad-hoc
-# pushes to the edge channel from a branch.
-# Runs on amd64 only: it is a debugging aid, not the release path, and one
-# arch is enough to exercise a snap fix. The tag build publishes both arches.
+# Publish branch builds to edge to test snap fixes without a full release.
+# This workflow checks amd64 only. The tag-driven publish-snap job in
+# builder.yml is the release path and publishes both architectures.
 name: Publish Snap (Manual) 📦
 
 on:

--- a/.github/workflows/update-electron-toolchain.yml
+++ b/.github/workflows/update-electron-toolchain.yml
@@ -32,11 +32,8 @@ jobs:
       - name: Update package metadata
         run: node scripts/update-electron-toolchain.cjs
       - name: Refresh lockfile
-        # Electron is named on its own first. A plain refresh keeps the commit a
-        # git dependency already resolved to, so a changed tag left package.json
-        # on the new release and package-lock.json on the old one, and every pull
-        # request this workflow opened carried the two disagreeing. The spec is
-        # read back from package.json, so the tag is written in one place only.
+        # Name Electron explicitly because a plain refresh retains its resolved
+        # Git commit. Read the spec from package.json to keep both files aligned.
         run: |
           npm install --package-lock-only --ignore-scripts \
             "electron@$(node -p "require('./package.json').devDependencies.electron")"
@@ -62,10 +59,8 @@ jobs:
           git fetch origin "$BRANCH:refs/remotes/origin/$BRANCH" || true
           git push --force-with-lease --set-upstream origin "$BRANCH"
 
-          # Matched on open pull requests only, and edited by number. "gh pr view
-          # <branch>" and "gh pr edit <branch>" both match a merged or closed pull
-          # request for the same branch, so once one merged, every later run edited
-          # that dead pull request and never opened a new one.
+          # Select an open pull request by number. Branch-based lookup can select
+          # a closed or merged pull request and prevent creation of a new one.
           pr_number="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
 
           if [ -n "$pr_number" ]; then

--- a/.github/workflows/update-electron-toolchain.yml
+++ b/.github/workflows/update-electron-toolchain.yml
@@ -39,6 +39,11 @@ jobs:
             "electron@$(node -p "require('./package.json').devDependencies.electron")"
           npm install --package-lock-only --ignore-scripts
       - name: Create pull request
+        # The default GITHUB_TOKEN creates this pull request. GitHub does not
+        # trigger workflow runs on pushes made with this token, and runs on the
+        # pull request need manual approval, so its checks stay pending until a
+        # maintainer approves them. If unattended checks become necessary, use
+        # a narrowly scoped GitHub App token instead.
         env:
           BRANCH: ci/update-electron-toolchain
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ result/
 release/
 *.log
 
-# Generated at build time by scripts/inject-lastfm-credentials.cjs - contains the
-# Last.fm API secret, must never be committed.
+# scripts/inject-lastfm-credentials.cjs generates this file at build time.
+# It contains the Last.fm API secret and must never be committed.
 assets/lastfm-credentials.json

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Sidra takes the opposite approach: wrap `music.apple.com` directly, stay out of 
 
 ## Features
 
-- 🎧 **Untouched audio** - no `AudioContext`, no DSP, no resampling; lossless on macOS and Windows via [CastLabs EVS production VMP signing](https://castlabs.com/security/widevine-certification/)
+- 🎧 **Untouched audio** - Sidra adds no `AudioContext`, DSP, or resampling of its own (Chromium and the OS can still resample); lossless on macOS and Windows via [CastLabs EVS production VMP signing](https://castlabs.com/security/widevine-certification/)
 - 🎨 **Eight bundled themes** - Catppuccin, Dracula, Everforest, Gruvbox, Nord, Rosé Pine, Solarized, and Tokyo Night - plus a live-reloading custom colour theme
 - 📊 **Last.fm scrobbling** - opt-in, with browser approval
 - 🎮 **Discord Rich Presence** - show what you are listening to

--- a/README.md
+++ b/README.md
@@ -360,6 +360,10 @@ Sign in on first launch; your session persists across relaunches. Run `just` wit
 Run `just generate-assets` to regenerate application icons, the logo, DMG backgrounds, tray icons and menu icons from SVG sources.
 The command also composes the README image from screenshots.
 
+### NixOS
+
+The dev shell puts the libraries CastLabs Electron needs on `LD_LIBRARY_PATH`, but the host must supply the ELF interpreter. The npm-installed Electron is a prebuilt binary that requests `/lib64/ld-linux-x86-64.so.2`, a path plain NixOS does not provide. Enable [nix-ld](https://github.com/nix-community/nix-ld) (`programs.nix-ld.enable = true;`) or an equivalent compatibility loader before running `just run`. Do not patch the Electron binary with `patchelf`: it is EVS-signed, and patching invalidates the signature.
+
 ### Widevine VMP signing
 
 Widevine enforces VMP (Verified Media Path) production signing on macOS and Windows - without it, Apple Music returns "Something went wrong" after login. CastLabs ECS ships with development keys; production signing requires a free [CastLabs EVS](https://github.com/castlabs/electron-releases/wiki/EVS) account.

--- a/assets/authFrameFix.js
+++ b/assets/authFrameFix.js
@@ -1,23 +1,13 @@
-// Apple's sign-in iframe offers passkey and "Sign in with iPhone" alongside
-// password sign-in, plus captions naming an iOS version requirement. This
-// hides them so password sign-in is the visible route.
-//
-// The script runs in the iframe's main world via executeJavaScript, so it must
-// be self-contained: nothing here can close over a main-process variable.
+// Hide passkey, "Sign in with iPhone" and iOS requirement captions to leave password sign-in visible.
+// executeJavaScript() runs this script in the iframe's main world, without access to main-process variables.
 (() => {
-  // Not standalone-executable JavaScript: loadAssets() in src/main.ts replaces
-  // this bare token with the stylesheet and the log prefix as JSON, because the
-  // script is injected with executeJavaScript() and cannot take the query
-  // parameters the splash screen uses. AUTH_FIX_TOKEN in src/authFrame.ts is
-  // the shared spelling, and test/authFrameFix.test.ts holds the two together.
+  // loadAssets() in src/main.ts replaces AUTH_FIX_TOKEN from src/authFrame.ts with JSON.
+  // executeJavaScript() cannot supply loadFile() query parameters, so the raw asset requires substitution.
   /** @type {{ css: string, containerSelectors: string[], logPrefix: string }} */
   var CONFIG = __SIDRA_AUTH_FIX__;
 
-  // PASSKEY_CONTAINER_SELECTORS in src/authFrame.ts, shared by the two jobs below:
-  // the stylesheet hides a match on sight, and closest() walks up to one from a
-  // matched button. The extras are script-only. A broad class prefix or a bare
-  // [role="group"] is safe for the walk, which starts at a button whose text
-  // named passkey or iPhone, and would hide unrelated form groups in the sheet.
+  // PASSKEY_CONTAINER_SELECTORS in src/authFrame.ts supplies CSS and ancestor matches.
+  // Broad selectors stay script-only: they start at a matched button, but CSS would hide unrelated form groups.
   const sharedContainers = CONFIG.containerSelectors;
   const SCRIPT_ONLY_CONTAINERS = ['[class*="passkey" i]', '[class*="iphone" i]', '[role="group"]', 'fieldset'];
 
@@ -48,9 +38,8 @@
   }
 
   function hideContainerFor(btn) {
-    // Prefer a structural container matched by class/role; fall back to a
-    // shallow parent walk (max 2 levels) whose textContent matches the
-    // caption regex. Strictly capped so we never collapse the whole form.
+    // Prefer a matching container. Limit the caption fallback to two parents
+    // to avoid hiding the whole form.
     const container = btn.closest(CONTAINER_SELECTOR);
     if (container && container !== document.body && container !== document.documentElement) {
       hideEl(container);
@@ -85,9 +74,8 @@
   }
 
   function hideCaptionElements() {
-    // Standalone caption scan: the helper text may sit outside any passkey
-    // container. Skip elements that wrap interactive controls so legitimate
-    // form rows survive.
+    // Captions can sit outside passkey containers. Keep elements that contain
+    // interactive controls so other form rows remain visible.
     let count = 0;
     const candidates = document.querySelectorAll(CAPTION_TAGS);
     for (const el of candidates) {
@@ -121,8 +109,8 @@
     }
   }
 
-  // console is the only channel out of a frame the main process has not
-  // preloaded; setupAuthFrameInjection() reads the line back off the prefix.
+  // Without a preload, the frame reports through console.
+  // setupAuthFrameInjection() recognises the log prefix.
   const cssRuleCount = css.split('}').length - 1;
   console.info(CONFIG.logPrefix + ' ' + cssRuleCount + ' CSS rules injected, ' + result.buttonsHidden + ' buttons hidden, ' + result.captionsHidden + ' captions hidden, ' + result.containersHidden + ' containers hidden');
 })();

--- a/assets/authStyleFix.css
+++ b/assets/authStyleFix.css
@@ -1,11 +1,6 @@
-/* Sign in with iPhone / passkey cross-device buttons in the Apple auth iframe.
-   Apple's auth UI obfuscates class names; use attribute selectors that survive
-   minor renaming. The fallback in assets/authFrameFix.js catches anything these
-   miss.
-
-   The container variants that group the cross-device option are not here. That
-   list is PASSKEY_CONTAINER_SELECTORS in src/main.ts, which the script shares
-   with its own ancestor search and appends to this sheet at injection time. */
+/* Hide iPhone and passkey buttons with attribute selectors that tolerate class
+   renaming. assets/authFrameFix.js also matches button text and appends the
+   PASSKEY_CONTAINER_SELECTORS from src/authFrame.ts, shared with its ancestor search. */
 button[data-component-name*="iphone" i],
 button[data-component-name*="cross-device" i],
 button[data-testid*="passkey" i],

--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -8,6 +8,16 @@
 
   const waitForMK = setInterval(() => {
     if (!window.MusicKit) return;
+    // MusicKit can be present while getInstance() still throws during its own
+    // initialisation. Resolve the instance before clearing the poll: a throw
+    // after the clear would end setup for the document lifetime, because
+    // __sidraHookInjected blocks re-injection.
+    let mk;
+    try {
+      mk = MusicKit.getInstance();
+    } catch (_) {
+      return;
+    }
     clearInterval(waitForMK);
 
     /** @type {number | null} Timer ID for the volume polling fallback. */
@@ -491,8 +501,6 @@
         console.error('[Sidra] failed to attach to the MusicKit instance', err);
       }
     }
-
-    const mk = MusicKit.getInstance();
 
     /**
      * Allowed commands dispatched via window.postMessage from the

--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -1,8 +1,6 @@
 (function () {
-  // This flag persists for the page lifetime and is never cleared. Re-injection
-  // must not re-run the IIFE: the 5-second monitor inside the hook already
-  // handles MusicKit instance replacement, and re-running would install a
-  // duplicate set of message and pointerover listeners.
+  // Keep this flag for the document lifetime to prevent duplicate message and pointerover listeners.
+  // The five-second monitor handles MusicKit instance replacement without re-injection.
   if (window.__sidraHookInjected) return;
   window.__sidraHookInjected = true;
   const injectedDocumentGeneration = __SIDRA_DOCUMENT_GENERATION__;
@@ -28,11 +26,8 @@
     /**
      * Send to the main process, tolerating an absent bridge.
      *
-     * window.AMWrapper is installed by the preload script. It is normally there
-     * before this runs, but the hook is injected into a page it does not
-     * control and cannot assume it. The eager volume send in attachVolume() is
-     * the most likely thrower, and every send goes through here so no path can
-     * throw on an absent bridge.
+     * The injected hook cannot assume that the preload bridge exists.
+     * Guard every send, including the initial volume report, against an absent bridge.
      *
      * @param {string} channel - IPC channel name
      * @param {unknown} [payload] - Channel payload
@@ -45,12 +40,8 @@
     }
 
     /**
-     * The media session to report position state on, or null when the page
-     * cannot take it.
-     *
-     * Resolved on every call rather than once: the hook is injected into a page
-     * it does not control, and Safari exposes navigator.mediaSession without
-     * setPositionState.
+     * Resolve the current media session only when it supports setPositionState.
+     * The injected hook cannot assume that the page provides this method.
      *
      * @returns {MediaSession | null} The usable media session, or null
      */
@@ -74,7 +65,7 @@
       try {
         sink.setPositionState();
       } catch (_) {
-        // Clearing is best effort; the caller has nothing else to try.
+        // A failed clear has no fallback.
       }
     }
 
@@ -90,11 +81,8 @@
     /**
      * Report explicit media session position state for OS media controls.
      *
-     * The playbackTimeDidChange listener calls this on every tick and must not
-     * debounce it: music.apple.com writes to the same MediaSession from the
-     * same world, and the repeated call keeps Sidra's value in place. It starts
-     * no debounce timer, so the project rule against debounced sends from that
-     * event still holds.
+     * Report on every playbackTimeDidChange event because Apple writes to the same MediaSession.
+     * Do not debounce these writes: continuous position events would keep postponing the update.
      *
      * @param {object} mk - The MusicKit.getInstance() singleton
      * @returns {void}
@@ -125,8 +113,7 @@
           position: Math.min(position, duration),
         });
       } catch (_) {
-        // A value Chromium rejects is not worth failing the listener over;
-        // the next playbackTimeDidChange tick reports again.
+        // Keep the listener active after rejection. The next playbackTimeDidChange event reports again.
       }
     }
 
@@ -172,7 +159,7 @@
 
       /**
        * Forward now-playing metadata to the main process.
-       * Sends null when no item is playing (e.g. queue cleared).
+       * Send null when the queue has no current item.
        * @param {{ item: object | null }} event - MusicKit nowPlayingItemDidChange event
        */
       function reportNowPlaying({ item }) {
@@ -204,9 +191,8 @@
             kind: pp.kind,
             isLibrary: pp.isLibrary,
           } : undefined,
-          // The document this item came from. The main process persists the
-          // active service separately and the two can disagree, so a share URL
-          // built from config can name a host the track was never on.
+          // Use the item's document host for sharing. The persisted service can
+          // change before the previous service's track metadata disappears.
           sourceHost: window.location.hostname,
         });
       }
@@ -314,18 +300,14 @@
       // Send the initial volume so MPRIS (and any other listener) receives the
       // real value immediately, not just on subsequent changes.
       sendToMain('volumeDidChange', lastVolume);
-      // playbackVolumeDidChange is the only volume event MusicKit publishes, so
-      // binding volumeDidChange leaves the listener dead. The IPC channel below
-      // keeps the volumeDidChange name, which is Sidra's own and deliberately
-      // unrelated to the MusicKit event name.
+      // MusicKit publishes playbackVolumeDidChange, not volumeDidChange.
+      // Sidra's separate IPC channel keeps the volumeDidChange name.
       mk.addEventListener('playbackVolumeDidChange', () => {
         lastVolume = mk.volume;
         sendToMain('volumeDidChange', mk.volume);
       });
-      // Poll mk.volume every 250ms as a fallback for a volume write the hook
-      // cannot observe through playbackVolumeDidChange. What the player bar
-      // volume control writes has never been confirmed, so this stays as the
-      // second of the only two paths reporting volume.
+      // Poll every 250 ms for volume changes that do not reach the listener.
+      // The player bar's write path is unknown, so both reporting paths are necessary.
       volumePollTimer = setInterval(() => {
         reportCapabilities();
         const v = mk.volume;
@@ -346,11 +328,8 @@
      * @returns {void}
      */
     function attachToInstance(mk) {
-      // The first statement, claimed before anything below can throw. The
-      // 5-second monitor re-attaches whenever this marker does not match the
-      // live instance, so a throw ahead of the assignment leaves it stale and
-      // the monitor adds a duplicate set of listeners on every cycle. A
-      // part-attached instance is the lesser fault, and attachSafely() logs it.
+      // Claim the instance before attachment can throw, or the monitor adds duplicate listeners on each cycle.
+      // attachSafely() logs partial attachment without retrying the same instance.
       window.__sidraHookedMk = mk;
 
       let generation = 0;
@@ -435,9 +414,8 @@
       /**
        * Control methods exposed to the preload script via window.postMessage.
        *
-       * The last assignment, so a throw in any call above leaves the hook
-       * object absent rather than half-built. The message listener indexes it
-       * defensively for that reason.
+       * Assign only after listener attachment succeeds. A failure leaves the previous
+       * hook object, or none on the first attachment, so the message listener checks it.
        *
        * @type {SidraHook}
        * @see {SidraHook} in src/types/hook.d.ts
@@ -500,11 +478,8 @@
     /**
      * Attach to an instance, containing any failure.
      *
-     * The marker is claimed inside attachToInstance() before it can throw, so
-     * the monitor will not retry a part-attached instance. Reporting the error
-     * is all that is left to do, and it must not propagate: the monitor's own
-     * catch would swallow it, and on the first call it would abort the rest of
-     * the hook, including the message and pointerover listeners below.
+     * attachToInstance() claims the marker first, so the monitor does not retry partial attachment.
+     * Log here because the monitor suppresses errors, and an initial failure must not prevent message and pointerover listener registration.
      *
      * @param {object} mk - The MusicKit.getInstance() singleton
      * @returns {void}
@@ -520,7 +495,7 @@
     const mk = MusicKit.getInstance();
 
     /**
-     * Allowed commands that may be dispatched via window.postMessage from the
+     * Allowed commands dispatched via window.postMessage from the
      * preload script. Must stay in sync with RECEIVE_CHANNELS in
      * src/preload.ts and keyof SidraHook in src/types/hook.d.ts.
      * @type {Set<string>}
@@ -546,10 +521,7 @@
         console.warn(`[Sidra] blocked unrecognised command: "${method}"`);
         return;
       }
-      // window.__sidra is the last thing attachToInstance() assigns, and this
-      // listener installs even when the attach threw before reaching it, so the
-      // hook object may be absent. An unguarded index would throw a TypeError
-      // straight back out of the path attachSafely() exists to contain.
+      // A failed initial attachment leaves no hook object, but this listener still runs.
       if (typeof window.__sidra?.[method] === 'function') {
         window.__sidra[method](...(args || []));
       }
@@ -557,10 +529,8 @@
     attachSafely(mk);
 
     /**
-     * Volume change applied per wheel notch. The step is fixed and never scaled
-     * by deltaY magnitude: Chromium reports a wheel and a touchpad identically
-     * as DOM_DELTA_PIXEL, so scaling gives a wheel a full-range jump and a
-     * touchpad an invisible nudge.
+     * Apply a fixed volume step per accumulated wheel notch. Both wheels and
+     * touchpads report DOM_DELTA_PIXEL, so per-event scaling gives inconsistent steps.
      */
     const VOLUME_STEP = 0.05;
     /** Chromium's default deltaY, in pixels, for one mouse wheel notch. */
@@ -573,12 +543,8 @@
     let wheelDelta = 0;
 
     /**
-     * Matches the player bar volume control by the class token both services
-     * put on it: a `div` on music.apple.com, an `amp-chrome-volume` element on
-     * classical.music.apple.com. It must stay a class-token selector and never
-     * an element name, which would work on Classical and silently do nothing on
-     * Apple Music. Never write a Svelte scope hash into it; those change on any
-     * Apple rebuild.
+     * Match the shared class on music.apple.com's div and Classical's amp-chrome-volume.
+     * Element names differ, and Svelte scope hashes change between Apple builds.
      */
     const VOLUME_SELECTOR = '.chrome-volume';
 
@@ -590,8 +556,8 @@
 
     /**
      * Change the volume when the wheel turns over the player bar volume
-     * control. Writing mk.volume reaches the main process by the existing
-     * playbackVolumeDidChange route, so nothing outside the hook changes.
+     * control. MusicKit's playbackVolumeDidChange event forwards mk.volume writes
+     * through Sidra's volumeDidChange IPC channel.
      *
      * @param {WheelEvent} event - The wheel event
      * @returns {void}
@@ -624,16 +590,10 @@
     }
 
     /**
-     * Point the wheel listener at the volume control, moving it off whichever
-     * control it was on before.
-     *
-     * The listener must never go on `window` or `document`: a non-passive wheel
-     * listener there marks the whole document a non-fast-scrollable region, so
-     * Chromium stops scrolling on the compositor thread and every wheel tick
-     * waits on a main thread Apple Music keeps busy. The cost comes from the
-     * listener existing, not from what it does, which is why it survived review
-     * while the handler itself stayed correct. On the control the region is
-     * that control's own box.
+     * Move the wheel listener from the previous volume control to the current one.
+     * A non-passive listener on window or document makes every scroll wait for
+     * Apple's busy main thread, even when the handler does not cancel the event.
+     * Binding only to the control limits that cost to its bounds.
      *
      * @param {Element} control - The volume control to bind
      * @returns {void}
@@ -650,14 +610,9 @@
     /**
      * Find the volume control and bind to it when the pointer reaches it.
      *
-     * The control does not exist when the hook runs and is replaced on
-     * navigation and service switches, so the binding is resolved lazily rather
-     * than once. `pointerover` is what resolves it: a wheel event over the
-     * control is always preceded by the pointer arriving there, and this
-     * listener is passive, so it costs scrolling nothing.
-     *
-     * A MutationObserver would answer the same question and is deliberately not
-     * used: one in this file previously cost 180 MiB/s.
+     * Navigation and service switches replace the control, so resolve it when the pointer arrives.
+     * A passive pointerover listener leaves compositor scrolling available and avoids
+     * the allocation cost of observing every DOM mutation.
      *
      * @param {PointerEvent} event - The pointerover event
      * @returns {void}
@@ -673,9 +628,7 @@
 
     console.log('[Sidra] MusicKit hooked successfully');
 
-    // Apple Music may re-create the MusicKit instance during a session, which
-    // raises no event, so the replacement is only visible by comparing the live
-    // instance against the marker.
+    // MusicKit instance replacement raises no event, so compare the live instance with the marker.
     setInterval(() => {
       try {
         const currentMk = MusicKit.getInstance();
@@ -685,7 +638,7 @@
           console.log('[Sidra] MusicKit re-hooked (instance replaced)');
         }
       } catch (_) {
-        // MusicKit.getInstance() may throw during re-initialisation; skip cycle
+        // Skip this cycle if MusicKit.getInstance() throws during re-initialisation.
       }
     }, 5000);
   }, 500);

--- a/assets/musicKitHook.js
+++ b/assets/musicKitHook.js
@@ -128,6 +128,24 @@
     }
 
     /**
+     * Wrap an instance-owned listener so events from a replaced instance are ignored.
+     *
+     * The monitor attaches to a replacement without detaching the old instance's
+     * listeners, and the old instance keeps emitting under the same document
+     * generation, so the main process cannot reject its events.
+     *
+     * @param {object} mk - The instance the listener is attached to
+     * @param {(...args: unknown[]) => void} listener - The instance-owned listener
+     * @returns {(...args: unknown[]) => void} The guarded listener
+     */
+    function whileHooked(mk, listener) {
+      return (...args) => {
+        if (window.__sidraHookedMk !== mk) return;
+        listener(...args);
+      };
+    }
+
+    /**
      * Register the playback listeners that forward state, metadata, position,
      * repeat and shuffle to the main process.
      *
@@ -165,7 +183,7 @@
         });
         reportCapabilities();
       }
-      mk.addEventListener('playbackStateDidChange', reportPlaybackState);
+      mk.addEventListener('playbackStateDidChange', whileHooked(mk, reportPlaybackState));
 
       /**
        * Forward now-playing metadata to the main process.
@@ -206,13 +224,13 @@
           sourceHost: window.location.hostname,
         });
       }
-      mk.addEventListener('nowPlayingItemDidChange', reportNowPlaying);
+      mk.addEventListener('nowPlayingItemDidChange', whileHooked(mk, reportNowPlaying));
 
       /**
        * Forward complete songs embedded in a radio station or archived show.
        * @param {object} metadata - MusicKit timedMetadataDidChange payload
        */
-      mk.addEventListener('timedMetadataDidChange', (metadata) => {
+      mk.addEventListener('timedMetadataDidChange', whileHooked(mk, (metadata) => {
         if (mk.nowPlayingItem?.attributes?.playParams?.kind !== 'radioStation') return;
 
         const title = typeof metadata?.title === 'string' ? metadata.title.trim() : '';
@@ -248,28 +266,28 @@
           trackId: catalogId ?? undefined,
           playParams: catalogId ? { catalogId, kind: 'song' } : undefined,
         });
-      });
+      }));
 
       /**
        * Forward playback position (in microseconds) to the main process and
        * refresh the media session position state.
        */
-      mk.addEventListener('playbackTimeDidChange', () => {
+      mk.addEventListener('playbackTimeDidChange', whileHooked(mk, () => {
         sendToMain('playbackTimeDidChange',
           mk.currentPlaybackTime * 1_000_000
         );
         reportPositionState(mk);
-      });
+      }));
 
       /** Forward repeat mode changes to the main process. */
-      mk.addEventListener('repeatModeDidChange', () => {
+      mk.addEventListener('repeatModeDidChange', whileHooked(mk, () => {
         sendToMain('repeatModeDidChange', mk.repeatMode);
-      });
+      }));
 
       /** Forward shuffle mode changes to the main process. */
-      mk.addEventListener('shuffleModeDidChange', () => {
+      mk.addEventListener('shuffleModeDidChange', whileHooked(mk, () => {
         sendToMain('shuffleModeDidChange', mk.shuffleMode);
-      });
+      }));
       reportNowPlaying({ item: mk.nowPlayingItem ?? null });
       reportPlaybackState({ state: mk.playbackState ?? (mk.isPlaying ? MusicKit.PlaybackStates.playing : 0) });
       sendToMain('playbackTimeDidChange', mk.currentPlaybackTime * 1_000_000);
@@ -312,10 +330,10 @@
       sendToMain('volumeDidChange', lastVolume);
       // MusicKit publishes playbackVolumeDidChange, not volumeDidChange.
       // Sidra's separate IPC channel keeps the volumeDidChange name.
-      mk.addEventListener('playbackVolumeDidChange', () => {
+      mk.addEventListener('playbackVolumeDidChange', whileHooked(mk, () => {
         lastVolume = mk.volume;
         sendToMain('volumeDidChange', mk.volume);
-      });
+      }));
       // Poll every 250 ms for volume changes that do not reach the listener.
       // The player bar's write path is unknown, so both reporting paths are necessary.
       volumePollTimer = setInterval(() => {

--- a/assets/navigationBar.js
+++ b/assets/navigationBar.js
@@ -1,14 +1,10 @@
-// Back, forward and reload buttons for the Apple Music sidebar header. The web
-// UI has no need for them; a desktop window with no browser chrome does.
+// Add navigation and Settings buttons to the sidebar because Sidra has no browser toolbar.
 (function () {
-  // The script runs on every page load and on SPA navigation, which can keep
-  // the existing header, so bail out rather than add a second set of buttons.
+  // SPA navigation can retain the header, so repeated injection must not duplicate buttons.
   if (document.getElementById('sidra-nav-buttons')) return;
 
-  // Not standalone-executable JavaScript: loadAssets() in src/main.ts replaces
-  // this bare token with the translated labels as JSON, because the script is
-  // injected with executeJavaScript() and cannot take the query parameters the
-  // splash screen uses. NAV_LABELS_TOKEN in src/i18n.ts is the shared spelling.
+  // loadAssets() in src/main.ts replaces NAV_LABELS_TOKEN from src/i18n.ts with JSON.
+  // executeJavaScript() cannot supply loadFile() query parameters, so the raw asset requires substitution.
   /** @type {{ back: string, forward: string, reload: string, settings: string }} */
   var LABELS = __SIDRA_NAV_LABELS__;
 
@@ -42,11 +38,8 @@
   /**
    * Send to the main process, tolerating an absent bridge.
    *
-   * window.AMWrapper is installed by the preload script. It is normally there
-   * before this runs, but the script is injected into a page it does not
-   * control and cannot assume it. sendToMain() in assets/musicKitHook.js guards
-   * the same bridge for the same reason; an unguarded send here would throw a
-   * TypeError out of a click listener with no catch above it.
+   * The injected script cannot assume that the preload bridge exists.
+   * Guard it as assets/musicKitHook.js does, so clicks cannot throw for an absent bridge.
    *
    * @param {string} channel - IPC channel name
    * @returns {void}
@@ -62,7 +55,7 @@
 
   /**
    * Create an SVG element with the given tag and attributes.
-   * @param {string} tag - SVG element tag name (e.g. 'svg', 'polyline', 'path')
+   * @param {string} tag - SVG element tag name
    * @param {Record<string, string>} attrs - Attribute key-value pairs
    * @returns {SVGElement}
    */
@@ -90,7 +83,7 @@
     'stroke-linejoin': 'round',
   };
 
-  // Icon geometry only; the wrapping svg carries sharedAttrs.
+  // Each icon defines geometry only. Its parent SVG carries sharedAttrs.
   /** @type {Array<{ label: string, channel: string, icon: Array<[string, Record<string, string>]> }>} */
   var BUTTONS = [
     { label: LABELS.back, channel: 'nav:back', icon: [['polyline', { points: '15 20 9 12 15 4' }]] },
@@ -118,9 +111,8 @@
   ];
 
   /**
-   * Paint a button and its icon. The base styles are inline and !important, so a
-   * :hover rule in an injected stylesheet could never beat them; hover has to be
-   * written from JavaScript.
+   * Paint a button and its icon. Inline !important styles override stylesheet
+   * :hover rules, so JavaScript must update the hover styles.
    *
    * @param {HTMLButtonElement} button - Button to paint
    * @param {string} color - Colour for the button and the icon stroke

--- a/assets/settings.js
+++ b/assets/settings.js
@@ -1,3 +1,4 @@
+// Render settings from the isolated preload bridge and serialise user changes.
 (() => {
   'use strict';
 
@@ -12,6 +13,7 @@
   const selects = ['musicService', 'startPage', 'theme', 'zoomFactor'];
   const toggles = ['closeToTray', 'notifications', 'discord', 'lastfmEnabled'];
   let state;
+  // Pushed state supersedes pending replies from getState() and apply().
   let revision = 0;
   let closed = false;
   let queue = Promise.resolve();
@@ -85,6 +87,7 @@
   for (const key of selects) {
     byId(key).addEventListener('change', () => {
       const action = { type: key, value: key === 'zoomFactor' ? Number(byId(key).value) : byId(key).value };
+      // Keep the selection tied to the displayed service while earlier actions wait.
       if (key === 'startPage') action.serviceId = state.musicService;
       apply(action);
     });

--- a/assets/styleFix.css
+++ b/assets/styleFix.css
@@ -1,12 +1,12 @@
 
-  /* "Open in Music" CTA — hide just the button and its container, not the wrapper */
+  /* Hide the "Open in Music" button and container, but keep the shared wrapper. */
   [data-testid="native-cta"],
   [data-testid="native-cta-button"],
   [class*="native-upsell"] {
     display: none !important;
   }
 
-  /* Re-expose the user profile row (Apple nests account-menu inside the same wrapper as the CTA) */
+  /* Keep the account menu visible inside the shared "Open in Music" wrapper. */
   #navigation > div.navigation__native-cta {
     display: block !important;
   }

--- a/build/afterPack.cjs
+++ b/build/afterPack.cjs
@@ -1,16 +1,15 @@
 'use strict';
 
 /**
- * afterPack hook: signs the packaged app with CastLabs EVS production VMP keys.
- * electron-builder runs it from the "build.afterPack" key in package.json.
+ * Sign macOS and Windows packages with CastLabs EVS production VMP keys.
+ * package.json registers this hook through build.afterPack.
  *
- * VMP signing must happen BEFORE macOS code-signing, which is why this is an
- * afterPack hook and not afterSign. Without production VMP keys, Widevine
- * refuses DRM licences on macOS.
- * Linux does not enforce VMP so this hook is a no-op there.
+ * VMP signing must precede macOS code-signing, so this uses afterPack, not
+ * afterSign. Without production VMP keys, Widevine refuses DRM licences on
+ * macOS. Linux does not enforce VMP and needs no signing here.
  *
  * Local builds skip signing when both EVS credentials are absent. Tag builds
- * require both credentials, so an unsigned release cannot be published.
+ * require both credentials, so these packages cannot ship without VMP signing.
  *
  * Setup: read EVS_PACKAGE from build/evs.cjs, then run
  *        uvx --from <package> evs-account signup

--- a/build/evs.cjs
+++ b/build/evs.cjs
@@ -1,5 +1,6 @@
 'use strict';
 
+/** Shared EVS version for local Electron signing and the afterPack hook. */
 const EVS_PACKAGE = 'castlabs-evs==1.3.2';
 
 module.exports = { EVS_PACKAGE };

--- a/docs/LASTFM-PRIVACY.md
+++ b/docs/LASTFM-PRIVACY.md
@@ -16,13 +16,13 @@ For each track, Sidra sends:
 - Track length (when the player reports one)
 - The time playback started (with a scrobble only)
 
-A now-playing update goes out when a track starts or resumes, and a scrobble once the track has played far enough to qualify. Nothing else about your listening is sent. Nothing at all is sent while the feature is off or no account is connected.
+A now-playing update goes out when a track starts or resumes, and a scrobble once the track has played far enough to qualify. When the track came from a radio station, the scrobble also carries a flag telling Last.fm that the station chose it rather than you. Nothing else about your listening is sent. Nothing at all is sent while the feature is off or no account is connected.
 
 ## What is stored on your machine
 
 Connecting stores a Last.fm session key and your Last.fm username in Sidra's configuration file (`config.json` in Sidra's user data directory), in plain text. The session key authorises scrobbling to your account. It goes nowhere except Last.fm.
 
-When a scrobble cannot reach Last.fm, because the connection dropped for example, the same file holds that play until the next request carries it out. Each held play is a track title, artist name and the time playback started, plus the album name and track length when the player reported them. At most 50 are held, and the oldest goes once that is full.
+When a scrobble cannot reach Last.fm, because the connection dropped for example, the same file holds that play until the next request carries it out. Each held play is a track title, artist name and the time playback started, plus the album name and track length when the player reported them. A play from a radio station also keeps the flag saying the station chose it. At most 50 are held, and the oldest goes once that is full.
 
 ## Turning it off and revoking access
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -25,6 +25,7 @@ The codebase is tightly focused and as lean as possible. Five runtime dependenci
 - [Discord Rich Presence](#discord-rich-presence)
 - [Last.fm Scrobbling](#lastfm-scrobbling)
 - [Track Change Notifications](#track-change-notifications)
+- [Settings Window](#settings-window)
 - [Tray](#tray)
 - [macOS Dock](#macos-dock)
 - [Windows Taskbar](#windows-taskbar)
@@ -384,6 +385,17 @@ Injected into `music.apple.com` and `classical.music.apple.com` after page load 
   window.__sidraHookInjected = true;
 
   function attachToInstance(mk) {
+    // Per-instance marker, read by the 5-second monitor below. It is not an
+    // injection guard: __sidraHookInjected is. The assignment is the first
+    // statement, before anything that can throw. A marker assigned last went
+    // stale on a throw, so the monitor re-attached on every cycle and added
+    // a duplicate set of listeners each time.
+    window.__sidraHookedMk = mk;
+
+    // Then, in this order: stopVolumePoll(), attachPlaybackListeners(mk),
+    // attachVolume(mk). The stop runs first so a throw in either attach
+    // cannot leave a second timer polling the replaced instance.
+
     // Event listeners: playbackStateDidChange, nowPlayingItemDidChange,
     // playbackTimeDidChange (forwards the position, then calls
     // reportPositionState()), repeatModeDidChange, shuffleModeDidChange,
@@ -400,24 +412,30 @@ Injected into `music.apple.com` and `classical.music.apple.com` after page load 
     // Volume polling: stores lastVolume, sends initial volume on attach,
     // polls mk.volume at 250ms intervals, sends IPC only on change
 
-    // window.__sidra control object:
-    //   play, pause, playPause, next, previous, seek,
-    //   setVolume, setRepeat, setShuffle
+    // window.__sidra control object, assigned last:
+    //   play, pause, stop, playPause, next, previous, openUri,
+    //   seek, setVolume, setRepeat, setShuffle
+  }
 
-    // Per-instance marker, read by the 5-second monitor below.
-    // This is not an injection guard: __sidraHookInjected is.
-    window.__sidraHookedMk = mk;
+  // Contains an attachment failure and logs it. The monitor's own catch
+  // would swallow the error silently, and a throw on the first call must
+  // not abort the message and pointerover listeners below.
+  function attachSafely(mk) {
+    try { attachToInstance(mk); } catch (err) { console.error(/* ... */); }
   }
 
   const waitForMK = setInterval(() => {
     if (!window.MusicKit) return;
     clearInterval(waitForMK);
-    attachToInstance(MusicKit.getInstance());
 
     // sidra:command message listener for preload bridge:
     //   window.addEventListener('message', ...) dispatches
     //   incoming { type: 'sidra:command', channel, args } messages
-    //   to the matching window.__sidra method via a COMMANDS allowlist
+    //   to the matching window.__sidra method via a COMMANDS allowlist.
+    //   It indexes window.__sidra?.[method], because a failed attach
+    //   leaves no hook object while the listener still runs.
+
+    attachSafely(MusicKit.getInstance());
 
     // A passive pointerover listener on window resolves the current volume
     // control with target.closest('.chrome-volume'). bindVolumeWheel() removes
@@ -425,7 +443,8 @@ Injected into `music.apple.com` and `classical.music.apple.com` after page load 
     // to the current control. The handler steps the live instance volume by 5%.
 
     // 5-second monitor: compares MusicKit.getInstance() against
-    // window.__sidraHookedMk and re-attaches when the singleton is replaced.
+    // window.__sidraHookedMk and calls attachSafely() when the singleton
+    // is replaced.
     setInterval(() => { /* ... */ }, 5000);
   }, 500);
 })();
@@ -585,17 +604,24 @@ Missing song fields clear the previous song's fields. A missing song URL falls b
 
 ## Volume Sync
 
-Cider's MPRIS volume sync is one-directional (MPRIS to MusicKit only, no reliable MusicKit to MPRIS), with a feedback loop on `volumeDidChange`. Sidra fixes this with a suppression flag pattern:
+Cider's MPRIS volume sync is one-directional (MPRIS to MusicKit only, no reliable MusicKit to MPRIS), with a feedback loop on `volumeDidChange`. Sidra fixes this with an ordered queue of pending echoes:
 
 ```
-MPRIS sets volume
-  → executeJavaScript sets mk.volume
-    → mk fires playbackVolumeDidChange
-      → IPC sends volume back to main
-        → suppression flag swallows the echo
+MPRIS sets Volume
+  → typed player:setVolume command reaches the preload
+    → window.postMessage() bridges it to the hook, which sets mk.volume
+      → mk fires playbackVolumeDidChange
+        → IPC sends the volume back to main
+          → the pending-echo queue swallows the echo
 ```
 
-The matching echo clears the flag. A 2000ms safety timeout (`_volumeSafetyMs` in `src/integrations/mpris/index.ts`) clears it when no echo arrives, so a lost echo cannot suppress volume updates for the rest of the session. The epsilon comparison (0.01) absorbs floating-point rounding without masking genuine user-initiated changes.
+The `set Volume` accessor in `src/integrations/mpris/index.ts` clamps and rounds the value, schedules its own `Volume` property emission, pushes the value onto `_pendingVolumes` and sends the command. Without the emission, only the client that made the change would know the new value.
+
+`updateVolume()` matches an incoming value against every pending entry within `VOLUME_ECHO_TOLERANCE` (0.01, absorbing floating-point rounding), then discards the matched entry and every older one: echoes arrive in order, so an overtaken set left in the queue would suppress a later in-app change. An unmatched value is an in-app change and is published.
+
+The queue is bounded by `MAX_PENDING_VOLUMES` (8). A full queue drops the value being added, never the oldest entry. The oldest entry is the one the next echo matches, so evicting it would make that echo read as an in-app change and pull the cached volume back behind the level the player reached - the same fault a single pending slot had, where a 0.5, 0.6, 0.7 drag burst left the cached volume one echo behind. An untracked newest value is harmless: its echo matches nothing and writes the level the player actually reached.
+
+A 2000ms safety timeout (`_volumeSafetyMs`) drops the whole queue when no echo arrives, so a missed echo cannot suppress volume updates for the rest of the session.
 
 **PulseAudio sink input volume is intentionally not synced.** MPRIS `Volume` controls MusicKit's software volume (`HTMLMediaElement.volume`) only. The PulseAudio/PipeWire sink input volume shown in pulsemixer and pavucontrol is independent and left to the user via their system mixer. This matches the behaviour of Rhythmbox, Spotify, VLC, mpv, and Clementine. Syncing both would cause double-volume multiplication (e.g. 0.5 × 0.5 = 0.25, −12 dB instead of the expected −6 dB) and would require a `libpulse` binding or fragile `pactl` subprocess calls.
 
@@ -681,7 +707,7 @@ Sidra loads two Apple web apps from one shell. `src/musicService.ts` holds the r
 
 `defineService()` infers the page id union from `startPages` alone and wraps `defaultStartPage` in `NoInfer`, so a typo there fails to compile instead of widening the union.
 
-Accessors: `isMusicServiceId()`, `getService()`, `getServiceByHost()` and `allServices()`. `getService()` is total at runtime as well as in the type: `?? MUSIC_SERVICES[DEFAULT_SERVICE_ID]` catches an unknown id. Every call runs while the tray menu is built, and the tray is the app's only settings surface.
+Accessors: `isMusicServiceId()`, `getService()`, `getServiceByHost()` and `allServices()`. `getService()` is total at runtime as well as in the type: `?? MUSIC_SERVICES[DEFAULT_SERVICE_ID]` catches an unknown id. Every call runs while the tray menu and the Settings state are built, the app's two settings surfaces.
 
 ### The two services
 
@@ -989,6 +1015,26 @@ Notifications are toggleable via an `electron-conf` boolean setting (default: on
 
 ---
 
+## Settings Window
+
+Sidra has two settings surfaces: the tray menu and a Settings window. `src/settingsWindow.ts` owns the window. `src/settings.ts` owns the state and the validated `SettingsAction` union that Settings and the tray controls share.
+
+The window is a local `BrowserWindow` that loads `assets/settings.html` over `file:` with `contextIsolation: true`, `nodeIntegration: false`, `sandbox: true` and its own preload, `src/settingsPreload.ts`. It opens from the gear button beside Back, Forward and Reload, and from Ctrl+, (Cmd+, on macOS), captured by a `before-input-event` listener on the main window. `will-navigate`, `will-frame-navigate` and `will-redirect` are all prevented, and `setWindowOpenHandler` denies every new window.
+
+### Private IPC
+
+Three channels are private to the Settings preload and appear on no other allowlist: `settings:get` and `settings:apply` (invoked from the renderer) and `settings:state` (pushed from main). The preload exposes them as `window.sidraSettings` with `getState()`, `apply(action)` and `onState(listener)`, checked against the `SettingsBridge` interface with `satisfies`.
+
+### Sender checks
+
+`validateSender()` guards both invoke handlers. It rejects a request unless the sender is the live Settings `webContents`, the sending frame is its main frame, and both the frame URL and `getURL()` equal the exact URL the window was created with. `handleSettingsNavigation()` opens the window only for a main-frame request from the main window's `webContents` whose document URL passes `isAllowedNavigationUrl()`.
+
+### State and actions
+
+`getSettingsState()` resolves the stored configuration, the available options and the translated labels into one `SettingsState`. `applySettingsAction()` validates each incoming action against that state, so an option that is not offered is rejected, then applies it, refreshes the tray and pushes the new state to subscribers. The tray and an open Settings window therefore stay in step. The window receives the active theme CSS through `insertCSS` and refreshes it on every state change.
+
+---
+
 ## Tray
 
 `src/tray.ts` manages the system tray icon and context menu. The menu is built from localised strings (`assets/locales/tray.json`) and rebuilds itself on state changes.
@@ -1197,7 +1243,7 @@ electron-updater manifest filenames are hardcoded and cannot be changed:
 | MPRIS (Linux) | `dbus-next` D-Bus service | `org.mpris.MediaPlayer2.sidra` |
 | MPRIS primitives | play/pause/next/prev/seek/stop/OpenUri | Typed IPC with capability updates, bounded seeking and ordered Stop |
 | MPRIS metadata | title/artist/album/artwork/duration/trackId | Queue-item metadata, effective duration and timed radio songs |
-| MPRIS volume | Two-way with suppression flag | musicKitHook.js + main MPRIS plugin |
+| MPRIS volume | Two-way with pending-echo queue | musicKitHook.js + main MPRIS plugin |
 | MPRIS repeat/shuffle | Two-way | `repeatModeDidChange` + `shuffleModeDidChange` |
 | Discord Rich Presence | `@xhayper/discord-rpc` | With debounce + pause timeout + retry |
 | Track change notifications | D-Bus on Linux, Electron `Notification` elsewhere | Tracks and radio songs, artwork, replacement, and Play/Pause/Previous/Next controls where supported |
@@ -1235,7 +1281,7 @@ electron-updater manifest filenames are hardcoded and cannot be changed:
 | Artwork cache | `src/artwork.ts` | UUID-based filenames, 7-day expiry, atomic writes |
 | Pause timer utility | `src/pauseTimer.ts` | `createPauseTimer()` shared by tray, dock, Discord |
 | Update checking (non-auto-update) | `src/update.ts` | GitHub API check for deb/rpm/Nix/DMG platforms |
-| Service worker cache clearing | `session.defaultSession.clearStorageData` | Clears on startup to prevent stale assets |
+| Service worker cache clearing | `clearData()` on the `persist:sidra` partition in `initSession()` | Clears service workers and cache for the service origins on startup |
 | Last.fm scrobbling | `src/integrations/lastfm` + Last.fm API 2.0 | Opt-in; browser auth from the tray, per-user session key in `electron-conf` |
 | Controller navigation | Gamepad API in `preload.ts` + `controllerIPC.ts` | Standard mapping; D-pad, Select, and guarded Back in both services |
 

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,7 @@
                 optipng # PNG optimisation for tray menu icons
                 nodejs # Node.js for npm and TypeScript builds
                 playwrightMcpChromium
+                python3Minimal # asset generation scripts (app icons, tray outline, README image)
               ]
               ++ lib.optionals stdenv.hostPlatform.isDarwin [
                 uv # required for EVS VMP signing via uvx

--- a/flake.nix
+++ b/flake.nix
@@ -94,17 +94,17 @@
                 nodejs # Node.js for npm and TypeScript builds
                 playwrightMcpChromium
               ]
-              ++ lib.optionals stdenv.isDarwin [
+              ++ lib.optionals stdenv.hostPlatform.isDarwin [
                 uv # required for EVS VMP signing via uvx
               ]
-              ++ lib.optionals stdenv.isLinux [
+              ++ lib.optionals stdenv.hostPlatform.isLinux [
                 gsettings-desktop-schemas
               ];
 
             # CastLabs Electron (installed via npm) is a prebuilt binary that
             # expects libraries in standard FHS paths. On NixOS we must set
             # LD_LIBRARY_PATH explicitly for the libraries it links against.
-            LD_LIBRARY_PATH = pkgs.lib.optionalString pkgs.stdenv.isLinux (
+            LD_LIBRARY_PATH = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
               with pkgs; lib.makeLibraryPath [
                 alsa-lib
                 at-spi2-atk
@@ -135,7 +135,7 @@
             );
 
             # Use the NixOS system GPU drivers without pinning a GPU vendor.
-            shellHook = (pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+            shellHook = (pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
               if [ -d "/run/opengl-driver/lib" ]; then
                 if [ -z "$LD_LIBRARY_PATH" ]; then
                   export LD_LIBRARY_PATH="/run/opengl-driver/lib"

--- a/flake.nix
+++ b/flake.nix
@@ -49,13 +49,10 @@
         system:
         let
           pkgs = import nixpkgs { inherit system; };
-          # Sidra uses Chromium only, so the Playwright MCP server ships
-          # Chromium only. The stock package wraps PLAYWRIGHT_BROWSERS_PATH
-          # with Chromium, the headless shell, Firefox, and WebKit (2.5 GB).
-          # Swapping the browser set in both the driver and playwright-test
-          # cuts the closure to 0.9 GB. The headless shell is not needed: the
-          # wrapper defaults PLAYWRIGHT_MCP_BROWSER to the chromium channel,
-          # which launches the full Chrome for Testing even in headless mode.
+          # Sidra needs only Chromium. Override both browser references to exclude
+          # Firefox, WebKit and the headless shell from the dependency closure.
+          # PLAYWRIGHT_MCP_BROWSER defaults to the chromium channel, which uses
+          # full Chrome for Testing even in headless mode.
           playwrightMcpChromium =
             let
               browsers = pkgs.playwright-driver.browsers-chromium;
@@ -94,7 +91,7 @@
                 just
                 librsvg # rsvg-convert for tray menu icon generation
                 optipng # PNG optimisation for tray menu icons
-                nodejs # 24.x Active LTS, matches Electron 40's bundled Node
+                nodejs # Node.js for npm and TypeScript builds
                 playwrightMcpChromium
               ]
               ++ lib.optionals stdenv.isDarwin [
@@ -137,9 +134,7 @@
               ]
             );
 
-            # GPU drivers: use NixOS system drivers from /run/opengl-driver/lib
-            # This works across GPU vendors (Intel, AMD, NVIDIA) without listing
-            # individual driver packages. Same pattern as jivefire.
+            # Use the NixOS system GPU drivers without pinning a GPU vendor.
             shellHook = (pkgs.lib.optionalString pkgs.stdenv.isLinux ''
               if [ -d "/run/opengl-driver/lib" ]; then
                 if [ -z "$LD_LIBRARY_PATH" ]; then

--- a/justfile
+++ b/justfile
@@ -22,19 +22,15 @@ _fix-frameworks:
         if [ -d "$fw/Versions/A" ] && [ ! -L "$fw/Versions/Current" ]; then
             ln -sf A "$fw/Versions/Current"
             name=$(basename "$fw" .framework)
-            # Symlink the main binary
             if [ -e "$fw/Versions/A/$name" ] && [ ! -L "$fw/$name" ]; then
                 ln -sf "Versions/Current/$name" "$fw/$name"
             fi
-            # Symlink Resources if present
             if [ -d "$fw/Versions/A/Resources" ] && [ ! -L "$fw/Resources" ]; then
                 ln -sf "Versions/Current/Resources" "$fw/Resources"
             fi
-            # Symlink Libraries if present
             if [ -d "$fw/Versions/A/Libraries" ] && [ ! -L "$fw/Libraries" ]; then
                 ln -sf "Versions/Current/Libraries" "$fw/Libraries"
             fi
-            # Symlink Helpers if present
             if [ -d "$fw/Versions/A/Helpers" ] && [ ! -L "$fw/Helpers" ]; then
                 ln -sf "Versions/Current/Helpers" "$fw/Helpers"
             fi
@@ -270,13 +266,11 @@ release VERSION:
         exit 1
     fi
 
-    # Check if tag already exists
     if git rev-parse --verify --quiet "refs/tags/$version" >/dev/null; then
         echo "Error: Tag $version already exists" >&2
         exit 1
     fi
 
-    # Bump package.json version if needed
     current_version=$(node -p "require('./package.json').version")
     if [[ "$current_version" != "$version" ]]; then
         npm version "$version" --no-git-tag-version

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -11,8 +11,8 @@ stdenvNoCC.mkDerivation {
   pname = "sidra";
   inherit version;
 
-  # The url and hash below are rewritten together by the nix-hash CI job, which
-  # reads the filename off the published release. Do not edit them by hand.
+  # The nix-hash CI job updates the URL and hash together from the published asset.
+  # Do not edit this pair by hand.
   src = fetchurl {
     url = "https://github.com/wimpysworld/sidra/releases/download/${version}/Sidra-${version}-mac-arm64.dmg";
     hash = "sha256-j17zj7G2eO1RVyFDW2dSsssfnBeHUXBVABtZByP4qxA=";

--- a/nix/linux.nix
+++ b/nix/linux.nix
@@ -50,10 +50,8 @@
 let
   pname = "sidra";
 
-  # Both pairs below are rewritten together by the nix-hash CI job, which
-  # reads the filename off the published release. Do not edit them by hand.
-  # aarch64-linux carries the fake hash until the first arm64 deb is released;
-  # the job replaces it then, and `nix build` on aarch64-linux fails before that.
+  # The nix-hash CI job updates each URL and hash together from published assets.
+  # Do not edit these pairs by hand.
   sources = {
     x86_64-linux = {
       url = "https://github.com/wimpysworld/sidra/releases/download/${version}/Sidra-${version}-linux-amd64.deb";

--- a/scripts/generate-readme-image.py
+++ b/scripts/generate-readme-image.py
@@ -20,6 +20,7 @@ for tool in ("rsvg-convert", "optipng"):
     if shutil.which(tool) is None:
         raise SystemExit(f"Required tool not found: {tool}")
 
+# The SVG renders at twice its viewBox size, so half-size layers retain native pixels.
 layers = []
 for name, x, y, width, height in screenshots:
     data = (root / "assets/source" / name).read_bytes()

--- a/scripts/generate-tray-outline.py
+++ b/scripts/generate-tray-outline.py
@@ -13,6 +13,7 @@ outline = ET.Element(symbol.tag, symbol.attrib)
 definitions = ET.SubElement(outline, f"{{{namespace}}}defs")
 geometry = ET.SubElement(definitions, f"{{{namespace}}}g", id="tray-symbol")
 geometry.extend(symbol)
+# A white copy covers the inner half of the dark stroke, leaving an outer border.
 ET.SubElement(outline, f"{{{namespace}}}use", {
     "href": "#tray-symbol",
     "fill": "#202124",

--- a/scripts/inject-lastfm-credentials.cjs
+++ b/scripts/inject-lastfm-credentials.cjs
@@ -1,18 +1,13 @@
-// Writes assets/lastfm-credentials.json from the SIDRA_LASTFM_API_KEY and
-// SIDRA_LASTFM_API_SECRET environment variables. It runs from npm's `prebuild`
-// hook and from the `build` recipe in the justfile, because `npx tsc` fires no
-// npm hook. In CI the env vars come from repository secrets.
+// Write assets/lastfm-credentials.json from SIDRA_LASTFM_API_KEY and
+// SIDRA_LASTFM_API_SECRET. npm's prebuild hook and the justfile build recipe
+// both call this script, because npx tsc runs no npm hook.
 //
-// Local builds with no env set write an empty file rather than leaving it
-// absent, because packaging fails when an asarUnpack entry is missing. Tag
-// builds require both values, so official packages cannot lose Last.fm.
+// Without environment credentials, local builds keep a populated file or write
+// empty values. Packaging needs the file for its asarUnpack entry.
+// Tag builds require both values, so official packages include Last.fm.
 //
-// An existing file that already holds credentials is left alone in a local
-// build when the env is unset, so building without the vars does not blank a
-// working setup.
-//
-// The output file is gitignored - the shared secret must never be committed to
-// the source tree. The real secret ends up only in official build artefacts.
+// CI reads repository secrets. The output is gitignored because the shared
+// secret belongs in build artefacts, never in the source tree.
 const fs = require("fs");
 const path = require("path");
 const { isOfficialBuild, validateCredentialPair } = require("./release-credentials.cjs");

--- a/scripts/release-credentials.cjs
+++ b/scripts/release-credentials.cjs
@@ -1,9 +1,11 @@
 'use strict';
 
+/** Identify tag builds, which require release credentials. */
 function isOfficialBuild(env = process.env) {
   return env.GITHUB_REF_TYPE === 'tag';
 }
 
+/** Return whether both credentials exist. Throw for a partial pair or a missing required pair. */
 function validateCredentialPair(env, firstName, secondName, required = false) {
   const firstPresent = typeof env[firstName] === 'string' && env[firstName].trim() !== '';
   const secondPresent = typeof env[secondName] === 'string' && env[secondName].trim() !== '';

--- a/scripts/update-electron-toolchain.cjs
+++ b/scripts/update-electron-toolchain.cjs
@@ -1,21 +1,18 @@
 #!/usr/bin/env node
 "use strict";
 
-// Points package.json at the newest CastLabs Electron, electron-builder and
-// electron-updater releases. The "Update Electron Toolchain" workflow runs it
-// weekly and opens a pull request when package.json changed; it installs
-// nothing and builds nothing itself.
+// Update package.json to the latest stable CastLabs Electron, electron-builder
+// and electron-updater releases. The weekly "Update Electron Toolchain"
+// workflow calls this script, which neither installs nor builds dependencies.
 //
-// Versions are read from git tags rather than the npm registry because the
-// Widevine-enabled Electron ships from castlabs/electron-releases and is
-// depended on as a GitHub tag, so the registry does not know about it.
+// Read git tags because the Widevine-enabled Electron dependency comes from
+// castlabs/electron-releases, not the npm registry.
 
 const { execFileSync } = require("node:child_process");
 const fs = require("node:fs");
 
 const packageJsonPath = "package.json";
-// Anchored on the +wvcus suffix: that is the Widevine CDM variant Sidra needs
-// for DRM playback, and the bare version triplet keeps prereleases out.
+// Require the Widevine CDM variant for DRM playback and exclude prereleases.
 const castLabsStableTagPattern = /^v(\d+)\.(\d+)\.(\d+)\+wvcus$/;
 const electronBuilderRepo = "https://github.com/electron-userland/electron-builder.git";
 
@@ -53,9 +50,7 @@ function latestCastLabsElectronTag() {
     "refs/tags/v*+wvcus",
   ]);
 
-  // git ls-remote lists an annotated tag twice, the second ref carrying a ^{}
-  // suffix for the commit it dereferences to, so those refs are dropped to
-  // leave one entry per release.
+  // Drop the ^{} commit refs that git ls-remote emits alongside annotated tags.
   const latest = refs
     .split(/\r?\n/)
     .map((line) => line.split(/\s+/)[1])
@@ -73,9 +68,8 @@ function latestCastLabsElectronTag() {
   return latest.tag;
 }
 
-// electron-builder and electron-updater are released from one monorepo whose
-// tags are prefixed "<package>@", so both versions come from the same remote
-// and the pattern has to be built per package.
+// Both packages share a repository. Match the <package>@ prefix to keep their
+// release versions separate.
 function latestElectronBuilderTag(packageName) {
   const tagPattern = new RegExp(`^${packageName}@(\\d+)\\.(\\d+)\\.(\\d+)$`);
   const refs = run("git", [
@@ -108,9 +102,8 @@ function latestElectronBuilderTag(packageName) {
   return latest.tag.replace(`${packageName}@`, "");
 }
 
-// Throws on an absent key rather than creating one: a dependency that moved
-// section or was renamed should fail the workflow, not gain a second entry in
-// the section this script expected it in.
+// Reject missing keys so a moved or renamed dependency cannot gain a duplicate
+// entry in the expected section.
 function setDependency(packageJson, section, name, value) {
   if (packageJson[section]?.[name] === undefined) {
     throw new Error(`${section}.${name} is missing from package.json`);

--- a/scripts/validate-build-config.cjs
+++ b/scripts/validate-build-config.cjs
@@ -1,26 +1,21 @@
-// Checks the electron-builder configuration before a packaging run. `just
-// validate` runs it locally and the test-config job in builder.yml runs it in
-// CI, so a fault is named here rather than surfacing later as an installer that
-// builds but misbehaves.
+// Check packaging settings through just validate and builder.yml's test-config
+// job, so configuration faults fail before installers reach users.
 const fs = require("fs");
 const path = require("path");
 
 function main() {
   const projectDir = process.cwd();
 
-  // 1. The whole electron-builder config lives in package.json under "build",
-  //    so reading that file reads the whole config. electron-builder exposes no
-  //    public API for loading or schema-validating it, so no schema pass runs.
-  //    Do not reach into app-builder-lib/out/... for its internal validator: a
-  //    compiled internal path breaks on a dependency bump and is then reported
-  //    as a module-not-found error rather than as anything about the config.
+  // package.json holds the complete build configuration. No schema check runs
+  // because electron-builder exposes no public validator. Internal paths under
+  // app-builder-lib/out/ can break on dependency updates with module-not-found
+  // errors instead of configuration errors.
   const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, "package.json"), "utf8"));
   const config = pkg.build ?? {};
   console.log("  \u2713 electron-builder config: read from package.json \"build\" (no schema check; electron-builder exposes no public validator)");
 
-  // 2. Options electron-builder has dropped or renamed. Each error names the
-  //    replacement, because a setting that is no longer read shows up only as
-  //    an installer missing the behaviour it was meant to configure.
+  // Reject obsolete options that electron-builder can otherwise ignore.
+  // Each error names the supported replacement.
   if (config.npmSkipBuildFromSource === false) {
     throw new Error("npmSkipBuildFromSource is deprecated; use buildDependenciesFromSource");
   }
@@ -37,7 +32,7 @@ function main() {
   }
   console.log("  \u2713 no deprecated options detected");
 
-  // 3. Validate package.json author has email (required by RPM/DEB FPM targets)
+  // FPM requires the author's email for the deb/rpm maintainer field.
   const author = pkg.author;
   const emailRegex = /<[^>]+@[^>]+>/;
   if (typeof author === "string") {
@@ -59,11 +54,9 @@ function main() {
   }
   console.log("  \u2713 package.json author email: present");
 
-  // 4. Validate Linux desktop actions used for launcher MPRIS controls.
-  //    Only the D-Bus wiring is pinned; the labels are free to change.
-  //    The MPRIS integration requests "org.mpris.MediaPlayer2." plus
-  //    app.getName() lowercased, and Electron prefers productName over name,
-  //    so the expected bus name is derived the same way and a rename fails here.
+  // Pin the D-Bus commands for launcher controls, not their labels.
+  // Match the MPRIS integration's lowercased app.getName(), which prefers
+  // productName over name, so a product rename requires matching commands.
   const desktop = config.linux?.desktop;
   const busName = `org.mpris.MediaPlayer2.${String(pkg.productName ?? pkg.name).toLowerCase()}`;
   const actionMethods = ["PlayPause", "Next", "Previous", "Stop"];
@@ -78,14 +71,9 @@ function main() {
     if (typeof action.Name !== "string" || action.Name.trim() === "") {
       throw new Error(`Linux desktop action ${method}.Name must be a non-empty string`);
     }
-    //    The Exec is matched token by token rather than as one whole string, so
-    //    extra whitespace or a flag reordered ahead of the member stays
-    //    harmless while the four parts that decide whether the launcher control
-    //    works are all pinned: the command, the destination, the object path
-    //    and the member, which must be the final token. Do not replace this
-    //    with includes() over the whole string, which passes a wrong object
-    //    path, a suffixed member and a trailing argument alike, nor with
-    //    equality against one expected command, which fails on formatting.
+    // Match tokens so whitespace and option order can vary without accepting
+    // a wrong command, destination, object path or member. The member must be
+    // last because dbus-send treats later tokens as message arguments.
     const exec = typeof action.Exec === "string" ? action.Exec : "";
     const tokens = exec.split(/\s+/).filter((token) => token !== "");
     const command = tokens.shift() ?? "";

--- a/src/aboutWindow.ts
+++ b/src/aboutWindow.ts
@@ -19,8 +19,7 @@ export function showAboutWindow(): void {
   }
 
   aboutLog.info('showing About window');
-  // The window is not resizable, so its size must scale with the zoom factor
-  // applied to the contents or the page is clipped
+  // Scale the fixed window with its contents to prevent clipping at higher zoom.
   const zoomFactor = getZoomFactor();
   aboutWindow = new BrowserWindow({
     width: Math.round(ABOUT_WINDOW_WIDTH_PX * zoomFactor),
@@ -40,7 +39,7 @@ export function showAboutWindow(): void {
     },
   });
 
-  // Held back until the page has rendered, so the window never flashes empty
+  // Wait for the page to render so the window does not flash empty.
   aboutWindow.once('ready-to-show', () => {
     aboutWindow?.webContents.setZoomFactor(getZoomFactor());
     aboutWindow?.show();
@@ -54,8 +53,7 @@ export function showAboutWindow(): void {
   const trayStrings = getTrayStrings();
   const aboutStrings = getAboutStrings();
 
-  // The page is sandboxed with no preload, so every string and every product
-  // detail reaches it as a query parameter
+  // With no preload, the sandboxed page receives text and product details through query parameters.
   aboutWindow.loadFile(getAssetPath('assets', 'about.html'), {
     query: {
       name: info.productName,

--- a/src/artwork.ts
+++ b/src/artwork.ts
@@ -48,15 +48,9 @@ function artworkCachePath(url: string): string {
 const inFlight = new Map<string, Promise<string | null>>();
 
 /**
- * Download artwork into the cache directory and resolve its local path, or null
- * when the download fails.
- *
- * Callers in flight for the same URL share one promise. Notifications, MPRIS and
- * the tray all ask for the same artwork on a track change and all three run at
- * once on Linux, so without this each change costs three fetches, three temp
- * files and three renames onto one destination; on Windows a later rename can
- * fail with EPERM while the tray holds the destination open. The key is the URL,
- * not the cache path, because the URL is what the callers share.
+ * Resolve a cached artwork path, or null for a failed download.
+ * Concurrent callers share one promise per URL, avoiding duplicate downloads and competing renames.
+ * A competing rename can fail with EPERM on Windows while the tray holds the destination open.
  */
 export function downloadArtwork(url: string): Promise<string | null> {
   const existing = inFlight.get(url);
@@ -64,9 +58,8 @@ export function downloadArtwork(url: string): Promise<string | null> {
     return existing;
   }
 
-  // The .finally() is attached before any caller sees the promise, so the entry
-  // is deleted ahead of every continuation: a failure is never cached, and a
-  // call made after an await refetches instead of replaying a settled promise
+  // Delete the in-flight entry before caller continuations run, so later calls
+  // check the disk cache again and can retry failed downloads.
   const pending = fetchArtwork(url).finally(() => {
     inFlight.delete(url);
   });
@@ -79,9 +72,8 @@ async function fetchArtwork(url: string): Promise<string | null> {
 
   if (fs.existsSync(filepath)) {
     artworkLog.debug('cache hit: %s', filepath);
-    // Touching mtime keeps the seven day sweep in cleanArtworkCache() from
-    // evicting artwork in daily use. Never awaited: a notification is waiting
-    // on the other end of this call
+    // Refresh mtime so cleanup preserves artwork in daily use.
+    // Do not await the timestamp write because notification delivery needs the path.
     const now = new Date();
     fsPromises.utimes(filepath, now, now).catch(() => {});
     return filepath;
@@ -150,7 +142,7 @@ export async function cleanArtworkCache(): Promise<void> {
         removed++;
       }
     } catch {
-      // File may have been removed between readdir and stat/unlink
+      // Concurrent removal or an inaccessible entry must not stop the remaining cleanup.
     }
   }
 

--- a/src/authFrame.ts
+++ b/src/authFrame.ts
@@ -1,20 +1,14 @@
-// Constants shared between loadAssets() in src/main.ts and the injected
-// assets/authFrameFix.js. They live here rather than in main.ts so
-// test/authFrameFix.test.ts can import them: main.ts calls app.whenReady() at
-// import and no test can load it. src/i18n.ts exports NAV_LABELS_TOKEN for the
-// same reason.
+// Shared injection constants live outside main.ts so tests can import them
+// without starting Electron through app.whenReady().
 
-// Substituted by loadAssets() in src/main.ts; assets/authFrameFix.js carries
-// the same spelling.
+/** Placeholder that loadAssets() replaces in assets/authFrameFix.js. */
 export const AUTH_FIX_TOKEN = '__SIDRA_AUTH_FIX__';
 
-// Containers that name the passkey or "Sign in with iPhone" option. Both jobs
-// in assets/authFrameFix.js need them: the injected stylesheet hides a match on
-// sight, and closest() walks up to one from a button it has already matched.
-// Only selectors that name the feature belong here. The broad class prefixes
-// and the structural [role="group"] and fieldset entries stay in the script,
-// where the walk starts at a matched button; in the stylesheet they would hide
-// unrelated form groups.
+/**
+ * Feature-specific containers shared by the injected stylesheet and closest() lookup.
+ * Broad selectors stay in assets/authFrameFix.js, where the lookup starts at a matched button.
+ * Used directly in CSS, those selectors would hide unrelated form groups.
+ */
 export const PASSKEY_CONTAINER_SELECTORS = [
   '[class*="passkey-option" i]',
   '[class*="passkey-section" i]',

--- a/src/autoUpdate.ts
+++ b/src/autoUpdate.ts
@@ -7,22 +7,17 @@ import { setUpdateReady, showUpdateNotification } from './update';
 const autoUpdateLog = log.scope('autoUpdate');
 
 /**
- * The single load point for electron-updater. It is required here and never
- * imported at module level, so it never loads on a platform that does not
- * support it. The return annotation is a type-only reference that tsc erases,
- * so the emitted JavaScript carries no top-level require of its own and the
- * whole updater surface is still checked against the published types.
+ * Load electron-updater only after the caller checks platform support.
+ * The return type adds compile-time checks without a top-level runtime import.
  */
 function loadAutoUpdater(): typeof import('electron-updater') {
   return require('electron-updater');
 }
 
 /**
- * True only where Sidra owns the install: an AppImage or a packaged Windows
- * NSIS build. Every other target is updated by its package manager, so the
- * updater must stay out of the way there and src/update.ts notifies instead.
- * app-update.yml ships in every packaged build, so this runtime check is what
- * keeps electron-updater from starting on deb, rpm and Nix.
+ * Check the update preference and AppImage or packaged Windows support, excluding Snap.
+ * Other targets use notifications from src/update.ts instead.
+ * app-update.yml ships in all packaged builds, so its presence cannot determine support.
  */
 export function isAutoUpdateSupported(): boolean {
   if (process.env.SIDRA_DISABLE_AUTO_UPDATE === '1') {
@@ -47,7 +42,6 @@ export function isAutoUpdateSupported(): boolean {
     return true;
   }
 
-  // Windows NSIS: packaged win32 app
   if (process.platform === 'win32' && app.isPackaged) {
     autoUpdateLog.info('auto-update supported: Windows NSIS detected');
     return true;
@@ -134,6 +128,7 @@ export async function configureAutoUpdate(
   await autoUpdater.checkForUpdates().catch(() => {});
 }
 
+/** Initialise the updater after a support check, logging setup failures without rejecting. */
 export async function initAutoUpdate(tray: Tray, rebuildMenu: (tray: Tray) => void): Promise<void> {
   try {
     await configureAutoUpdate(loadAutoUpdater(), tray, rebuildMenu);

--- a/src/commandBridge.ts
+++ b/src/commandBridge.ts
@@ -13,11 +13,8 @@ export function initCommandBridge(send: (channel: ReceiveChannel, ...args: unkno
 }
 
 /**
- * Sends one command to the renderer. Callers must invoke this from the click
- * handler rather than capturing `sender` at build time: a menu built before
- * initCommandBridge() runs still works, because the sender is read when the
- * item is clicked. The warning covers the remaining case, a click that lands
- * before the window exists, which would otherwise fail in silence.
+ * Send a command through the current renderer sender, warning if none exists.
+ * Call from click handlers so menus built before initCommandBridge() still work once the window exists.
  */
 export function sendCommand(channel: ReceiveChannel, ...args: unknown[]): void {
   if (!sender) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,6 @@
 /**
- * Typed wrapper around electron-conf and the single place persistent state is
- * read or written; nothing else touches the store directly. Each key gets a
- * getter/setter pair, and the schema carries no defaults: a default lives in
- * the getter that needs one, so keys such as storefront can still report
- * "never set" and drive the fallback chain in src/storefront.ts.
+ * Typed access to persistent state through electron-conf.
+ * Defaults belong to getters, not the schema, so an absent storefront still triggers system-region fallback in src/storefront.ts.
  */
 import { Conf } from 'electron-conf/main';
 import log from 'electron-log/main';
@@ -19,6 +16,7 @@ import {
 
 const configLog = log.scope('config');
 
+/** A play held for later Last.fm submission, with a timestamp in Unix seconds. */
 export interface PendingScrobble {
   artist: string;
   track: string;
@@ -75,68 +73,84 @@ function setConfigValue<K extends keyof StoreSchema>(key: K, value: StoreSchema[
   configLog.info(`${key} set:`, value);
 }
 
+/** Read `storefront`, returning undefined when the key is absent. */
 export function getStorefront(): string | undefined {
   return getConfigValueOptional('storefront');
 }
 
+/** Persist `storefront` without applying the setting to running components. */
 export function setStorefront(code: string): void {
   setConfigValue('storefront', code);
 }
 
+/** Read `language`, returning undefined when the key is absent. */
 export function getLanguage(): string | null | undefined {
   return getConfigValueOptional('language');
 }
 
+/** Persist `language` without applying the setting to running components. */
 export function setLanguage(lang: string | null): void {
   setConfigValue('language', lang);
 }
 
+/** Read `notifications.enabled`, defaulting to `true` when absent. */
 export function getNotificationsEnabled(): boolean {
   return getConfigValue('notifications.enabled', true);
 }
 
+/** Persist `notifications.enabled` without applying the setting to running components. */
 export function setNotificationsEnabled(enabled: boolean): void {
   setConfigValue('notifications.enabled', enabled);
 }
 
+/** Read `closeToTray.enabled`, defaulting to `false` when absent. */
 export function getCloseToTrayEnabled(): boolean {
   return getConfigValue('closeToTray.enabled', false);
 }
 
+/** Persist `closeToTray.enabled` without applying the setting to running components. */
 export function setCloseToTrayEnabled(enabled: boolean): void {
   setConfigValue('closeToTray.enabled', enabled);
 }
 
+/** Read `discord.enabled`, defaulting to `false` when absent. */
 export function getDiscordEnabled(): boolean {
   return getConfigValue('discord.enabled', false);
 }
 
+/** Persist `discord.enabled` without applying the setting to running components. */
 export function setDiscordEnabled(enabled: boolean): void {
   setConfigValue('discord.enabled', enabled);
 }
 
+/** Read `lastfm.enabled`, defaulting to `false` when absent. */
 export function getLastfmEnabled(): boolean {
   return getConfigValue('lastfm.enabled', false);
 }
 
+/** Persist `lastfm.enabled` without applying the setting to running components. */
 export function setLastfmEnabled(enabled: boolean): void {
   setConfigValue('lastfm.enabled', enabled);
 }
 
+/** Read `lastfm.sessionKey`, returning undefined when the key is absent. */
 export function getLastfmSessionKey(): string | null | undefined {
   return getConfigValueOptional('lastfm.sessionKey');
 }
 
+/** Read `lastfm.username`, returning undefined when the key is absent. */
 export function getLastfmUsername(): string | null | undefined {
   return getConfigValueOptional('lastfm.username');
 }
 
+/** Store the Last.fm session and username without logging the session key. */
 export function setLastfmSession(sessionKey: string, username: string): void {
   store.set('lastfm.sessionKey', sessionKey);
   store.set('lastfm.username', username);
   configLog.info('lastfm session set for user:', username);
 }
 
+/** Clear Last.fm credentials without changing the enabled preference or pending queue. */
 export function clearLastfmSession(): void {
   store.set('lastfm.sessionKey', null);
   store.set('lastfm.username', null);
@@ -144,13 +158,9 @@ export function clearLastfmSession(): void {
 }
 
 /**
- * The store is hand-editable JSON on disk, so every field is checked, optional
- * ones included: `flushPendingScrobbles()` stringifies whatever survives into
- * one batch, and Last.fm refuses the batch whole, so a single malformed entry
- * costs every queued play. The ranges match what the integration produces - a
- * Unix second and a rounded track length, both positive integers. A second later
- * than now is refused because Last.fm ignores such a scrobble without an API
- * error, so the flush reads success and drops the batch with the valid plays in it.
+ * Validate every field from the editable store because one malformed play can invalidate a Last.fm batch.
+ * Timestamps and durations are positive whole seconds, matching the integration's output.
+ * Reject future timestamps because Last.fm can ignore them in a successful response, after which the queue drops them.
  */
 function isPendingScrobble(value: unknown): value is PendingScrobble {
   if (typeof value !== 'object' || value === null) return false;
@@ -167,6 +177,7 @@ function isPendingScrobble(value: unknown): value is PendingScrobble {
     && (entry.chosenByUser === undefined || entry.chosenByUser === 0);
 }
 
+/** Read pending plays and discard malformed entries without logging listening history. */
 export function getPendingScrobbles(): PendingScrobble[] {
   const stored: unknown = getConfigValue('lastfm.pendingScrobbles', []);
   if (!Array.isArray(stored)) {
@@ -181,51 +192,63 @@ export function getPendingScrobbles(): PendingScrobble[] {
   return entries;
 }
 
+/** Replace the pending queue and log its length, not its contents. */
 export function setPendingScrobbles(entries: PendingScrobble[]): void {
   store.set('lastfm.pendingScrobbles', entries);
   configLog.info('lastfm.pendingScrobbles set, queued:', entries.length);
 }
 
+/** Read `theme`, defaulting to `'apple-music'` when absent. */
 export function getTheme(): ThemeName {
   return getConfigValue('theme', 'apple-music');
 }
 
+/** Persist `theme` without applying the setting to running components. */
 export function setTheme(name: ThemeName): void {
   setConfigValue('theme', name);
 }
 
+/** Read `autoUpdate.enabled`, defaulting to `true` when absent. */
 export function getAutoUpdateEnabled(): boolean {
   return getConfigValue('autoUpdate.enabled', true);
 }
 
+/** Persist `autoUpdate.enabled` without applying the setting to running components. */
 export function setAutoUpdateEnabled(enabled: boolean): void {
   setConfigValue('autoUpdate.enabled', enabled);
 }
 
+/** Read `lastPageUrl`, returning undefined when the key is absent. */
 export function getLastPageUrl(): string | undefined {
   return getConfigValueOptional('lastPageUrl');
 }
 
+/** Persist `lastPageUrl` without applying the setting to running components. */
 export function setLastPageUrl(url: string): void {
   setConfigValue('lastPageUrl', url);
 }
 
+/** Read `startPage`, defaulting to `'new'` when absent. */
 export function getStartPage(): MusicStartPageId | 'last' {
   return getConfigValue('startPage', 'new');
 }
 
+/** Persist `startPage` without applying the setting to running components. */
 export function setStartPage(page: MusicStartPageId | 'last'): void {
   setConfigValue('startPage', page);
 }
 
+/** Read `zoomFactor`, defaulting to `1.0` when absent. */
 export function getZoomFactor(): number {
   return getConfigValue('zoomFactor', 1.0);
 }
 
+/** Persist `zoomFactor` without applying the setting to running components. */
 export function setZoomFactor(factor: number): void {
   setConfigValue('zoomFactor', factor);
 }
 
+/** Read the stored service, falling back to the default for an unregistered id. */
 export function getMusicService(): MusicServiceId {
   const id = getConfigValue('musicService', DEFAULT_SERVICE_ID);
   if (!isMusicServiceId(id)) {
@@ -235,31 +258,34 @@ export function getMusicService(): MusicServiceId {
   return id;
 }
 
+/** Persist `musicService` without applying the setting to running components. */
 export function setMusicService(id: MusicServiceId): void {
   setConfigValue('musicService', id);
 }
 
+/** Read `classical.startPage`, defaulting to `'home'` when absent. */
 export function getClassicalStartPage(): ClassicalStartPageId | 'last' {
   return getConfigValue('classical.startPage', 'home');
 }
 
+/** Persist `classical.startPage` without applying the setting to running components. */
 export function setClassicalStartPage(page: ClassicalStartPageId | 'last'): void {
   setConfigValue('classical.startPage', page);
 }
 
+/** Read `classical.lastPageUrl`, returning undefined when the key is absent. */
 export function getClassicalLastPageUrl(): string | undefined {
   return getConfigValueOptional('classical.lastPageUrl');
 }
 
+/** Persist `classical.lastPageUrl` without applying the setting to running components. */
 export function setClassicalLastPageUrl(url: string): void {
   setConfigValue('classical.lastPageUrl', url);
 }
 
 /**
- * Service-keyed views of the pairs above, so a caller holding a MusicServiceId
- * reads and writes without branching on it. This table is the only place a
- * service id maps to its stored keys, and the Record annotation makes a new
- * service a compile error here rather than a missed branch at a call site.
+ * Map each service to its stored page accessors without branching at call sites.
+ * The total Record requires an entry for every registered service.
  */
 const SERVICE_PAGE_ACCESSORS: Record<MusicServiceId, {
   getStartPage: () => AnyStartPageId | 'last';
@@ -279,20 +305,19 @@ const SERVICE_PAGE_ACCESSORS: Record<MusicServiceId, {
 };
 
 /**
- * Stored start page for a service. The union covers both services, because the
- * caller's id is a variable: a caller that knows which service it means takes
- * the narrower pair above. Reading wide is safe - the id is matched against the
- * service's own startPages, and one from the wrong service matches nothing and
- * falls back to that service's default.
+ * Read a service's stored start page with a union that covers both services.
+ * Callers must resolve the result against that service's startPages, using its default when no entry matches.
  */
 export function getStartPageFor(id: MusicServiceId): AnyStartPageId | 'last' {
   return SERVICE_PAGE_ACCESSORS[id].getStartPage();
 }
 
+/** Read the last page stored for the requested service. */
 export function getLastPageUrlFor(id: MusicServiceId): string | undefined {
   return SERVICE_PAGE_ACCESSORS[id].getLastPageUrl();
 }
 
+/** Persist the last page under the requested service. */
 export function setLastPageUrlFor(id: MusicServiceId, url: string): void {
   SERVICE_PAGE_ACCESSORS[id].setLastPageUrl(url);
 }

--- a/src/contentReady.ts
+++ b/src/contentReady.ts
@@ -1,13 +1,9 @@
-// Hash-immune handles: Apple's data test id on the app container and the amp-* custom element tag survive class hashing.
-// The Stencil hydrated attribute on the playback control marks the first render, so JS has executed and chrome is interactive.
+/** Detect rendered playback controls through stable attributes and tags, independent of Apple's hashed classes. */
 export const CONTENT_READY_SELECTOR = '[data-testid="app-container"] amp-playback-controls-play[hydrated]';
 
 /**
- * Build the expression main.ts runs with executeJavaScript() to poll a loading
- * page. It returns a boolean and touches nothing, so it is safe to repeat until
- * the chrome is interactive and the splash can be dismissed. The selector comes
- * in as a parameter because each entry in the music service registry carries its
- * own, and JSON.stringify() quotes it so its own quotes cannot end the literal.
+ * Build a read-only readiness probe for a service's selector.
+ * JSON.stringify() prevents quotes in the selector from ending the JavaScript literal.
  */
 export function contentReadyProbeScript(selector: string = CONTENT_READY_SELECTOR): string {
   return `!!document.querySelector(${JSON.stringify(selector)})`;

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,8 +1,13 @@
+/** Navigation actions accepted from the isolated controller preload. */
 export type ControllerAction = 'up' | 'down' | 'left' | 'right' | 'select' | 'back';
 
+/** Private preload-to-main channel, outside the AMWrapper bridge. */
 export const CONTROLLER_ACTION_CHANNEL = 'controller:action' as const;
+/** Private main-to-preload channel that suppresses held buttons after navigation. */
 export const CONTROLLER_RESET_CHANNEL = 'controller:reset' as const;
+/** Literal type for private controller action messages. */
 export type ControllerActionChannel = typeof CONTROLLER_ACTION_CHANNEL;
+/** Literal type for private controller reset messages. */
 export type ControllerResetChannel = typeof CONTROLLER_RESET_CHANNEL;
 
 const CONTROLLER_ACTIONS: readonly ControllerAction[] = [
@@ -14,14 +19,17 @@ const CONTROLLER_ACTIONS: readonly ControllerAction[] = [
   'back',
 ];
 
+/** Validate an IPC payload against the fixed navigation action list. */
 export function isControllerAction(value: unknown): value is ControllerAction {
   return typeof value === 'string' && CONTROLLER_ACTIONS.some((action) => action === value);
 }
 
+/** Identify the private action channel without widening the bridge allowlist. */
 export function isControllerActionChannel(value: string): value is typeof CONTROLLER_ACTION_CHANNEL {
   return value === CONTROLLER_ACTION_CHANNEL;
 }
 
+/** Identify the private reset channel without widening the bridge allowlist. */
 export function isControllerResetChannel(value: string): value is typeof CONTROLLER_RESET_CHANNEL {
   return value === CONTROLLER_RESET_CHANNEL;
 }

--- a/src/controllerIPC.ts
+++ b/src/controllerIPC.ts
@@ -12,12 +12,14 @@ const ACTION_KEYS: Readonly<Record<Exclude<ControllerAction, 'back'>, string>> =
   select: 'Enter',
 };
 
+/** Navigate back only when the window has a previous history entry. */
 export function goBackIfPossible(win: BrowserWindow): void {
   if (win.webContents.navigationHistory.canGoBack()) {
     win.webContents.navigationHistory.goBack();
   }
 }
 
+/** Accept fixed controller actions from this window and send native keys only while focused. */
 export function initControllerIPC(win: BrowserWindow): void {
   ipcMain.on(CONTROLLER_ACTION_CHANNEL, (event, payload: unknown) => {
     if (event.sender !== win.webContents) {

--- a/src/customTheme.ts
+++ b/src/customTheme.ts
@@ -20,6 +20,7 @@ function parseScheme(value: unknown): SchemeColours | null {
   return colours;
 }
 
+/** Parse complete hex-colour schemes, using dark for omitted light and returning null for invalid JSON or colours. */
 export function parseCustomTheme(json: string): ThemeDefinition | null {
   let value: unknown;
   try {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -26,11 +26,7 @@ function loadLocaleFile(filename: string): TranslationFile {
   }
 }
 
-// Read synchronously at module load, because the splash screen needs its string
-// before the first window renders and there is no point at which these files are
-// not wanted. The four together are a few kilobytes. The lazy-require rule in
-// AGENTS.md covers platform modules that must never load at all, which is a
-// different problem.
+// Load synchronously because the splash needs its translation before the first window renders.
 const loadingData = loadLocaleFile('loading.json');
 const trayData = loadLocaleFile('tray.json');
 const aboutData = loadLocaleFile('about.json');
@@ -38,63 +34,118 @@ const updateData = loadLocaleFile('update.json');
 
 // --- Translation records, re-exported so importers name a record, not a file ---
 
+/** Translations for loading, keyed by BCP 47 language tag. */
 export const LOADING_TEXT: Record<string, string> = loadingData.LOADING_TEXT;
 
+/** Translations for about, keyed by BCP 47 language tag. */
 export const ABOUT_TEXT: Record<string, string> = trayData.ABOUT_TEXT;
+/** Translations for quit, keyed by BCP 47 language tag. */
 export const QUIT_TEXT: Record<string, string> = trayData.QUIT_TEXT;
+/** Translations for notifications, keyed by BCP 47 language tag. */
 export const NOTIFICATIONS_TEXT: Record<string, string> = trayData.NOTIFICATIONS_TEXT;
+/** Translations for discord, keyed by BCP 47 language tag. */
 export const DISCORD_TEXT: Record<string, string> = trayData.DISCORD_TEXT;
+/** Translations for discord play on, keyed by BCP 47 language tag. */
 export const DISCORD_PLAY_ON_TEXT: Record<string, string> = trayData.DISCORD_PLAY_ON_TEXT;
+/** Translations for discord by artist, keyed by BCP 47 language tag. */
 export const DISCORD_BY_ARTIST_TEXT: Record<string, string> = trayData.DISCORD_BY_ARTIST_TEXT;
+/** Translations for unknown artist, keyed by BCP 47 language tag. */
 export const UNKNOWN_ARTIST_TEXT: Record<string, string> = trayData.UNKNOWN_ARTIST_TEXT;
+/** Translations for lastfm connect, keyed by BCP 47 language tag. */
 export const LASTFM_CONNECT_TEXT: Record<string, string> = trayData.LASTFM_CONNECT_TEXT;
+/** Translations for lastfm connected, keyed by BCP 47 language tag. */
 export const LASTFM_CONNECTED_TEXT: Record<string, string> = trayData.LASTFM_CONNECTED_TEXT;
+/** Translations for lastfm connect failed, keyed by BCP 47 language tag. */
 export const LASTFM_CONNECT_FAILED_TEXT: Record<string, string> = trayData.LASTFM_CONNECT_FAILED_TEXT;
+/** Translations for lastfm disconnect, keyed by BCP 47 language tag. */
 export const LASTFM_DISCONNECT_TEXT: Record<string, string> = trayData.LASTFM_DISCONNECT_TEXT;
+/** Translations for start page, keyed by BCP 47 language tag. */
 export const START_PAGE_TEXT: Record<string, string> = trayData.START_PAGE_TEXT;
+/** Translations for start page home, keyed by BCP 47 language tag. */
 export const START_PAGE_HOME_TEXT: Record<string, string> = trayData.START_PAGE_HOME_TEXT;
+/** Translations for start page new, keyed by BCP 47 language tag. */
 export const START_PAGE_NEW_TEXT: Record<string, string> = trayData.START_PAGE_NEW_TEXT;
+/** Translations for start page radio, keyed by BCP 47 language tag. */
 export const START_PAGE_RADIO_TEXT: Record<string, string> = trayData.START_PAGE_RADIO_TEXT;
+/** Translations for start page all playlists, keyed by BCP 47 language tag. */
 export const START_PAGE_ALL_PLAYLISTS_TEXT: Record<string, string> = trayData.START_PAGE_ALL_PLAYLISTS_TEXT;
+/** Translations for start page last, keyed by BCP 47 language tag. */
 export const START_PAGE_LAST_TEXT: Record<string, string> = trayData.START_PAGE_LAST_TEXT;
+/** Translations for on, keyed by BCP 47 language tag. */
 export const ON_TEXT: Record<string, string> = trayData.ON_TEXT;
+/** Translations for off, keyed by BCP 47 language tag. */
 export const OFF_TEXT: Record<string, string> = trayData.OFF_TEXT;
+/** Translations for style, keyed by BCP 47 language tag. */
 export const STYLE_TEXT: Record<string, string> = trayData.STYLE_TEXT;
+/** Translations for style custom, keyed by BCP 47 language tag. */
 export const STYLE_CUSTOM_TEXT: Record<string, string> = trayData.STYLE_CUSTOM_TEXT;
+/** Translations for zoom, keyed by BCP 47 language tag. */
 export const ZOOM_TEXT: Record<string, string> = trayData.ZOOM_TEXT;
+/** Translations for previous, keyed by BCP 47 language tag. */
 export const PREVIOUS_TEXT: Record<string, string> = trayData.PREVIOUS_TEXT;
+/** Translations for play, keyed by BCP 47 language tag. */
 export const PLAY_TEXT: Record<string, string> = trayData.PLAY_TEXT;
+/** Translations for pause, keyed by BCP 47 language tag. */
 export const PAUSE_TEXT: Record<string, string> = trayData.PAUSE_TEXT;
+/** Translations for next, keyed by BCP 47 language tag. */
 export const NEXT_TEXT: Record<string, string> = trayData.NEXT_TEXT;
+/** Translations for volume, keyed by BCP 47 language tag. */
 export const VOLUME_TEXT: Record<string, string> = trayData.VOLUME_TEXT;
+/** Translations for mute, keyed by BCP 47 language tag. */
 export const MUTE_TEXT: Record<string, string> = trayData.MUTE_TEXT;
+/** Translations for share, keyed by BCP 47 language tag. */
 export const SHARE_TEXT: Record<string, string> = trayData.SHARE_TEXT;
+/** Translations for hide window, keyed by BCP 47 language tag. */
 export const HIDE_WINDOW_TEXT: Record<string, string> = trayData.HIDE_WINDOW_TEXT;
+/** Translations for show window, keyed by BCP 47 language tag. */
 export const SHOW_WINDOW_TEXT: Record<string, string> = trayData.SHOW_WINDOW_TEXT;
+/** Translations for close to tray, keyed by BCP 47 language tag. */
 export const CLOSE_TO_TRAY_TEXT: Record<string, string> = trayData.CLOSE_TO_TRAY_TEXT;
+/** Translations for player, keyed by BCP 47 language tag. */
 export const PLAYER_TEXT: Record<string, string> = trayData.PLAYER_TEXT;
+/** Translations for start page browse, keyed by BCP 47 language tag. */
 export const START_PAGE_BROWSE_TEXT: Record<string, string> = trayData.START_PAGE_BROWSE_TEXT;
+/** Translations for start page library, keyed by BCP 47 language tag. */
 export const START_PAGE_LIBRARY_TEXT: Record<string, string> = trayData.START_PAGE_LIBRARY_TEXT;
+/** Translations for start page playlists, keyed by BCP 47 language tag. */
 export const START_PAGE_PLAYLISTS_TEXT: Record<string, string> = trayData.START_PAGE_PLAYLISTS_TEXT;
+/** Translations for start page search, keyed by BCP 47 language tag. */
 export const START_PAGE_SEARCH_TEXT: Record<string, string> = trayData.START_PAGE_SEARCH_TEXT;
+/** Translations for not playing, keyed by BCP 47 language tag. */
 export const NOT_PLAYING_TEXT: Record<string, string> = trayData.NOT_PLAYING_TEXT;
+/** Translations for back, keyed by BCP 47 language tag. */
 export const BACK_TEXT: Record<string, string> = trayData.BACK_TEXT;
+/** Translations for forward, keyed by BCP 47 language tag. */
 export const FORWARD_TEXT: Record<string, string> = trayData.FORWARD_TEXT;
+/** Translations for reload, keyed by BCP 47 language tag. */
 export const RELOAD_TEXT: Record<string, string> = trayData.RELOAD_TEXT;
+/** Translations for settings, keyed by BCP 47 language tag. */
 export const SETTINGS_TEXT: Record<string, string> = trayData.SETTINGS_TEXT;
+/** Translations for integrations, keyed by BCP 47 language tag. */
 export const INTEGRATIONS_TEXT: Record<string, string> = trayData.INTEGRATIONS_TEXT;
+/** Translations for settings error, keyed by BCP 47 language tag. */
 export const SETTINGS_ERROR_TEXT: Record<string, string> = trayData.SETTINGS_ERROR_TEXT;
 
+/** Translations for update available, keyed by BCP 47 language tag. */
 export const UPDATE_AVAILABLE_TEXT: Record<string, string> = updateData.UPDATE_AVAILABLE_TEXT;
+/** Translations for up to date, keyed by BCP 47 language tag. */
 export const UP_TO_DATE_TEXT: Record<string, string> = updateData.UP_TO_DATE_TEXT;
+/** Translations for update ready, keyed by BCP 47 language tag. */
 export const UPDATE_READY_TEXT: Record<string, string> = updateData.UPDATE_READY_TEXT;
+/** Translations for restart now, keyed by BCP 47 language tag. */
 export const RESTART_NOW_TEXT: Record<string, string> = updateData.RESTART_NOW_TEXT;
+/** Translations for later, keyed by BCP 47 language tag. */
 export const LATER_TEXT: Record<string, string> = updateData.LATER_TEXT;
 
+/** Translations for close, keyed by BCP 47 language tag. */
 export const CLOSE_TEXT: Record<string, string> = aboutData.CLOSE_TEXT;
+/** Translations for about description, keyed by BCP 47 language tag. */
 export const ABOUT_DESCRIPTION_TEXT: Record<string, string> = aboutData.ABOUT_DESCRIPTION_TEXT;
+/** Translations for version prefix, keyed by BCP 47 language tag. */
 export const VERSION_PREFIX: Record<string, string> = aboutData.VERSION_PREFIX;
+/** Translations for copyright suffix, keyed by BCP 47 language tag. */
 export const COPYRIGHT_SUFFIX: Record<string, string> = aboutData.COPYRIGHT_SUFFIX;
+/** Translations for license prefix, keyed by BCP 47 language tag. */
 export const LICENSE_PREFIX: Record<string, string> = aboutData.LICENSE_PREFIX;
 
 // --- Cached system language list ---
@@ -109,9 +160,9 @@ function getSystemLanguages(): string[] {
 // --- Generic locale resolution ---
 
 /**
- * Resolve one record against the caller's ordered language list: an exact BCP 47
- * tag first, then the base language, so en-GB falls to en. English is the last
- * resort, which every record must therefore carry.
+ * Resolve preferred languages in order, checking exact and normalised tags before base languages.
+ * Chinese script matching precedes base-language fallback.
+ * Use English only when no preferred language matches, so every record needs an en entry.
  */
 export function getLocalizedString(
   record: Record<string, string>,
@@ -174,6 +225,7 @@ export function getLoadingText(): { text: string; lang: string } {
   return { text, lang };
 }
 
+/** Resolved labels shared by tray and settings controls. */
 export interface TrayStrings {
   settings: string;
   integrations: string;
@@ -300,30 +352,36 @@ export function getTrayStrings(): TrayStrings {
   return strings;
 }
 
+/** Format the localised Discord service label. */
 export function getDiscordPlayOnText(service: string): string {
   return getLocalizedString(DISCORD_PLAY_ON_TEXT, getSystemLanguages()).replace('{service}', () => service);
 }
 
+/** Format the localised Discord artist label, using the unknown-artist translation for null. */
 export function getDiscordArtistText(artist: string | null): string {
   const langs = getSystemLanguages();
   const name = artist ?? getLocalizedString(UNKNOWN_ARTIST_TEXT, langs);
   return getLocalizedString(DISCORD_BY_ARTIST_TEXT, langs).replace('{artist}', () => name);
 }
 
+/** Format the connected Last.fm account label. */
 export function getLastfmConnectedText(name: string): string {
   const langs = getSystemLanguages();
   return getLocalizedString(LASTFM_CONNECTED_TEXT, langs).replace('{name}', name);
 }
 
+/** Resolve the Last.fm connection failure message. */
 export function getLastfmConnectFailedText(): string {
   return getLocalizedString(LASTFM_CONNECT_FAILED_TEXT, getSystemLanguages());
 }
 
-// Replaced with a JSON label object when assets/navigationBar.js is read in
-// src/main.ts. That script is injected with executeJavaScript(), so the
-// loadFile() query parameters the splash screen uses are not available.
+/**
+ * Placeholder for JSON labels in assets/navigationBar.js.
+ * executeJavaScript() injection has no loadFile() query parameters, so loadAssets() substitutes labels before injection.
+ */
 export const NAV_LABELS_TOKEN = '__SIDRA_NAV_LABELS__';
 
+/** Resolve the labels for the injected navigation bar. */
 export function getNavigationStrings(): {
   settings: string;
   back: string;
@@ -339,6 +397,7 @@ export function getNavigationStrings(): {
   };
 }
 
+/** Resolve the About window text and metadata labels. */
 export function getAboutStrings(): {
   description: string;
   close: string;
@@ -356,6 +415,7 @@ export function getAboutStrings(): {
   };
 }
 
+/** Resolve update availability messages. */
 export function getUpdateStrings(): {
   updateAvailable: string;
   upToDate: string;
@@ -367,6 +427,7 @@ export function getUpdateStrings(): {
   };
 }
 
+/** Resolve the downloaded-update prompt and its action labels. */
 export function getAutoUpdateStrings(): {
   ready: string;
   restartNow: string;

--- a/src/integrations/discord-presence/index.ts
+++ b/src/integrations/discord-presence/index.ts
@@ -52,9 +52,8 @@ function clearTrackMetadata(): void {
   trackUrl = undefined;
 }
 
-// Playback state. init() assigns playerRef before it builds the only client, so
-// nothing can reach the send path without one. Every call below enable()/disable()
-// carries the Player as an argument, so tsc checks it rather than an assertion.
+// init() assigns playerRef before creating a client. Internal request functions
+// take Player directly so only enable()/disable() need a nullable reference.
 let playerRef: Player | null = null;
 let previousState = 0;
 
@@ -91,28 +90,12 @@ function createClient(player: Player): Client {
   return created;
 }
 
-// Ends a client that is being discarded. removeAllListeners() must run before
-// destroy(): destroy() closes the transport, whose close handler emits
-// 'disconnected' on the old client, and that stray event would arm a second
-// backoff chain.
-//
-// clearActivity() is an RPC round trip on the transport destroy() closes, and
-// destroy() neither flushes the socket nor waits for Discord's reply, so the
-// destroy waits on the clear rather than running beside it. That wait is
-// bounded, because the clear can hang for good: it settles only when Discord
-// answers the SET_ACTIVITY nonce, IPCTransport.send() is a silent no-op once
-// the socket has gone, and the library's rejection path is a one-shot 'close'
-// listener that has already fired and been removed by the time a toggle-off
-// reaches here. A socket that is open while Discord answers no RPC hangs the
-// same way, and that is the case that costs something: the socket leaks and
-// the stale activity outlives Discord's own recovery. So the clear races
-// CLEAR_ACTIVITY_TIMEOUT_MS and whichever settles first destroys. The flag
-// keeps that to one destroy, whether or not the loser settles later.
-//
-// The try/catch covers a synchronous throw from destroy(). It is async in
-// @xhayper/discord-rpc 1.3.4 and cannot throw synchronously today, so this
-// guards a later non-async destroy(); it costs nothing, and a bare .catch()
-// on the call would miss that throw.
+// Remove listeners before destroy(), whose transport close emits 'disconnected'
+// and can otherwise start another reconnect timer.
+// Wait for clearActivity() before closing its transport, but bound the wait:
+// a silent peer or closed socket can leave that RPC unresolved after the one-shot close listener expires.
+// destroyOnce() prevents duplicate destruction when the timeout and RPC both settle.
+// The try/catch also contains synchronous destroy() failures.
 function retireClient(retiring: Client, clearActivity: boolean): void {
   retiring.removeAllListeners();
 
@@ -125,7 +108,7 @@ function retireClient(retiring: Client, clearActivity: boolean): void {
     try {
       retiring.destroy().catch(() => {});
     } catch {
-      // A destroy that fails has nothing left to clean up.
+      // Keep client disposal failures from interrupting the caller.
     }
   };
 
@@ -150,11 +133,8 @@ function replaceClient(player: Player, clearActivity = false): Client {
   return client;
 }
 
-// One failure policy for every login attempt: warn with the site that made it,
-// then hand the retry to the backoff chain. The client is a parameter because
-// the reconnect path logs in on a fresh one while the other sites use the live
-// one, and logging in twice on the same instance is what replaceClient() exists
-// to prevent.
+// Share login failure handling. Reconnect supplies a fresh client, while other
+// callers supply the current one, so a failed instance is not reused for retries.
 function loginOrRetry(player: Player, target: Client, context: string): void {
   target.login().catch((err: Error) => {
     discordLog.warn(`${context} failed:`, err.message);
@@ -162,12 +142,8 @@ function loginOrRetry(player: Player, target: Client, context: string): void {
   });
 }
 
-// Every request for an activity arrives here, so this is where the connection
-// is answered for: a disabled toggle arms no timer, and a client that is down is
-// asked to log in rather than given a debounce whose expiry would find it down
-// anyway. Its 'ready' handler schedules the update the login was for, so nothing
-// is lost. An armed reconnect already owns the retry, so the login is skipped
-// there instead of running a second one on the same instance.
+// Schedule activity only for a connected, enabled client. Otherwise log in and
+// let 'ready' schedule the update, unless a reconnect timer already owns the attempt.
 function scheduleUpdate(player: Player): void {
   if (!getDiscordEnabled() || !client) return;
 
@@ -204,9 +180,8 @@ function disconnectClient(player: Player): void {
   discordLog.info('disconnected from Discord (disabled via toggle)');
 }
 
-// Builds the activity and sends it. The connection is scheduleUpdate()'s
-// business: only a live client is ever given a debounce, and disable() clears a
-// pending one, so this cannot run behind a toggle that has gone off.
+// scheduleUpdate() checks the connection before arming the debounce.
+// disable() cancels pending work so it cannot send after the toggle turns off.
 function sendActivity(player: Player): void {
   if (!client) return;
 
@@ -279,7 +254,7 @@ function scheduleReconnect(player: Player): void {
   }, delay);
 }
 
-/** Turns presence on from the tray toggle; connects if the client is idle. */
+/** Connects an idle presence client when the tray toggle turns on. */
 export function enable(): void {
   const player = playerRef;
   if (!player || !client) return;
@@ -289,7 +264,7 @@ export function enable(): void {
   }
 }
 
-/** Turns presence off from the tray toggle; clears the activity and drops every timer. */
+/** Clears presence and cancels activity and reconnect timers when the tray toggle turns off. */
 export function disable(): void {
   const player = playerRef;
   if (!player || !client) return;
@@ -308,7 +283,7 @@ export function init(ctx: IntegrationContext): void {
     loginOrRetry(player, client, 'initial login');
   }
 
-  // Named listener references for removeListener in will-quit
+  // Named listeners let will-quit remove the same function references.
   const onNowPlayingItemDidChange = (payload: NowPlayingPayload | null): void => {
     if (!payload) {
       clearTrackMetadata();
@@ -358,9 +333,7 @@ export function init(ctx: IntegrationContext): void {
       reconnectTimer = null;
     }
 
-    // Quitting removes the presence anyway, so the activity is not cleared: that
-    // is an RPC round trip the destroy would have to wait on, and the process is
-    // ending underneath it.
+    // Quitting removes presence. Destroy immediately without waiting for a clearActivity() RPC.
     if (client) {
       retireClient(client, false);
       client = undefined;

--- a/src/integrations/discord-presence/index.ts
+++ b/src/integrations/discord-presence/index.ts
@@ -2,7 +2,7 @@ import { app } from 'electron';
 import log from 'electron-log/main';
 import { Client, SetActivity, StatusDisplayType } from '@xhayper/discord-rpc';
 import { ActivityType } from 'discord-api-types/v10';
-import { Player, NowPlayingPayload, PlaybackState, PlaybackStatePayload, IntegrationContext } from '../../player';
+import { Player, NowPlayingPayload, PlaybackState, PlaybackStatePayload, IntegrationContext, getShareUrl } from '../../player';
 import { getDiscordEnabled, getMusicService } from '../../config';
 import { getService } from '../../musicService';
 import { createPauseTimer } from '../../pauseTimer';
@@ -293,7 +293,9 @@ export function init(ctx: IntegrationContext): void {
       albumName = payload.albumName ?? null;
       artworkUrl = payload.artworkUrl;
       durationMs = payload.durationInMillis ?? 0;
-      trackUrl = payload.url;
+      // getShareUrl() rebuilds the link from the catalogue id when payload.url
+      // is absent, which it always is on a library item.
+      trackUrl = getShareUrl(payload);
     }
 
     // A track change supersedes an earlier pause, so the pending clear-activity

--- a/src/integrations/lastfm/index.ts
+++ b/src/integrations/lastfm/index.ts
@@ -30,6 +30,7 @@ const lastfmLog = log.scope('lastfm');
 
 let stateChangedCallback: (() => void) | null = null;
 
+/** Sets or clears the UI refresh callback for authentication and disconnects. */
 export function setStateChangedCallback(callback: (() => void) | null): void {
   stateChangedCallback = callback;
 }
@@ -38,17 +39,10 @@ const API_ROOT = 'https://ws.audioscrobbler.com/2.0/';
 const AUTH_URL = 'https://www.last.fm/api/auth/';
 
 /**
- * Resolves the app-level Last.fm API credentials. These identify the Sidra
- * application to Last.fm (not the user - each user authenticates their own
- * account via the browser flow). Resolution order:
- *
- * 1. `SIDRA_LASTFM_API_KEY` / `SIDRA_LASTFM_API_SECRET` env vars - for local dev.
- * 2. `assets/lastfm-credentials.json` - written at build time by
- *    `scripts/inject-lastfm-credentials.cjs` from CI secrets, so the real secret
- *    ships only in official builds and never lives in the public source tree.
- *
- * Absent both, the credentials are empty and the integration stays inert (the
- * tray hides the Last.fm menu via `isConfigured()`).
+ * Reads application credentials from SIDRA_LASTFM_API_KEY/SIDRA_LASTFM_API_SECRET,
+ * then assets/lastfm-credentials.json, which scripts/inject-lastfm-credentials.cjs generates at build time.
+ * These identify Sidra, not the user, and stay outside the public source tree.
+ * Missing credentials disable the integration and hide its menu through isConfigured().
  */
 function loadCredentials(): { apiKey: string; apiSecret: string } {
   const envKey = process.env.SIDRA_LASTFM_API_KEY;
@@ -88,8 +82,7 @@ const MAX_PENDING_SCROBBLES = 50;
 // scrobble or hold a queued-scrobble drain open for the life of the session.
 const REQUEST_TIMEOUT_MS = 30_000;
 
-// Authentication poll: Last.fm has no callback, so poll auth.getSession until the
-// user approves the token in their browser, then give up.
+// Last.fm has no desktop auth callback. Poll until approval or the timeout.
 const AUTH_POLL_INTERVAL_MS = 4000;
 const AUTH_POLL_TIMEOUT_MS = 120_000;
 
@@ -134,17 +127,9 @@ function toCount(value: number | string | undefined): number {
 }
 
 /**
- * Reads what Last.fm actually stored out of a track.scrobble body, or null when
- * the body carries no `scrobbles` field at all.
- *
- * Filtering is not an error. A batch Last.fm kept nothing from still answers
- * `status: ok` with no `error` field, so it settles on the success path and
- * cannot be told from a batch stored whole unless the body is read. That is the
- * only reason this exists.
- *
- * The null return is what keeps a body without the field reported exactly as it
- * always was: reading an absent field as zero accepted would report a loss for
- * every response that merely does not carry the counts.
+ * Reads accepted and filtered counts from a successful track.scrobble response.
+ * Filtering carries no API error, so only these fields reveal rejected plays.
+ * Returns null for an absent `scrobbles` field, because missing counts do not mean zero accepted plays.
  */
 function readScrobbleOutcome(res: LastfmResponse): ScrobbleOutcome | null {
   const scrobbles = res.scrobbles;
@@ -172,31 +157,10 @@ function readScrobbleOutcome(res: LastfmResponse): ScrobbleOutcome | null {
 // account's Applications settings looks like. No retry can recover it.
 const INVALID_SESSION_ERROR = 9;
 
-// The Last.fm codes that answer about something other than the play. Two
-// classes sit here. The state of the service: 8 "Operation failed - Most likely
-// the backend service failed. Please try again.", 11 "Service Offline - This
-// service is temporarily offline. Try again later.", 16 "The service is
-// temporarily unavailable, please try again." and 29 "Rate Limit Exceded". The
-// state of Sidra's own application credential: 10 "Invalid API key - You must
-// be granted a valid key by last.fm" and 26 "API Key Suspended - This
-// application is not allowed to make requests to the web services", which the
-// track.scrobble page words as "Suspended API key - Access for your account has
-// been suspended, please contact Last.fm". Neither is anything the user can
-// fix, and Last.fm can restore a rejected key server-side exactly as it can
-// lift a suspension: `active()` gates every request on `isConfigured()`, so a
-// build shipped without credentials never makes a request at all and code 10
-// can only mean a key that is present was rejected. None of the six means the
-// play was seen and refused, so the play is held exactly as one the network
-// never delivered is. Every other code answers about this play and is final.
-//
-// None of them can be provoked by the contents of a batch either, which is what
-// keeps a held batch from blocking the queue: the condition belongs to the
-// service or to the credential, and it clears when that does. While the
-// credential is rejected no request can succeed, so the queue neither drains
-// nor blocks anything; `queueScrobble()` evicts oldest-first, so it stays a
-// rolling window of the newest 50 plays. No timer retries either: a drain only
-// rides on the success path of a request the user's playback triggered. See
-// `flushPendingScrobbles()`.
+// Service failures (8, 11, 16, 29) and rejected application keys (10, 26) do not
+// refuse the play itself, and Last.fm can restore service or keys without user action.
+// Batch contents cannot cause these failures, so retain plays in the bounded queue
+// until a successful playback request calls flushPendingScrobbles(), never a retry timer.
 const RETRIABLE_ERRORS = new Set([8, 10, 11, 16, 26, 29]);
 
 /** An error the Last.fm API reported in its response body, with its code intact. */
@@ -242,8 +206,8 @@ export function signParams(params: Record<string, string>, secret: string): stri
 }
 
 /**
- * Returns the play time after which a track should be scrobbled, or null if the
- * track is too short to ever scrobble.
+ * Returns the required play time in milliseconds, or null for tracks of 30 seconds or less.
+ * A non-positive duration is unknown and uses the four-minute fallback.
  */
 export function scrobbleThresholdMs(durationMs: number): number | null {
   if (durationMs > 0 && durationMs <= MIN_TRACK_LENGTH_MS) return null;
@@ -374,9 +338,8 @@ function clearScrobbleTimer(): void {
 }
 
 /**
- * Banks the time played since the last resume. Every path that stops counting
- * play time goes through this, so the running total survives a pause and a
- * disable alike and the scrobble threshold is measured against real listening.
+ * Adds elapsed time since resume for normal tracks before a pause or disable.
+ * Radio time comes from position advances, so wall time never increases its total.
  */
 function foldPlayTime(): void {
   if (lastResumeAt === null) return;
@@ -403,7 +366,7 @@ function cancelAuth(): void {
   authInProgress = false;
 }
 
-/** The session and the track a request path may use, once `active()` has passed. */
+/** Validated session and track fields for a playback request. */
 interface ActiveTrack {
   sessionKey: string;
   artist: string;
@@ -413,14 +376,8 @@ interface ActiveTrack {
 }
 
 /**
- * The single gate every request path checks: credentials in the build, the
- * feature on, an account connected, and a track worth naming. A build without
- * credentials therefore never reaches Last.fm at all.
- *
- * The session key and the track fields are handed back rather than left for the
- * caller to read again, because tsc cannot see through a boolean gate: every
- * call site carried a non-null assertion on the very values this had just
- * checked. Returning them makes the check and the narrowing one thing.
+ * Allows playback requests only with application credentials, an enabled integration, a session and named track metadata.
+ * Returns the validated fields so callers need no non-null assertions.
  */
 function active(): ActiveTrack | null {
   if (!isConfigured() || !getLastfmEnabled()) return null;
@@ -430,26 +387,9 @@ function active(): ActiveTrack | null {
 }
 
 /**
- * Disconnects the account when Last.fm rejects the session key, and reports it.
- * Returns true once the error is handled, so callers skip their own logging.
- *
- * Without this the session stays set, nothing retries, and the tray still shows
- * the account as connected: scrobbling is dead and the UI says otherwise.
- *
- * The rejection only counts against the session the request went out under,
- * which is why the caller passes in the generation it captured rather than
- * reading anything stored again here. A second request in flight when the first
- * is refused belongs to a session that is already gone, so it settles here
- * silently and the user sees one notification. A refusal that arrives after the
- * user has reconnected belongs to the old session too, so it cannot tear down
- * the session that replaced it.
- *
- * The generation is the gate rather than the session key because Last.fm hands
- * back the same key when the same account reconnects. Comparing keys let such a
- * refusal pass as current: it disconnected the session the user had just
- * established and emptied the queue with it. The generation moves at both
- * writers of the stored key, so an equal generation means the session that sent
- * the request is still the one connected.
+ * Disconnects and reports an invalid current session, returning true to prevent duplicate logging.
+ * Ignores stale refusals so concurrent failures notify once and cannot disconnect a replacement session.
+ * Compares generations because Last.fm can return the same key when an account reconnects.
  */
 function handleInvalidSession(err: unknown, generation: number): boolean {
   if (!(err instanceof LastfmApiError) || err.code !== INVALID_SESSION_ERROR) return false;
@@ -461,16 +401,8 @@ function handleInvalidSession(err: unknown, generation: number): boolean {
 }
 
 /**
- * Holds a play the network stopped from reaching Last.fm. The queue is
- * persisted, so it survives the restart that a dropped connection often ends
- * in, and the newest entries win once it is full: an old play is the one the
- * user is least likely to miss.
- *
- * A trim made while a drain is in flight is counted, because it takes an entry
- * off the head that the drain has already submitted and is about to remove
- * again. Only a drain from the session still connected counts: one from an
- * account that has gone removes nothing, so a trim against it would be
- * subtracted from a batch that is never dropped.
+ * Persists an undelivered play, retaining the newest MAX_PENDING_SCROBBLES entries across restarts.
+ * Counts head trims during the current session's drain so dropSubmitted() does not remove newer plays twice.
  */
 function queueScrobble(entry: PendingScrobble): void {
   const queued = [...getPendingScrobbles(), entry];
@@ -492,32 +424,10 @@ function dropSubmitted(count: number): void {
 }
 
 /**
- * Runs every check a drain must pass, in the order it must pass them, and
- * returns the batch to submit or null when one of them stops it. Nothing is
- * claimed here: the caller marks the drain, so the checks stay free of side
- * effects.
- *
- * Off is an instruction to stop sending. Nothing cancels a request already out,
- * so one that left while the feature was on can settle after the toggle and
- * carry the whole queue to Last.fm from here. The check belongs in the drain
- * rather than at its callers, so every path into it is covered. The plays stay
- * queued: the user consented to them when they played them, and they go out if
- * the feature is turned back on.
- *
- * A drain from a generation that has moved on is left where it is: it never
- * reaches `dropSubmitted()`, so it cannot collide with this one, and `null`
- * never matches a generation.
- *
- * The batch is capped at the 50 Last.fm accepts in a single track.scrobble
- * request. Anything past that stays on the queue and goes out with the next
- * drain: nothing here is scheduled, so a longer queue clears over as many
- * requests as the user's own playback triggers. Sending it whole would be
- * refused, losing the backlog to a final error and resending the same over-long
- * batch forever when the request never reached Last.fm at all.
- *
- * The session key is passed in by the caller and checked against the stored one
- * because a drain signed with a key the user has since replaced belongs to
- * nobody.
+ * Returns an eligible batch without claiming the drain or changing the queue.
+ * Requires an enabled integration and matching session key, since an earlier request can settle after disable or reconnect.
+ * Only a current-generation drain blocks another batch, because stale drains cannot remove current entries.
+ * Caps each request at Last.fm's 50-play limit, leaving any excess for later playback-triggered drains.
  */
 function drainGuard(sessionKey: string): PendingScrobble[] | null {
   if (!getLastfmEnabled()) return null;
@@ -595,8 +505,7 @@ function onDrainFailed(err: Error, batch: PendingScrobble[], generation: number)
     if (!handleInvalidSession(err, generation)) {
       lastfmLog.warn('queued scrobbles refused, dropped:', err.message);
     }
-    // `handleInvalidSession()` may have disconnected, which empties the
-    // queue and moves the generation on; either way the batch is gone.
+    // An invalid session clears the queue and advances the generation.
     if (generation === sessionGeneration) dropSubmitted(batch.length);
     return;
   }
@@ -667,29 +576,10 @@ function sendNowPlaying(): void {
 }
 
 /**
- * True when live playback confirms the track really reached its scrobble
- * threshold.
- *
- * A committed document navigation resets `Player`, which cancels the timer
- * through its playback-state event. This check remains a defence against a
- * missing or malformed renderer event. If playback stops without a valid state
- * event, the wall-clock timer stays armed and `Player` keeps its last snapshot.
- * Re-reading that snapshot prevents a track abandoned before its threshold
- * from earning play time while idle.
- *
- * The playhead belongs to the player, not to the track held here, so it is only
- * trusted once a position report has arrived for this track: `positionReported`
- * is cleared with the rest of the track state. Without it, a metadata event can
- * announce a new track while a missing or malformed position event leaves the
- * previous track's playhead cached. A short track could then scrobble without
- * playing. The stale value does not count until the new track reports a valid
- * position.
- *
- * The comparison is absolute rather than a delta against the position sampled
- * when the timer was armed. A delta cannot work: a track abandoned after some
- * real playback has moved its playhead, and repeat-one re-arms on the play
- * transition that precedes the first position report of the new loop, so the
- * baseline would be the end of the previous loop.
+ * Requires live playback and position evidence before a timer can submit a play.
+ * Normal tracks need a position report for this track, excluding cached positions from the previous item.
+ * Their threshold uses absolute position, because repeat-one can arm before the new loop's first position report.
+ * Radio instead requires recent continuous advances and enough accumulated play time, never the station's absolute playhead or stalled wall time.
  */
 function playbackReachedThreshold(): boolean {
   const snapshot = playerRef?.playbackSnapshot();
@@ -757,21 +647,9 @@ function doScrobble(): void {
   if (current.durationMs > 0) entry.durationSec = Math.round(current.durationMs / 1000);
   if (isRadioSong) entry.chosenByUser = 0;
 
-  // A refusal is final for this track. `scrobbled` stays set, so the track is
-  // submitted once and once only. Clearing it re-opened the submission without
-  // re-arming anything, so the only way back to a request was the user pausing
-  // and resuming; a retry that fires on a failed submission is a retry loop,
-  // and the remaining time it would wait comes from `accumulatedMs`, which is
-  // only folded at pause and so means nothing mid-play.
-  //
-  // A transport failure says nothing about the track: Last.fm never saw it. So
-  // does a temporary service error, which answers about the service and leaves
-  // the play unrecorded. The play goes on the queue instead, and leaves with the
-  // next request playback triggers. `scrobbled` still stays set, because a
-  // queued play counts as submitted and nothing here re-arms. It is only queued
-  // while the account that listened is still connected: the queue is drained
-  // under whichever key is stored when it goes out, so queuing past a
-  // disconnect would hand this play to the next account.
+  // Keep scrobbled set after submission, including failures, to prevent resubmission on resume.
+  // submitScrobble() queues non-final failures only for the same session.
+  // A later playback request drains the queue without a retry timer.
   submitScrobble(entry, sessionKey, generation);
 }
 
@@ -976,8 +854,7 @@ export function startAuth(onComplete?: () => void): void {
       if (generation !== authGeneration) return;
       const token = res.token;
       if (!token) throw new Error('no token returned');
-      // URLSearchParams percent-encodes both values. Interpolating them left a
-      // token carrying `&` or `#` to rewrite or truncate the query.
+      // Percent-encode both values so token characters cannot change the query structure.
       const url = new URL(AUTH_URL);
       url.searchParams.set('api_key', API_KEY);
       url.searchParams.set('token', token);
@@ -1061,9 +938,8 @@ export function disconnect(): void {
 }
 
 /**
- * Subscribes to the three player events scrobbling needs, and releases them on
- * `will-quit`. The module runs on every platform and stays inert without
- * credentials, so no gate keeps it out of a build.
+ * Subscribes to track, radio metadata, playback state and position events on every platform.
+ * Releases listeners on will-quit and makes no requests without application credentials.
  */
 export function init(ctx: IntegrationContext): void {
   playerRef = ctx.player;
@@ -1111,8 +987,8 @@ export function init(ctx: IntegrationContext): void {
     }
   };
 
-  // Stores a flag only, and starts nothing: a debounced send from this event
-  // would reset its own timer on every position report and never expire.
+  // Normal tracks mark the playhead as current. Radio counts continuous advances
+  // and confirms song boundaries here, since wall time cannot prove stream playback.
   const onPlaybackTimeDidChange = (positionUs: number): void => {
     positionReported = true;
     const now = Date.now();

--- a/src/integrations/macos-dock/index.ts
+++ b/src/integrations/macos-dock/index.ts
@@ -59,7 +59,7 @@ function buildDockMenu(
   return Menu.buildFromTemplate(items);
 }
 
-/** Installs the macOS dock menu and progress bar; no-op on every other platform. */
+/** Installs the dock menu and progress bar on macOS only. */
 export function init(ctx: IntegrationContext): void {
   if (process.platform !== 'darwin') return;
 
@@ -92,7 +92,7 @@ export function init(ctx: IntegrationContext): void {
 
   const dockPauseTimer = createPauseEdgeTimer(DOCK_PAUSE_TIMEOUT_MS, clearNowPlaying);
 
-  // Named listener references for removeListener in will-quit
+  // Named listeners let will-quit remove the same function references.
   const onNowPlayingItemDidChange = (payload: NowPlayingPayload | null): void => {
     dockPauseTimer.cancel();
     currentPayload = payload;
@@ -134,13 +134,11 @@ export function init(ctx: IntegrationContext): void {
     player.removeListener('nowPlayingItemDidChange', onNowPlayingItemDidChange);
     player.removeListener('playbackStateDidChange', onPlaybackStateDidChange);
     player.removeListener('playbackTimeDidChange', onPlaybackTimeDidChange);
-    // The 30 second timer outlives the listeners, and clearNowPlaying() calls
-    // app.dock.setMenu(), so a pending one fires into a torn-down dock.
+    // Cancel the timer before clearNowPlaying() can call a torn-down dock.
     dockPauseTimer.destroy();
   });
 
-  // The menu must exist before playback starts, so the dock carries the
-  // Not Playing entry from launch rather than nothing at all
+  // Show Not Playing from launch, before any player event arrives.
   rebuildDock(false);
   dockLog.info('dock menu initialised');
 }

--- a/src/integrations/mpris/index.ts
+++ b/src/integrations/mpris/index.ts
@@ -8,7 +8,7 @@ import { getServiceByHost } from '../../musicService';
 import { getMusicService } from '../../config';
 import { switchService } from '../../serviceSwitch';
 
-// @holusion/dbus-next is lazy-required because the MPRIS module only loads on Linux
+// main.ts loads this module only on Linux, keeping dbus-next off other platforms.
 const dbus = require('@holusion/dbus-next');
 const {
   Interface,
@@ -76,32 +76,39 @@ function logCommand(method: MprisMethod, result: 'sent' | 'dropped', channel?: R
 class MediaPlayer2 extends Interface {
   private _getMainWindow: () => BrowserWindow | null;
 
+  /** Creates the root interface with a current-window lookup. */
   constructor(getMainWindow: () => BrowserWindow | null) {
     super('org.mpris.MediaPlayer2');
     this._getMainWindow = getMainWindow;
   }
 
+  /** Returns the application name shown by media clients. */
   get Identity(): string {
     return app.getName();
   }
 
+  /** Returns the desktop entry name without its .desktop suffix. */
   get DesktopEntry(): string {
     return app.getName().toLowerCase();
   }
 
+  /** Reports that clients can quit Sidra. */
   get CanQuit(): boolean {
     return true;
   }
 
+  /** Reports that clients can bring Sidra to the foreground. */
   get CanRaise(): boolean {
     return true;
   }
 
+  /** Reads fullscreen state from the current window. */
   get Fullscreen(): boolean {
     const win = this._getMainWindow();
     return win && !win.isDestroyed() ? win.isFullScreen() : false;
   }
 
+  /** Applies fullscreen state if the window is available. */
   set Fullscreen(value: boolean) {
     const win = this._getMainWindow();
     if (win && !win.isDestroyed()) {
@@ -112,22 +119,27 @@ class MediaPlayer2 extends Interface {
     }
   }
 
+  /** Reports support for changing fullscreen state. */
   get CanSetFullscreen(): boolean {
     return true;
   }
 
+  /** Reports that Sidra exposes no MPRIS TrackList interface. */
   get HasTrackList(): boolean {
     return false;
   }
 
+  /** Reports no MIME-type-based opening support. */
   get SupportedMimeTypes(): string[] {
     return [];
   }
 
+  /** Advertises HTTPS for validated service URLs. */
   get SupportedUriSchemes(): string[] {
     return ['https'];
   }
 
+  /** Shows and focuses the current window. */
   Raise(): void {
     const win = this._getMainWindow();
     if (win) {
@@ -139,6 +151,7 @@ class MediaPlayer2 extends Interface {
     }
   }
 
+  /** Requests application shutdown. */
   Quit(): void {
     app.quit();
     logCommand('Quit', 'sent');
@@ -222,8 +235,7 @@ function buildMetadata(payload: NowPlayingPayload): Record<string, InstanceType<
   };
 
   if (payload.durationInMillis != null) {
-    // Convert milliseconds to microseconds (int64); truncated because the 'x'
-    // marshaller throws on a fractional value
+    // Truncate microseconds because the D-Bus 'x' marshaller rejects fractional values.
     metadata['mpris:length'] = new Variant('x', Math.trunc(payload.durationInMillis * MS_TO_US));
   }
 
@@ -321,6 +333,7 @@ class MediaPlayer2Player extends Interface {
   private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private _pendingChanges: Record<string, unknown> = {};
 
+  /** Initialises cached capabilities and the ready hook URL. */
   constructor(getMainWindow: () => BrowserWindow | null, capabilities: PlaybackCapabilities, readyUrl: string | null) {
     super('org.mpris.MediaPlayer2.Player');
     this._getMainWindow = getMainWindow;
@@ -368,6 +381,7 @@ class MediaPlayer2Player extends Interface {
 
   // --- Update methods (called by player event handlers) ---
 
+  /** Publishes changed capabilities and refreshes the current track length. */
   updateCapabilities(capabilities: PlaybackCapabilities): void {
     const previous = this._capabilities;
     this._capabilities = capabilities;
@@ -388,6 +402,7 @@ class MediaPlayer2Player extends Interface {
     else this._metadata['mpris:length'] = new Variant('x', lengthUs);
   }
 
+  /** Maps MusicKit state to MPRIS while preserving an acknowledged Stop. */
   updatePlaybackStatus(payload: PlaybackStatePayload): void {
     if (!payload) return;
     if (payload.state === PlaybackState.Playing) {
@@ -395,12 +410,9 @@ class MediaPlayer2Player extends Interface {
       this._stopped = false;
     }
 
-    // Only Playing and Paused have an MPRIS value of their own. Every other
-    // MusicKit state falls through to 'Stopped', the transient ones (loading,
-    // seeking, waiting, stalled) included, so MPRIS always reports the state
-    // the player is in. Do not add early returns for the transient states, and
-    // do not map Stopped to 'Paused', which shows clients a pause button for a
-    // player that has stopped.
+    // An acknowledged Stop stays Stopped until play resumes or the track changes.
+    // All states except Playing and ordinary Paused, including transient states,
+    // map to Stopped so clients do not show controls for the previous state.
     let status: string;
     if (payload.state === PlaybackState.Playing) {
       status = 'Playing';
@@ -473,6 +485,7 @@ class MediaPlayer2Player extends Interface {
     }
   }
 
+  /** Updates radio song labels without replacing station identity or position. */
   updateTimedMetadata(payload: TimedMetadataPayload): void {
     if (!this._radioStation) return;
     const url = getShareUrl({ ...payload, sourceHost: this._radioStation.sourceHost }) ?? getShareUrl(this._radioStation);
@@ -493,6 +506,7 @@ class MediaPlayer2Player extends Interface {
     this._schedulePropertyEmission({ Metadata: metadata });
   }
 
+  /** Maps a recognised MusicKit repeat mode to MPRIS LoopStatus. */
   updateRepeatMode(payload: number | null): void {
     if (payload == null) return;
 
@@ -511,6 +525,7 @@ class MediaPlayer2Player extends Interface {
     this._schedulePropertyEmission({ LoopStatus: loopStatus });
   }
 
+  /** Publishes whether MusicKit shuffle is enabled. */
   updateShuffleMode(payload: number | null): void {
     if (payload == null) return;
 
@@ -519,6 +534,7 @@ class MediaPlayer2Player extends Interface {
     this._schedulePropertyEmission({ Shuffle: shuffle });
   }
 
+  /** Publishes in-app volume changes while suppressing pending control echoes. */
   updateVolume(payload: number | null): void {
     if (payload == null) return;
 
@@ -541,6 +557,7 @@ class MediaPlayer2Player extends Interface {
     this._schedulePropertyEmission({ Volume: rounded });
   }
 
+  /** Caches microseconds and signals seeks without scheduling property emissions. */
   updatePosition(payload: number): void {
     // dbus-next marshals an 'x' field with BigInt(data.toString()), which throws
     // on a fractional value, so truncate once here and let every consumer of the
@@ -582,64 +599,79 @@ class MediaPlayer2Player extends Interface {
 
   // --- Read-only properties ---
 
+  /** Returns the cached MPRIS playback state. */
   get PlaybackStatus(): string {
     return this._playbackStatus;
   }
 
+  /** Returns the cached track metadata as D-Bus variants. */
   get Metadata(): Record<string, InstanceType<typeof Variant>> {
     return this._metadata;
   }
 
+  /** Returns the cached playhead in integer microseconds. */
   get Position(): number {
     return Math.trunc(this._position);
   }
 
+  /** Reports normal speed as the minimum supported rate. */
   get MinimumRate(): number {
     return 1.0;
   }
 
+  /** Reports normal speed as the maximum supported rate. */
   get MaximumRate(): number {
     return 1.0;
   }
 
+  /** Advertises support for the next-track command. */
   get CanGoNext(): boolean {
     return true;
   }
 
+  /** Advertises support for the previous-track command. */
   get CanGoPrevious(): boolean {
     return true;
   }
 
+  /** Returns the latest validated play capability. */
   get CanPlay(): boolean {
     return this._capabilities.canPlay;
   }
 
+  /** Returns the latest validated pause capability. */
   get CanPause(): boolean {
     return this._capabilities.canPause;
   }
 
+  /** Allows seeking unless the renderer explicitly disables it. */
   get CanSeek(): boolean {
     return this._capabilities.canSeek !== false;
   }
 
+  /** Advertises support for player control. */
   get CanControl(): boolean {
     return true;
   }
 
   // --- Read/write properties ---
 
+  /** Reports normal playback speed. */
   get Rate(): number {
     return 1.0;
   }
 
+  /** Treats zero as pause and ignores other rate changes. */
   set Rate(value: number) {
     if (value === 0) this._send('Rate', 'player:pause');
   }
 
+  /** Returns the cached MPRIS repeat mode. */
   get LoopStatus(): string {
     return this._loopStatus;
   }
 
+  /** Maps a valid MPRIS repeat mode to MusicKit. */
   set LoopStatus(value: string) {
     const loopToMusicKit: Record<string, number> = {
       'None': 0,
@@ -655,30 +687,31 @@ class MediaPlayer2Player extends Interface {
     this._send('LoopStatus', 'player:setRepeat', mode);
   }
 
+  /** Returns the cached shuffle setting. */
   get Shuffle(): boolean {
     return this._shuffle;
   }
 
+  /** Sends the shuffle setting to MusicKit. */
   set Shuffle(value: boolean) {
     this._shuffle = value;
     const mode = value ? 1 : 0;
     this._send('Shuffle', 'player:setShuffle', mode);
   }
 
+  /** Returns cached software volume rounded to two decimal places. */
   get Volume(): number {
     return Math.round(this._volume * 100) / 100;
   }
 
+  /** Clamps software volume and records pending echoes before sending it. */
   set Volume(value: number) {
     const clamped = Math.round(Math.max(0.0, Math.min(1.0, value)) * 100) / 100;
     this._volume = clamped;
     this._schedulePropertyEmission({ Volume: clamped });
-    // The queue is bounded, and a full one drops the value being added rather
-    // than the oldest entry. Echoes arrive in order, so the oldest entry is the
-    // one the next echo matches; discarding it makes that echo read as an
-    // in-app change and drag the cached volume back to a value the drag left
-    // behind. An untracked newest value costs nothing instead: its echo matches
-    // nothing and writes the level the player has actually reached.
+    // Preserve old entries when full because echoes arrive in order. Dropping
+    // the oldest makes its echo look like an in-app change and restores stale volume.
+    // An untracked newest echo instead reports the level that the player reached.
     if (this._pendingVolumes.length < MAX_PENDING_VOLUMES) {
       this._pendingVolumes.push(clamped);
     }
@@ -694,22 +727,27 @@ class MediaPlayer2Player extends Interface {
 
   // --- Methods ---
 
+  /** Requests the next queue item. */
   Next(): void {
     this._send('Next', 'player:next');
   }
 
+  /** Requests the previous queue item. */
   Previous(): void {
     this._send('Previous', 'player:previous');
   }
 
+  /** Requests a playback pause. */
   Pause(): void {
     this._send('Pause', 'player:pause');
   }
 
+  /** Requests a play/pause toggle. */
   PlayPause(): void {
     this._send('PlayPause', 'player:playPause');
   }
 
+  /** Requests Stop once and waits for acknowledgement with a bounded timeout. */
   Stop(): void {
     if (this._stopped || this._pendingStopId !== null) return;
     this._pendingStopId = ++this._stopRequestId;
@@ -726,6 +764,7 @@ class MediaPlayer2Player extends Interface {
     this._stopTimer = null;
   }
 
+  /** Publishes Stopped only after the matching successful acknowledgement. */
   updateStopped(payload: PlaybackStopped): void {
     if (payload.requestId !== this._pendingStopId) return;
     this._clearPendingStop();
@@ -735,10 +774,12 @@ class MediaPlayer2Player extends Interface {
     this._schedulePropertyEmission({ PlaybackStatus: 'Stopped' });
   }
 
+  /** Requests playback start or resume. */
   Play(): void {
     this._send('Play', 'player:play');
   }
 
+  /** Seeks by a microsecond offset, advancing tracks when the target exceeds known duration. */
   Seek(offset: bigint): void {
     if (!this.CanSeek || !Number.isSafeInteger(this._position)) return;
     const targetUs = BigInt(this._position) + offset;
@@ -751,6 +792,7 @@ class MediaPlayer2Player extends Interface {
     this._send('Seek', 'player:seek', Number(targetUs < 0n ? 0n : targetUs) / 1_000_000);
   }
 
+  /** Seeks to valid microseconds only when the supplied track ID matches. */
   SetPosition(trackId: string, position: bigint): void {
     if (trackId === NO_TRACK || trackId !== this._currentTrackId) {
       mprisLog.debug('SetPosition trackId mismatch, ignoring');
@@ -768,6 +810,7 @@ class MediaPlayer2Player extends Interface {
     return typeof length === 'number' && Number.isSafeInteger(length) && length >= 0 ? length : undefined;
   }
 
+  /** Opens a validated service URL, navigating first when its hook is not ready. */
   OpenUri(uri: string): void {
     const parsed = parseServiceUri(uri);
     if (!parsed) {
@@ -803,6 +846,7 @@ class MediaPlayer2Player extends Interface {
     this._openUriTimer = null;
   }
 
+  /** Dispatches a pending URL only after its navigation target reports hook readiness. */
   updateHookReady(url: string | null): void {
     this._readyUrl = this._navigating ? null : url;
     const pending = this._pendingOpenUri;
@@ -811,6 +855,7 @@ class MediaPlayer2Player extends Interface {
     this._send('OpenUri', 'player:openUri', pending.url);
   }
 
+  /** Invalidates replaced-document readiness and cancels unrelated pending URL requests. */
   navigationStarted(url: string, sameDocument: boolean): void {
     if (!sameDocument) {
       this._readyUrl = null;
@@ -819,6 +864,7 @@ class MediaPlayer2Player extends Interface {
     if (this._pendingOpenUri && parseServiceUri(url)?.href !== this._pendingOpenUri.navigationUrl) this._clearOpenUri();
   }
 
+  /** Tracks same-service redirects and cancels pending requests that leave the service. */
   navigationRedirected(url: string): void {
     const pending = this._pendingOpenUri;
     if (!pending) return;
@@ -827,11 +873,12 @@ class MediaPlayer2Player extends Interface {
     else this._clearOpenUri();
   }
 
+  /** Marks document navigation complete so hook readiness can be accepted. */
   navigationCommitted(): void {
     this._navigating = false;
   }
 
-  // Signal - declared via configureMembers, calling this method emits on D-Bus
+  /** Emits the D-Bus Seeked signal through configureMembers, with a position in microseconds. */
   Seeked(_position: number): number {
     return _position;
   }
@@ -1006,8 +1053,7 @@ export function init(ctx: IntegrationContext): void {
     }
   };
 
-  // Named wrappers, because `will-quit` has to hand removeListener the same
-  // function reference; an inline handler could never be detached.
+  // Named wrappers let will-quit detach the same function references.
   const onPlaybackStateDidChange = (payload: PlaybackStatePayload): void => {
     playerIface.updatePlaybackStatus(payload);
   };
@@ -1059,13 +1105,9 @@ export function init(ctx: IntegrationContext): void {
 
   mprisLog.info('enabling MPRIS service');
 
-  // A session bus is not guaranteed to exist. dbus-next falls through to
-  // getDbusAddressFromFs(), which throws synchronously when
-  // DBUS_SESSION_BUS_ADDRESS is unset; containers, bare X and su-launched
-  // sessions all hit it. Catching it here reports a missing bus as the ordinary
-  // condition it is, rather than letting an exception stand in for it, and the
-  // return leaves the export and the player subscriptions below undone. Losing
-  // MPRIS is the correct outcome, and the connection is not retried.
+  // Without DBUS_SESSION_BUS_ADDRESS, dbus-next can throw while reading the bus
+  // address from disk. Disable MPRIS without exports, subscriptions or retries
+  // when no session bus exists, as in containers or su-launched sessions.
   try {
     bus = dbus.sessionBus();
   } catch (err: unknown) {

--- a/src/integrations/notifications/index.ts
+++ b/src/integrations/notifications/index.ts
@@ -55,15 +55,13 @@ async function showNotification(
   }
   const title = payload.name;
 
-  // Checked before the artwork download so a daemon-less session does no
-  // network and disk work per track
+  // Check availability before downloading artwork to avoid unused network and disk work.
   if (!notificationsAvailable()) {
     notifLog.debug('skipping notification: no notification daemon');
     return;
   }
 
-  // A slow artwork fetch must not hold the notification past the track it
-  // announces, so the download races a timeout and loses its icon on expiry
+  // Bound the artwork wait so a slow fetch cannot delay the track notification indefinitely.
   const artworkPath = payload.artworkUrl
     ? await Promise.race([
         downloadArtwork(payload.artworkUrl).catch((error: unknown) => {
@@ -210,8 +208,8 @@ async function showNotification(
 }
 
 /**
- * Announces each new track as a desktop notification. The debounce keeps a
- * queue jump or a burst of metadata updates to a single notification.
+ * Announces tracks and radio song labels, coalescing bursts through a debounce.
+ * Refreshes playback actions from player state and retires notifications on shutdown.
  */
 export function init(ctx: IntegrationContext): void {
   const { player, getMainWindow } = ctx;

--- a/src/integrations/windows-taskbar/index.ts
+++ b/src/integrations/windows-taskbar/index.ts
@@ -12,8 +12,7 @@ const taskbarLog = log.scope('taskbar');
 const iconsDir = getAssetPath('assets', 'icons');
 const menuIconsDir = path.join(iconsDir, 'tray', 'menu');
 
-// Transient states hold the overlay badge at its last value: each one lasts a
-// moment and clearing the badge for it makes the taskbar icon flicker
+// Keep the previous badge during transient states to prevent taskbar flicker.
 const TRANSIENT_STATES: ReadonlySet<number> = new Set([
   PlaybackState.Loading,
   PlaybackState.Seeking,
@@ -22,10 +21,8 @@ const TRANSIENT_STATES: ReadonlySet<number> = new Set([
 ]);
 
 function loadIcon(baseName: string): Electron.NativeImage | null {
-  // The thumbar and the overlay badge are painted on the taskbar, which follows
-  // the Windows system colour mode. shouldUseDarkColors reports the app colour
-  // mode, a separate setting, and a light app with a dark taskbar is the
-  // default on a fresh install.
+  // Taskbar icons follow the Windows system colour mode, not the separate app
+  // setting that shouldUseDarkColors reports.
   const variant = nativeTheme.shouldUseDarkColorsForSystemIntegratedUI ? 'dark' : 'light';
   const iconPath = path.join(menuIconsDir, variant, `${baseName}.png`);
   const img = nativeImage.createFromPath(iconPath);
@@ -78,7 +75,7 @@ function setOverlayIcon(win: BrowserWindow, state: number): void {
   }
 }
 
-/** Installs the taskbar thumbar buttons, overlay badge and progress bar; no-op off Windows. */
+/** Installs the thumbar buttons, overlay badge and progress bar on Windows only. */
 export function init(ctx: IntegrationContext): void {
   if (process.platform !== 'win32') return;
 
@@ -99,7 +96,7 @@ export function init(ctx: IntegrationContext): void {
     });
   }
 
-  // Named listener references for removeListener in will-quit
+  // Named listeners let will-quit remove the same function references.
   const onThemeUpdated = (): void => {
     const win = getMainWindow?.();
     if (!win) return;

--- a/src/itms.ts
+++ b/src/itms.ts
@@ -1,7 +1,5 @@
-// src/itms.ts
 // Pure parser for itms:// URLs delivered via OS protocol handler or argv.
-// No imports from electron, electron-log, or config: keep this module
-// dependency-free so it is trivially unit-testable.
+// Only the pure service registry is imported, so tests need no Electron runtime.
 
 import { MUSIC_SERVICES } from './musicService';
 
@@ -55,7 +53,6 @@ export function transformItmsUrl(input: string): ItmsTarget | null {
     return { kind: 'route', token };
   }
 
-  // Catalogue URL: rebuild as https, strip the `app` parameter.
   const rebuilt = new URL(`${MUSIC_SERVICES['music'].origin}/`);
   rebuilt.pathname = parsed.pathname;
   const params = new URLSearchParams(parsed.searchParams);

--- a/src/linuxNotifications.ts
+++ b/src/linuxNotifications.ts
@@ -13,6 +13,7 @@ const BUS_PATH = '/org/freedesktop/DBus';
 const DELIVERY_TIMEOUT_MS = 5000;
 const notificationLog = log.scope('linuxNotifications');
 
+/** Localised track content and actions for one replaceable desktop notification. */
 export interface TrackNotification {
   title: string;
   body: string;
@@ -28,7 +29,7 @@ interface BusInternals {
   _connection?: { stream?: { destroy: () => void } };
 }
 
-/** Linux-only delivery, loaded after the platform check in the integration. */
+/** Create serialised Linux notification delivery and cleanup, loaded only after the integration's platform check. */
 export function createLinuxNotifications() {
   let bus: MessageBus | null = null;
   let owner = '';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, components, ipcMain, Menu, session, Tray, webFrameMain } from 'electron';
+import { app, BrowserWindow, components, dialog, ipcMain, Menu, session, Tray, webFrameMain } from 'electron';
 import fs from 'fs';
 import path from 'path';
 import log from 'electron-log/main';
@@ -726,6 +726,17 @@ if (gotLock) {
         pendingItmsTarget = null;
       }
     });
+  }).catch((err: unknown) => {
+    // The splash is already on screen and setupSplashTransition() was never
+    // reached, so without this catch a startup failure leaves the splash up
+    // for the life of the process with no message.
+    mainLog.error('startup failed:', err);
+    const detail = err instanceof Error ? err.message : String(err);
+    dialog.showErrorBox(
+      'Sidra failed to start',
+      `Sidra could not finish starting.\n\n${detail}\n\nSee the Sidra log for details, then start Sidra again.`
+    );
+    app.quit();
   });
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,11 +111,8 @@ if (process.platform === 'darwin') process.env.TMPDIR = app.getPath('temp');
 // Use a platform-accurate Chrome UA, stripping Electron identifiers that
 // Apple Music detects and blocks. The platform component must be truthful
 // to match Sec-CH-UA-Platform Client Hints sent on every request.
-// The Chrome version is read from process.versions.chrome, so a CastLabs ECS bump
-// carries the UA with it and the two cannot drift; a hardcoded version stayed on
-// 144 while the pinned build moved to Chromium 148. Only the major is used, and
-// the other three components are always 0: Chrome's reduced UA freezes them there,
-// so this is the form real Chrome sends rather than a truncation of it.
+// Read the Chrome major from process.versions.chrome so CastLabs ECS updates
+// also update the UA. Chrome's reduced UA fixes the other components at 0.
 function chromeUA(): string {
   const version = `${process.versions.chrome.split('.')[0]}.0.0.0`;
   const webkit = 'AppleWebKit/537.36 (KHTML, like Gecko)';
@@ -139,8 +136,7 @@ let appTray: Tray | null = null;
 let isQuitting = false;
 app.on('before-quit', () => { isQuitting = true; });
 
-// Promoted to module scope so second-instance and pending-target handlers can
-// access the main window without threading it through closures.
+// Shared by second-instance and pending-target handlers.
 let win: BrowserWindow | null = null;
 let rendererDocumentGeneration = 0;
 
@@ -180,6 +176,7 @@ function routeItmsTarget(target: ItmsTarget | null): void {
   mainLog.info(`itms target routed: kind=${target.kind}`);
 }
 
+/** Local styles and scripts prepared for injection into service pages and authentication frames. */
 export interface Assets {
   STYLE_FIX_CSS: string;
   authFrameScript: string;
@@ -434,14 +431,9 @@ function setupWindowZoomAndNav(win: BrowserWindow): void {
   });
 }
 
-// Injects the MusicKit hook and then the navigation bar. Called from
-// did-finish-load and from did-navigate-in-page, which is why it never rejects:
-// in did-finish-load an escaping rejection skips markCssReady(), and that is the
-// only thing that dismisses the splash, so the app would show it for the life of
-// the process. Every await sits in its own try/catch, and the gate's getURL()
-// read is inside the first one because a destroyed webContents throws there.
-// A hook failure still injects the nav bar: back and forward buttons that work
-// beat none at all on a page whose media controls are already dead.
+// Contain injection failures in both full-load and in-page navigation handlers.
+// The URL read can throw after WebContents destruction, so it stays inside the catch.
+// Separate catches let navigation controls load even when the MusicKit hook fails.
 async function injectRendererScripts(win: BrowserWindow, assets: Assets, context: string): Promise<void> {
   try {
     const currentUrl = win.webContents.getURL();
@@ -464,9 +456,8 @@ async function injectRendererScripts(win: BrowserWindow, assets: Assets, context
 }
 
 function setupNavigationHandlers(win: BrowserWindow, player: Player): void {
-  // Keeps the main frame on Apple's hosts, so the preload command bridge and the
-  // injected hook can only ever reach Apple Music. Main-process loadURL() calls do
-  // not raise this event, so launch, service switching and itms:// routing are unaffected.
+  // Keep page-initiated main-frame navigation on registered service and authentication hosts.
+  // Main-process loadURL() calls bypass this event and need their own validated targets.
   win.webContents.on('will-navigate', (event, url) => {
     if (!isAllowedNavigationUrl(url)) {
       event.preventDefault();
@@ -554,9 +545,7 @@ function setupWindowEvents(win: BrowserWindow, markCssReady: () => void): void {
     event.preventDefault();
   });
 
-  // A single did-fail-load handler covers both error logging and splash
-  // dismissal. The first-fire markCssReady() call prevents the splash screen
-  // from hanging indefinitely when Apple Music fails to load.
+  // Release the CSS readiness wait on load failure without waiting for its timeout.
   let cssMarked = false;
   win.webContents.on('did-fail-load', (_event, errorCode, errorDescription) => {
     if (!cssMarked) {
@@ -568,7 +557,7 @@ function setupWindowEvents(win: BrowserWindow, markCssReady: () => void): void {
 
   // Apple Music registers a beforeunload handler while audio plays. Electron
   // shows no confirmation dialog, so the handler silently blocks close() and
-  // app.quit() with no error; overriding it here is what lets Sidra exit.
+  // app.quit() with no error. Overriding it here lets Sidra exit.
   win.webContents.on('will-prevent-unload', (event) => {
     event.preventDefault();
   });
@@ -614,10 +603,8 @@ function setupContentHandlers(win: BrowserWindow, player: Player, markCssReady: 
     initialized = true;
 
     if (firstLoad) {
-      // Integration failures are contained for the same reason: markCssReady()
-      // below is the only thing that dismisses the splash. Each initialiser is
-      // its own step, so a throw from one cannot cancel the rest for the
-      // lifetime of the process.
+      // Isolate initialisers so one failure cannot skip the others or delay
+      // markCssReady() until the splash timeout.
       runSteps([
         ['notifications', () => initNotifications({ player, getMainWindow: () => win })],
         ['discord', () => initDiscordPresence({ player })],
@@ -632,9 +619,7 @@ function setupContentHandlers(win: BrowserWindow, player: Player, markCssReady: 
         ['wedgeDetector', () => initWedgeDetector({ player, getMainWindow: () => win })],
         ['trayState', () => {
           if (!appTray) return;
-          // The returned closure is the teardown for all four resources it
-          // holds, so it must reach will-quit; called as a bare statement it
-          // would be discarded and every one of them would stay attached.
+          // Register teardown so the tray timers and player listeners end on quit.
           const teardownTrayState = initTrayStateManager(player, appTray);
           app.on('will-quit', teardownTrayState);
         }],

--- a/src/musicService.ts
+++ b/src/musicService.ts
@@ -1,6 +1,5 @@
-// src/musicService.ts
 // Pure music service registry: no imports from electron, electron-log, or config.
-// Kept dependency-free so itms.ts and tests can import without pulling in Electron.
+// The readiness selector is a pure constant, so importing this registry does not start Electron.
 
 import { CONTENT_READY_SELECTOR } from './contentReady';
 
@@ -29,7 +28,7 @@ export interface MusicService<PageId extends string = string> {
   defaultStartPage: PageId;
 }
 
-// PageId is inferred from startPages alone; NoInfer keeps defaultStartPage out of the inference,
+// PageId is inferred from startPages alone. NoInfer keeps defaultStartPage out of the inference,
 // so a typo there fails to compile instead of widening the union.
 function defineService<const PageId extends string>(
   def: Omit<MusicService<PageId>, 'defaultStartPage'> & { defaultStartPage: NoInfer<PageId> },
@@ -90,8 +89,7 @@ export function isMusicServiceId(value: string): value is MusicServiceId {
   return Object.hasOwn(MUSIC_SERVICES, value);
 }
 
-// Total at runtime as well as in the type. An id that escaped validation must not throw here:
-// every dereference is on the path that builds the tray, the app's only settings surface.
+/** Return the registered service, or the default if an unvalidated id reaches a UI caller. */
 export function getService(id: MusicServiceId): MusicService {
   return MUSIC_SERVICES[id] ?? MUSIC_SERVICES[DEFAULT_SERVICE_ID];
 }
@@ -106,18 +104,16 @@ export function allServices(): readonly MusicService[] {
   return Object.values(MUSIC_SERVICES);
 }
 
-// Derived from the registry so a new service or auth host widens the allowlist automatically.
+/** Service and authentication hosts derived from the registry for navigation checks. */
 export const ALLOWED_NAVIGATION_HOSTS: ReadonlySet<string> = new Set(
   allServices().flatMap(svc => [svc.host, ...svc.authFrameHosts]),
 );
 
-// Takes a URL string rather than a hostname so malformed input is rejected in one place.
-// URL.hostname is lowercased, punycoded and port-free, and the match is exact: a subdomain,
-// a suffix or a userinfo prefix of an allowed host is not an allowed host.
-// The scheme is checked too, because hostname alone does not imply a web origin: the parser
-// reads an authority out of any URL carrying '//', so 'javascript://music.apple.com/%0aalert(1)'
-// and 'file://music.apple.com/etc/passwd' both yield an allowed hostname. Apple serves both
-// services and the authentication flow over https, so nothing legitimate needs another scheme.
+/**
+ * Accept HTTPS URLs with an exact registered hostname, after URL normalisation.
+ * Hostname matching rejects subdomains and suffixes, but ignores ports and credentials.
+ * Check the scheme separately because non-web URLs can also contain an allowed hostname.
+ */
 export function isAllowedNavigationUrl(url: string): boolean {
   try {
     const parsed = new URL(url);

--- a/src/notificationDaemon.ts
+++ b/src/notificationDaemon.ts
@@ -31,7 +31,7 @@ interface DbusMessage {
   body?: unknown[];
 }
 
-// Module-level bus reference for graceful shutdown
+// Retain the bus so will-quit can release its socket.
 let bus: InstanceType<typeof dbus.MessageBus> | null = null;
 
 // dbus-next exposes no public API to fully close its socket, so the internal
@@ -74,10 +74,8 @@ function dbusCall(member: string, argument: string): Promise<DbusMessage | null>
 }
 
 /**
- * Report whether a notification daemon owns the name, once for the probe reply
- * and again on every later owner change. A session bus that cannot be opened,
- * which happens in containers and in su-launched sessions, leaves notifications
- * off for the session; the connection is not retried.
+ * Report notification-daemon ownership from the initial probe and subsequent owner changes.
+ * If the session bus cannot open, notifications remain off without a retry.
  */
 export function initDaemonProbe(onOwnerChange: (hasOwner: boolean) => void): void {
   try {

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -28,9 +28,8 @@ export function notificationsAvailable(): boolean {
 }
 
 /**
- * Open the gate on Linux once a notification daemon is confirmed, and follow it
- * for the rest of the session. Called once from app.whenReady(); a no-op on
- * every other platform.
+ * On Linux, follow notification-daemon ownership for the session.
+ * Call once from app.whenReady(). Other platforms need no probe.
  */
 export function initNotificationProbe(): void {
   if (process.platform !== 'linux') {

--- a/src/palettes.ts
+++ b/src/palettes.ts
@@ -11,8 +11,7 @@
 // - text and subtext0 reach 4.5:1 against base once the template applies
 //   its alpha. Catppuccin Latte holds its shipped 4.37:1 instead.
 //
-// Upstream palettes (colour values only; palettes are not creative
-// works, attribution given as a courtesy):
+// Upstream sources for palette colour values:
 // - Catppuccin (Mocha/Latte)  https://github.com/catppuccin/palette      MIT
 // - Dracula                   https://github.com/dracula/dracula-theme   MIT
 // - Everforest (Dark/Light)   https://github.com/sainnhe/everforest      MIT

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -20,6 +20,7 @@ interface PackageJson {
   license?: string;
 }
 
+/** Product details shared by the About window and tray. */
 export interface ProductInfo {
   productName: string;
   description: string;
@@ -30,14 +31,9 @@ export interface ProductInfo {
 let cachedProductInfo: ProductInfo | null = null;
 
 /**
- * Product details taken from package.json, which is the single source for the
- * About window and the tray. The author field keeps only the text before the
- * first '<', because the npm author form is 'Name <email> (url)' and the About
- * window shows the name alone. Cutting at the delimiter rather than deleting a
- * '<...>' match cannot leave part of a bracketed segment behind, which is what
- * CodeQL's incomplete-sanitization check flags about a single-pass replace. require() reads through the asar archive, so
- * package.json is loaded relative to the compiled output and needs no
- * asarUnpack entry, unlike everything getAssetPath() resolves.
+ * Read and cache product details from package.json and Electron's application name.
+ * Keep only author text before '<' so bracketed contact details cannot remain after a partial replacement.
+ * require() reads package.json through the asar archive, so it needs no asarUnpack entry.
  */
 export function getProductInfo(): ProductInfo {
   if (cachedProductInfo) {

--- a/src/pauseTimer.ts
+++ b/src/pauseTimer.ts
@@ -46,14 +46,8 @@ export interface PauseEdgeTimer extends PauseTimer {
 }
 
 /**
- * Build a timer that arms on the playing-to-paused edge only. Paused states
- * repeat, and start() discards the run in progress, so arming on each report
- * would push the clear-down further away every time and a paused player would
- * keep its Now Playing entries for ever.
- *
- * Every caller builds its own, because the retained previous value belongs to
- * that surface. One value shared between the tray and the dock would let a
- * report to either consume the edge the other was waiting for.
+ * Arm only on a playing-to-paused transition, so repeated pause reports cannot postpone expiry.
+ * Each caller needs its own timer because playback history belongs to that UI surface.
  */
 export function createPauseEdgeTimer(timeoutMs: number, onExpiry: () => void): PauseEdgeTimer {
   const timer = createPauseTimer(timeoutMs, onExpiry);

--- a/src/player.ts
+++ b/src/player.ts
@@ -6,6 +6,7 @@ import { getService, getServiceByHost, isAllowedNavigationUrl } from './musicSer
 
 const playerLog = log.scope('player');
 
+/** MusicKit identifiers used to resolve catalogue links from library items. */
 export interface PlayParams {
   catalogId?: string;
   globalId?: string;
@@ -13,6 +14,7 @@ export interface PlayParams {
   isLibrary?: boolean;
 }
 
+/** Queue-item metadata that the main process validates before forwarding to integrations. */
 export interface NowPlayingPayload {
   name?: string;
   artistName?: string;
@@ -31,13 +33,16 @@ export interface NowPlayingPayload {
   sourceHost?: string;
 }
 
+/** Classification of a delivered radio song relative to the previous identity. */
 export type RadioMetadataTransition = 'initial' | 'clean' | 'ambiguous';
 
+/** Catalogue identity for a song announced within a radio stream. */
 export interface TimedPlayParams {
   catalogId: string;
   kind: 'song';
 }
 
+/** Radio song fields accepted from the renderer. */
 export interface TimedMetadataInput {
   name: string;
   artistName: string;
@@ -46,6 +51,7 @@ export interface TimedMetadataInput {
   playParams?: TimedPlayParams;
 }
 
+/** Validated radio metadata with the main process's transition classification. */
 export interface TimedMetadataPayload extends TimedMetadataInput {
   transition: RadioMetadataTransition;
   /** Main-process receipt time for the delivered candidate. */
@@ -158,10 +164,8 @@ function sanitiseNowPlayingPayload(value: unknown): NowPlayingPayload | null {
  */
 export function getShareUrl(payload: NowPlayingPayload): string | undefined {
   if (payload.url) return payload.url;
-  // The origin comes from the document that announced the track, not from the
-  // persisted service: the two can disagree, and config would then name a host
-  // the track was never on. An absent or unknown host falls back to config, so
-  // an older hook and an unexpected host both degrade to the previous result.
+  // Service switching can persist the new service before the previous track clears.
+  // Use the payload's host, falling back to config only when that host is absent or unknown.
   const sourceService = payload.sourceHost ? getServiceByHost(payload.sourceHost) : undefined;
   const origin = (sourceService ?? getService(getMusicService())).origin;
   const catalogId = payload.playParams?.catalogId;
@@ -203,12 +207,15 @@ const TERMINAL_PLAYBACK_STATES: ReadonlySet<number> = new Set([
   PlaybackState.Completed,
 ]);
 
+/** True when tray, dock and taskbar Now Playing entries must clear. */
 export function isTerminalPlaybackState(state: number): boolean {
   return TERMINAL_PLAYBACK_STATES.has(state);
 }
 
+/** Renderer playback report, or null when no state is available. */
 export type PlaybackStatePayload = { status: boolean; state: number } | null;
 
+/** Typed events forwarded from Player to native integrations. */
 export interface PlayerEvents {
   hookReady: [url: string | null];
   playbackStopped: [payload: PlaybackStopped];
@@ -223,6 +230,7 @@ export interface PlayerEvents {
   volumeDidChange: [payload: number | null];
 }
 
+/** Player and optional window accessor supplied to integration initialisers. */
 export interface IntegrationContext {
   player: Player;
   getMainWindow?: () => BrowserWindow | null;
@@ -250,33 +258,40 @@ const PLAYBACK_STATES: Record<number, string> = Object.fromEntries(
  * reaching an integration as a listener that never fires.
  */
 export class TypedEmitter<Events extends { [K in keyof Events]: unknown[] }> extends EventEmitter {
+  /** Emit an event with its declared payload tuple. */
   override emit<K extends keyof Events & string>(event: K, ...args: Events[K]): boolean {
     return super.emit(event, ...args);
   }
 
+  /** Register a listener with the event's declared payload types. */
   override on<K extends keyof Events & string>(event: K, listener: (...args: Events[K]) => void): this {
     return super.on(event, listener as (...args: unknown[]) => void);
   }
 
+  /** Register a typed listener that runs at most once. */
   override once<K extends keyof Events & string>(event: K, listener: (...args: Events[K]) => void): this {
     return super.once(event, listener as (...args: unknown[]) => void);
   }
 
+  /** Remove a listener while preserving its event's payload contract. */
   override removeListener<K extends keyof Events & string>(event: K, listener: (...args: Events[K]) => void): this {
     return super.removeListener(event, listener as (...args: unknown[]) => void);
   }
 
+  /** Typed alias for removeListener(). */
   override off<K extends keyof Events & string>(event: K, listener: (...args: Events[K]) => void): this {
     return super.off(event, listener as (...args: unknown[]) => void);
   }
 }
 
+/** Cached playback state with position in microseconds. */
 export interface PlaybackSnapshot {
   isPlaying: boolean;
   positionUs: number;
   state: number;
 }
 
+/** Current controls and duration, with null for unknown seek support or duration. */
 export interface PlaybackCapabilities {
   canPlay: boolean;
   canPause: boolean;
@@ -284,6 +299,7 @@ export interface PlaybackCapabilities {
   durationUs: number | null;
 }
 
+/** Result of a Stop command, correlated with its request ID. */
 export interface PlaybackStopped {
   requestId: number;
   success: boolean;
@@ -392,14 +408,17 @@ export class Player extends TypedEmitter<PlayerEvents> {
     return { isPlaying: this._isPlaying, positionUs: this._positionUs, state: this._state };
   }
 
+  /** Return a copy so integrations cannot mutate cached capabilities. */
   capabilitiesSnapshot(): PlaybackCapabilities {
     return { ...this._capabilities };
   }
 
+  /** Return the last validated ready document URL, or null after document replacement. */
   hookReadyUrl(): string | null {
     return this._hookReadyUrl;
   }
 
+  /** Accept readiness only for a registered service origin without URL credentials. */
   handleHookReady(value: unknown): void {
     if (typeof value !== 'string') return;
     try {
@@ -412,6 +431,7 @@ export class Player extends TypedEmitter<PlayerEvents> {
     }
   }
 
+  /** Validate and forward a Stop acknowledgement with a positive request ID. */
   handlePlaybackStopped(payload: unknown): void {
     if (!isRecord(payload) || Object.keys(payload).length !== 2 ||
       !isNonNegativeSafeInteger(payload.requestId) || payload.requestId === 0 ||
@@ -422,6 +442,7 @@ export class Player extends TypedEmitter<PlayerEvents> {
     this.emit('playbackStopped', { requestId: payload.requestId, success: payload.success });
   }
 
+  /** Validate, cache and forward control capabilities without collapsing unknown values. */
   handlePlaybackCapabilitiesDidChange(payload: unknown): void {
     if (!isRecord(payload) || Object.keys(payload).length !== 4 ||
       typeof payload.canPlay !== 'boolean' || typeof payload.canPause !== 'boolean' ||
@@ -439,6 +460,7 @@ export class Player extends TypedEmitter<PlayerEvents> {
     this.emit('playbackCapabilitiesDidChange', this.capabilitiesSnapshot());
   }
 
+  /** Clear document-owned state, emitting stopped playback before clearing track metadata. */
   resetForDocumentReplacement(): void {
     this._hookReadyUrl = null;
     this.emit('hookReady', null);
@@ -452,6 +474,7 @@ export class Player extends TypedEmitter<PlayerEvents> {
     this.emit('nowPlayingItemDidChange', null);
   }
 
+  /** Validate playback reports and derive playing status from the MusicKit state. */
   handlePlaybackStateDidChange(payload: PlaybackStatePayload): void {
     if (payload != null) {
       if (typeof payload !== 'object' || Array.isArray(payload)) {
@@ -477,6 +500,7 @@ export class Player extends TypedEmitter<PlayerEvents> {
     this.emit('playbackStateDidChange', payload);
   }
 
+  /** Reset radio identity and forward a queue item with invalid metadata fields removed. */
   handleNowPlayingItemDidChange(payload: unknown): void {
     this._isRadioStation = false;
     this.resetTimedMetadata();
@@ -495,6 +519,7 @@ export class Player extends TypedEmitter<PlayerEvents> {
     this.emit('nowPlayingItemDidChange', sanitised);
   }
 
+  /** Validate radio song candidates and coalesce them before classifying transitions. */
   handleTimedMetadataDidChange(payload: unknown): void {
     if (!this._isRadioStation) {
       playerLog.warn('timedMetadataDidChange: ignored outside radio playback');
@@ -521,6 +546,7 @@ export class Player extends TypedEmitter<PlayerEvents> {
     this.dispatchTimedMetadata(input);
   }
 
+  /** Cache and forward finite positions in microseconds, limiting only diagnostic log frequency. */
   handlePlaybackTimeDidChange(payload: number): void {
     if (typeof payload !== 'number' || !isFinite(payload)) {
       playerLog.warn('playbackTimeDidChange: invalid payload, expected finite number');
@@ -554,14 +580,17 @@ export class Player extends TypedEmitter<PlayerEvents> {
     this.emit(event, payload);
   }
 
+  /** Forward repeat mode changes through the shared numeric validator. */
   handleRepeatModeDidChange(payload: number | null): void {
     this.handleModeChange('repeatModeDidChange', payload, REPEAT_MODES);
   }
 
+  /** Forward shuffle mode changes through the shared numeric validator. */
   handleShuffleModeDidChange(payload: number | null): void {
     this.handleModeChange('shuffleModeDidChange', payload, SHUFFLE_MODES);
   }
 
+  /** Forward numeric volume reports or null without changing their scale. */
   handleVolumeDidChange(payload: number | null): void {
     if (payload != null && typeof payload !== 'number') {
       playerLog.warn('volumeDidChange: invalid payload, expected number or null');

--- a/src/player.ts
+++ b/src/player.ts
@@ -150,8 +150,9 @@ function sanitiseNowPlayingPayload(value: unknown): NowPlayingPayload | null {
   if (!isRecord(value)) return null;
   const validators: Record<string, FieldValidator> = NOW_PLAYING_FIELD_VALIDATORS;
   const fields = Object.entries(value).filter(([field, fieldValue]) => {
-    const validate = validators[field];
-    if (validate?.(fieldValue)) return true;
+    // Object.hasOwn() first: a prototype-named key such as __proto__ or
+    // constructor would otherwise resolve a prototype member here.
+    if (Object.hasOwn(validators, field) && validators[field](fieldValue)) return true;
     playerLog.warn('nowPlayingItemDidChange: dropping invalid metadata field', field);
     return false;
   });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -46,6 +46,8 @@ function createPadState(): PadState {
   };
 }
 
+// Keep controller runtime code here: a sandboxed preload can require only electron.
+// Reset samples suppress held buttons until release, preventing input across document and focus changes.
 class ControllerState {
   private readonly pads = new Map<number, PadState>();
   private lastFrameAt: number | null = null;
@@ -133,12 +135,8 @@ class ControllerState {
 }
 
 /**
- * Builds a channel allowlist from a record keyed by the channel union, so the
- * allowlist and the union cannot drift: a missing key and an unknown key are
- * both compile errors. Object.keys() is typed string[], so the cast lives here
- * rather than at the two call sites. allows() takes a string because the value
- * it checks arrives from the main world, where nothing is typed; the predicate
- * narrows it to C for the caller.
+ * Build an exhaustive channel allowlist, making missing and unknown keys compile errors.
+ * Keep the Object.keys() cast here, while allows() narrows untrusted main-world strings to the channel union.
  */
 function channelSet<C extends string>(
   channels: Record<C, true>,
@@ -296,12 +294,8 @@ for (const channel of RECEIVE_CHANNELS.all) {
 }
 
 /**
- * The renderer-to-main half of the bridge, exposed as window.AMWrapper and used
- * by sendToMain() in assets/musicKitHook.js. Sending is the only capability the
- * renderer gets, and an unlisted channel is dropped with a warning rather than
- * forwarded. The satisfies clause is what type-checks the payload at all:
- * exposeInMainWorld() takes it untyped, so the declaration in
- * src/types/hook.d.ts would otherwise be checked against nothing.
+ * Expose only allowlisted sends through window.AMWrapper for the hook's sendToMain().
+ * satisfies checks the bridge contract because exposeInMainWorld() does not type-check its payload.
  */
 contextBridge.exposeInMainWorld('AMWrapper', {
   ipcRenderer: {

--- a/src/serviceSwitch.ts
+++ b/src/serviceSwitch.ts
@@ -1,6 +1,4 @@
-// src/serviceSwitch.ts
-// The one service-switch sequence. Both the tray Player submenu and itms:// routing
-// go through switchService(), so the order below is the only order that ships.
+// Shared service-switch sequence for the tray, itms:// routing and MPRIS OpenUri.
 
 import type { Tray } from 'electron';
 import { getMusicService, setMusicService } from './config';
@@ -10,8 +8,7 @@ import { notifyDocumentReplacing } from './theme';
 import { rebuildTrayMenu } from './tray';
 import { reset as resetWedgeDetector } from './wedgeDetector';
 
-// main.ts owns the window and the tray but cannot be imported (it runs app.whenReady()
-// at import), so it supplies both here, as it does for setGetMainWindowCallback and friends.
+// main.ts supplies accessors because importing it would run app.whenReady().
 let getTrayCallback: (() => Tray | null) | null = null;
 let loadURLCallback: ((url: string) => void) | null = null;
 
@@ -40,8 +37,7 @@ export function switchService(id: MusicServiceId, targetUrl?: string): void {
   loadURLCallback?.(url);
 }
 
-// itms:// links always target the music service. Passing the link to switchService()
-// rather than navigating after it keeps the switch to one navigation.
+/** Route an itms:// target to music with one navigation, switching services when needed. */
 export function routeToMusicService(url: string): void {
   if (getMusicService() !== 'music') {
     switchService('music', url);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,7 +7,9 @@ import { applyTheme, hasCustomTheme, resolveTheme } from './theme';
 import { enable as enableDiscord, disable as disableDiscord } from './integrations/discord-presence';
 import * as lastfm from './integrations/lastfm';
 
+/** Zoom levels that Settings accepts. */
 export type ZoomFactor = 1 | 1.25 | 1.5 | 1.75 | 2;
+/** Validated actions shared by Settings and tray controls. */
 export type SettingsAction =
   | { type: 'musicService'; value: MusicServiceId }
   | { type: 'startPage'; serviceId: 'music'; value: MusicStartPageId | 'last' }
@@ -17,7 +19,9 @@ export type SettingsAction =
   | { type: 'closeToTray' | 'notifications' | 'discord' | 'lastfmEnabled'; value: boolean }
   | { type: 'lastfmConnect' | 'lastfmDisconnect' };
 
+/** A stored option value paired with its display label. */
 export interface SettingsOption<T> { value: T; label: string }
+/** Current settings, available choices and translated labels for the renderer. */
 export interface SettingsState {
   musicService: MusicServiceId;
   startPage: AnyStartPageId | 'last';
@@ -37,9 +41,13 @@ export interface SettingsState {
   lang: string;
 }
 
+/** Isolated preload API for the local Settings page. */
 export interface SettingsBridge {
+  /** Read the current settings and available choices. */
   getState(): Promise<SettingsState>;
+  /** Apply a validated action and return the resulting state. */
   apply(action: SettingsAction): Promise<SettingsState>;
+  /** Subscribe to state changes and return an unsubscribe function. */
   onState(listener: (state: SettingsState) => void): () => void;
 }
 
@@ -53,6 +61,7 @@ interface SettingsRuntime {
 let runtime: SettingsRuntime | null = null;
 const listeners = new Set<(state: SettingsState) => void>();
 
+/** Connect application callbacks and Last.fm updates, returning their teardown function. */
 export function initSettingsActions(callbacks: SettingsRuntime): () => void {
   runtime = callbacks;
   lastfm.setStateChangedCallback(() => {
@@ -67,6 +76,7 @@ export function initSettingsActions(callbacks: SettingsRuntime): () => void {
   };
 }
 
+/** Map every service's start-page IDs to translated labels. */
 export function startPageLabels(strings: TrayStrings): Record<AnyStartPageId | 'last', string> {
   return {
     home: strings.startPageHome, new: strings.startPageNew, radio: strings.startPageRadio,
@@ -75,6 +85,7 @@ export function startPageLabels(strings: TrayStrings): Record<AnyStartPageId | '
   };
 }
 
+/** Resolve stored settings against the active service and currently available options. */
 export function getSettingsState(): SettingsState {
   const labels = getTrayStrings();
   const storedService = config.getMusicService();
@@ -111,11 +122,13 @@ export function getSettingsState(): SettingsState {
   };
 }
 
+/** Register a state listener and return its unsubscribe function. */
 export function subscribeSettingsChanges(listener: (state: SettingsState) => void): () => void {
   listeners.add(listener);
   return () => { listeners.delete(listener); };
 }
 
+/** Send one freshly resolved state to all registered listeners. */
 export function notifySettingsChanged(): void {
   if (!listeners.size) return;
   const state = getSettingsState();
@@ -141,6 +154,7 @@ function isSettingsAction(action: unknown, state: SettingsState): action is Sett
   }
 }
 
+/** Validate an action against available choices, apply it and refresh the tray and Settings. */
 export function applySettingsAction(action: unknown): SettingsState {
   const state = getSettingsState();
   if (!isSettingsAction(action, state)) throw new Error('Invalid settings action');

--- a/src/settingsPreload.ts
+++ b/src/settingsPreload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
 import type { SettingsBridge, SettingsState } from './settings';
 
+// Expose only Settings operations, with an unsubscribe function for renderer listeners.
 contextBridge.exposeInMainWorld('sidraSettings', {
   getState: () => ipcRenderer.invoke('settings:get'),
   apply: action => ipcRenderer.invoke('settings:apply', action),

--- a/src/settingsWindow.ts
+++ b/src/settingsWindow.ts
@@ -14,6 +14,7 @@ let refreshSettingsTheme: (() => Promise<void>) | null = null;
 let currentSettingsUrl: string | null = null;
 const settingsLog = log.scope('settings');
 
+// Accept only the current local Settings document in its own main frame.
 function validateSender(event: IpcMainInvokeEvent): void {
   const contents = settingsWindow?.webContents;
   if (!settingsWindow || settingsWindow.isDestroyed() || !contents || contents.isDestroyed()
@@ -23,6 +24,7 @@ function validateSender(event: IpcMainInvokeEvent): void {
   }
 }
 
+/** Focus the existing Settings window or create one for the live main window. */
 export function showSettingsWindow(): void {
   if (!mainWindow || mainWindow.isDestroyed()) return;
   if (settingsWindow && !settingsWindow.isDestroyed()) {
@@ -117,6 +119,7 @@ export function showSettingsWindow(): void {
   });
 }
 
+/** Open Settings only for navigation requests from an allowed main-frame document. */
 export function handleSettingsNavigation(event: IpcMainEvent, window: BrowserWindow): void {
   if (window.isDestroyed() || window.webContents.isDestroyed()
     || event.sender !== window.webContents || event.senderFrame !== window.webContents.mainFrame
@@ -124,6 +127,7 @@ export function handleSettingsNavigation(event: IpcMainEvent, window: BrowserWin
   showSettingsWindow();
 }
 
+/** Register Settings IPC, updates and the keyboard shortcut, returning an idempotent teardown function. */
 export function initSettingsWindow(window: BrowserWindow): () => void {
   mainWindow = window;
   const contents = window.webContents;

--- a/src/storefront.ts
+++ b/src/storefront.ts
@@ -1,7 +1,5 @@
-// src/storefront.ts
-// Builds every URL Sidra navigates to itself, and records where the user has
-// been. Storefront, language and start page are resolved per service through the
-// registry in src/musicService.ts, so neither host is written down here.
+// Build service launch URLs and record navigation preferences.
+// Resolve hosts and start pages through the registry in src/musicService.ts.
 
 import log from 'electron-log/main';
 import { getStorefront, setStorefront, getLanguage, setLanguage, getMusicService, getStartPageFor, getLastPageUrlFor, setLastPageUrlFor } from './config';
@@ -59,7 +57,6 @@ export function buildAppleMusicURL(): string {
   const startPage = getStartPageFor(serviceId);
 
   if (startPage === 'last') {
-    // Read the stored path only in this branch; the getter stays untouched for every other page.
     const lastPath = getLastPageUrlFor(serviceId);
     if (lastPath) {
       return appendLanguage(`${service.origin}/${storefront}/${lastPath}`, language);
@@ -116,8 +113,7 @@ export function extractStorefrontFromURL(url: string): { storefront: string; lan
 }
 
 /**
- * Follow the user: Apple's own region and language switchers navigate, so a
- * changed storefront or language in the URL is persisted as the new preference.
+ * Persist region and explicit language changes from Apple's own navigation controls.
  */
 export function handleStorefrontNavigation(url: string): void {
   const result = extractStorefrontFromURL(url);

--- a/src/storefront.ts
+++ b/src/storefront.ts
@@ -58,8 +58,12 @@ export function buildAppleMusicURL(): string {
 
   if (startPage === 'last') {
     const lastPath = getLastPageUrlFor(serviceId);
-    if (lastPath) {
-      return appendLanguage(`${service.origin}/${storefront}/${lastPath}`, language);
+    // Classical's Home is stored as the empty root path, possibly carrying a
+    // query, so only an absent value falls through. Neither form takes the
+    // separator slash: the root must not gain a trailing one.
+    if (lastPath !== undefined) {
+      const separator = lastPath === '' || lastPath.startsWith('?') ? '' : '/';
+      return appendLanguage(`${service.origin}/${storefront}${separator}${lastPath}`, language);
     }
     // fall through: no stored path yet, use the service default
   }
@@ -150,10 +154,14 @@ export function handleLastPageNavigation(url: string): void {
     if (!service) return;
     const segments = parsed.pathname.split('/').filter(Boolean);
     const pageSegments = segments[0] && /^[a-z]{2}$/.test(segments[0]) ? segments.slice(1) : segments;
-    if (pageSegments.length > 0) {
+    const pagePath = pageSegments.join('/');
+    // The storefront root is a real page only on a service whose registry
+    // declares a root start page (Classical's Home). Elsewhere a bare root is
+    // a redirect stop, not a page, and must not displace the stored path.
+    if (pagePath !== '' || service.startPages.some(page => page.path === '')) {
       // Keep the query so a search or a filtered view resumes as it was left.
       // The fragment is dropped: it is renderer state, not a page address.
-      const path = `${pageSegments.join('/')}${parsed.search}`;
+      const path = `${pagePath}${parsed.search}`;
       setLastPageUrlFor(service.id, path);
     }
   } catch {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -32,13 +32,8 @@ let themeCssKey: string | null = null;
 // post-load injection cannot interleave and strand a stylesheet on the page.
 let themeCssOp: Promise<void> = Promise.resolve();
 
-// insertCSS applies to whatever document the WebContents holds when the call is
-// made, not the one that queued the work, and the WebContents outlives every
-// document it loads. Work that waits its turn across a navigation would insert
-// into the new page on behalf of the old one, on top of that page's own
-// injection, leaving two theme sheets with only the later key tracked. The
-// counter advances on main-frame did-navigate, which is the commit point, so a
-// captured value that no longer matches means the document is gone.
+// WebContents survives document replacement, so queued insertCSS work can reach a different page.
+// Advance on main-frame did-navigate and reject stale generations to avoid untracked duplicate stylesheets.
 let documentGeneration = 0;
 
 // Every await inside queued work is another point a navigation can commit at,
@@ -65,14 +60,8 @@ function enqueueThemeCssOp(work: (generation: number) => Promise<void>): Promise
       }
       return work(generation);
     })
-    // The catch sits at the end, so the promise stored and returned here always
-    // fulfils. applyTheme() discards that promise, and a rejection left on it is
-    // an unhandled rejection in the main process; a fulfilled one also keeps one
-    // failure from deadlocking the queue, because the next operation still runs.
-    // It drops the tracked key because a failed operation leaves it naming a
-    // sheet that either cannot be removed or is already gone, and keeping it
-    // would send every later change down the same rejected removal, so none
-    // would reach its insertion.
+    // Catch after then() so discarded promises cannot reject and later operations still run.
+    // Drop the uncertain key so later changes cannot repeat a failed removal.
     .catch((error: unknown) => {
       themeCssKey = null;
       themeLog.warn('Theme CSS operation failed', error);
@@ -212,9 +201,8 @@ export function injectThemeCss(contents: WebContents): Promise<void> {
 }
 
 /**
- * Bring the theme system to life against a window: document tracking, the real
- * applyTheme implementation, re-application on a system colour-scheme change,
- * and the custom-theme.json watcher. Call once.
+ * Initialise document tracking, theme changes, system colour-scheme updates and the custom-theme.json watcher for one window.
+ * Call once.
  */
 export function initThemeCSS(win: BrowserWindow): void {
   // Commit of a main-frame navigation; did-navigate-in-page keeps the document,
@@ -229,8 +217,7 @@ export function initThemeCSS(win: BrowserWindow): void {
     if (previousKey !== null) {
       await win.webContents.removeInsertedCSS(previousKey);
       themeCssKey = null;
-      // The removal is awaited, so the new document's own injection may already
-      // have run; inserting now would put a second sheet on it.
+      // Navigation can commit during removal, so verify the document before inserting.
       if (documentReplaced(generation)) return;
     }
     if (css === null) {
@@ -265,7 +252,7 @@ function initCustomThemeWatcher(win: BrowserWindow): void {
   try {
     fs.mkdirSync(userDataPath, { recursive: true });
     watcher = fs.watch(userDataPath, { persistent: false }, (eventType, filename) => {
-      // macOS may emit a null filename for directory-level change events.
+      // macOS can emit a null filename for directory-level change events.
       if (filename !== null && filename.toString() !== customThemeFilename) return;
       themeLog.debug(`custom-theme.json watcher event: ${eventType}`);
       // Before the debounce, not inside it: a Settings refresh during the debounce
@@ -308,17 +295,9 @@ function initCustomThemeWatcher(win: BrowserWindow): void {
 }
 
 /**
- * Told by serviceSwitch.ts that a navigation is about to replace the document, so
- * the sheet the tracked key names is about to go with it and the next injection
- * must not remove against that key.
- *
- * The clear is queued rather than written straight to the field, because the field
- * belongs to the chain: an insert already in flight records its own key when it
- * resolves, and a raw write made before that would be overwritten by it. Queueing
- * cannot lose the clear either. Work dropped for a stale generation clears the key
- * on its way out, so both paths through the queue leave nothing tracked, and FIFO
- * order puts this ahead of the next document's own injection, which is queued from
- * that document's load.
+ * Queue a key clear before service-switch navigation so the next document cannot remove the previous document's stylesheet.
+ * Queueing prevents an in-flight insert from overwriting the clear and orders it before the next load's injection.
+ * The stale-generation path also clears the key, so dropped work cannot lose the clear.
  */
 export function notifyDocumentReplacing(): void {
   void enqueueThemeCssOp(() => {

--- a/src/themeTemplate.ts
+++ b/src/themeTemplate.ts
@@ -1,9 +1,7 @@
 // Pure module: no electron imports so tests can exercise it directly.
 //
-// Renders a complete Apple Music override stylesheet from a 12-slot
-// palette. Catppuccin renders byte for byte to the values the retired
-// hand-written catppuccin.css asset shipped, which test/themes.test.ts
-// pins, so the emitted form is not free to drift.
+// Render an Apple Music override stylesheet from a 12-slot palette.
+// test/themes.test.ts checks the generated Catppuccin values and output format.
 //
 // Everything inside the template literals below is output, comments included:
 // the string ships to the renderer with insertCSS() on every page load. A
@@ -60,8 +58,7 @@ function rgba(hex: string, alpha: number): string {
   return `rgba(${rgbTriplet(hex)},${alpha})`;
 }
 
-// The side-panel block alone emits spaced rgba(). test/themes.test.ts pins that
-// form against the values the retired catppuccin.css asset shipped.
+// The side-panel block uses spaced rgba(), as required by test/themes.test.ts.
 function rgbaSpaced(hex: string, alpha: number): string {
   return `rgba(${rgbTriplet(hex).split(',').join(', ')}, ${alpha})`;
 }
@@ -83,8 +80,7 @@ function rgbaSpaced(hex: string, alpha: number): string {
 //
 // The scheme block carries no ::-webkit-scrollbar-* rules. From Chrome 121
 // Chromium ignores that pseudo-element on any element carrying a non-auto
-// scrollbar-color, and the block sets one on every element; Sidra runs
-// Chromium 144, so such rules could never apply.
+// scrollbar-color, which the block sets on every element.
 function schemeBlock(c: SchemeColours): string {
   const playerBG = rgba(c.mantle, 0.88);
   return `  :root {

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -20,10 +20,7 @@ const trayLog = log.scope('tray');
 const iconsDir = getAssetPath('assets', 'icons');
 const menuIconsDir = path.join(iconsDir, 'tray', 'menu');
 
-// Every action a menu item can carry an icon for. Both maps below are typed
-// against it, so a key in one and not the other is either declared as a gap or
-// fails tsc, and a misspelt call site fails at the call rather than rendering
-// an iconless row.
+/** Menu actions accepted by both platform icon maps and checked at call sites. */
 export type MenuIconKey =
   | 'about'
   | 'player'
@@ -137,7 +134,6 @@ export function getMenuIcon(action: MenuIconKey): Electron.NativeImage | undefin
     return img;
   }
 
-  // Linux and Windows: resolve themed PNG
   const baseName = menuIconFileMap[action];
   if (!baseName) return undefined;
 
@@ -191,10 +187,8 @@ export function sanitiseLinuxLabel(text: string): string {
 }
 
 /**
- * Shortens a track, artist or album name for a menu row. The text is first cut
- * at the opening bracket of a trailing qualifier such as "(Remastered 2011)",
- * which carries little for the reader and consumes the whole row, then
- * ellipsised at maxLength so one long title cannot stretch the menu.
+ * Remove text from the first '(' or '[' after the first character, then truncate at maxLength and append an ellipsis.
+ * This removes qualifiers and limits the width of metadata rows.
  */
 export function truncateMenuLabel(text: string, maxLength = 32): string {
   const splitIndex = text.search(/[([]/);
@@ -505,27 +499,24 @@ function buildContextMenu(tray: Tray): Menu {
   return Menu.buildFromTemplate(menuItems);
 }
 
+/** Supply the current main window for tray visibility controls. */
 export function setGetMainWindowCallback(callback: () => BrowserWindow | null): void {
   getMainWindowCallback = callback;
 }
 
 /**
- * Merges named fields into the rendered Now Playing state. A partial update is
- * what lets a volume event leave the track and its artwork alone, and the field
- * names are what stop a caller pairing a track with another one's artwork.
+ * Merge only supplied fields so volume and playback updates preserve track metadata and artwork.
  */
 export function updateNowPlayingState(update: Partial<NowPlayingState>): void {
   Object.assign(nowPlayingState, update);
 }
 
+/** Rebuild the menu from current settings and cached Now Playing state. */
 export function rebuildTrayMenu(tray: Tray): void {
   tray.setContextMenu(buildContextMenu(tray));
 }
 
-// Playback, volume and now-playing events arrive in bursts: the hook polls
-// mk.volume every 250ms while the slider moves, and the renderer can emit far
-// faster than that. Each rebuild walks every submenu and
-// resizes the artwork five times, so a burst is collapsed into one rebuild.
+// Coalesce event bursts because each rebuild recreates submenus and resizes artwork.
 const TRAY_REBUILD_COALESCE_MS = 250;
 
 let rebuildTimer: NodeJS.Timeout | null = null;
@@ -544,6 +535,7 @@ function scheduleTrayRebuild(tray: Tray): void {
   }, TRAY_REBUILD_COALESCE_MS);
 }
 
+/** Cancel a pending coalesced rebuild and release its tray reference. */
 export function cancelTrayRebuild(): void {
   if (rebuildTimer) {
     clearTimeout(rebuildTimer);
@@ -552,6 +544,7 @@ export function cancelTrayRebuild(): void {
   pendingRebuildTray = null;
 }
 
+/** Show track details or the product name, escaping Linux tooltip markup. */
 export function updateTrayTooltip(tray: Tray, payload: NowPlayingPayload | null): void {
   const fallback = getProductInfo().productName;
   const text = payload?.name
@@ -563,6 +556,7 @@ export function updateTrayTooltip(tray: Tray, payload: NowPlayingPayload | null)
   tray.setToolTip(escaped);
 }
 
+/** Create the platform tray icon, menu and visibility handlers. */
 export function createTray(): Tray {
   const iconPath = getTrayIconPath();
   trayLog.info('creating tray with icon:', iconPath);
@@ -603,17 +597,12 @@ export function createTray(): Tray {
 }
 
 /**
- * Keeps the tray menu and tooltip in step with playback, and clears Now Playing
- * once a pause has lasted TRAY_PAUSE_TIMEOUT_MS. The caller must register the
- * returned closure on will-quit: it destroys the pause timer, cancels a pending
- * rebuild and removes the three player listeners, all of which otherwise outlive
- * the tray they act on.
+ * Update the menu and tooltip from playback events, clearing Now Playing after TRAY_PAUSE_TIMEOUT_MS of pause.
+ * Register the returned closure on will-quit to destroy the pause timer, cancel pending rebuilds and remove player listeners.
  */
 export function initTrayStateManager(player: Player, tray: Tray): () => void {
   const TRAY_PAUSE_TIMEOUT_MS = 30_000;
-  // The track whose artwork is in flight, held only to date the download. The
-  // rendered payload is not it: that one is committed with its own artwork once
-  // the download lands, so nothing can pair a track with another one's image.
+  // Reject artwork downloads for superseded tracks before committing metadata and artwork together.
   let pendingPayload: NowPlayingPayload | null = null;
 
   // Volume is left as it stands: it belongs to the player, not to the track

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -1,9 +1,9 @@
-// Module augmentation for CastLabs Electron type gaps. CastLabs ECS exposes
-// these APIs at runtime but omits them from its bundled electron.d.ts. They are
-// declared once here rather than cast at each call site, so every use is still
-// checked against a signature and a genuine mistake is not hidden by a cast.
+// CastLabs ECS exposes these APIs but omits their types. Shared declarations
+// keep call sites type-checked without casts.
 
+/** Runtime APIs missing from the bundled CastLabs Electron declarations. */
 declare namespace Electron {
+  /** CastLabs additions to the Electron application API. */
   interface App {
     /**
      * Set the XDG desktop filename (Linux). It sets CHROME_DESKTOP, which is

--- a/src/types/hook.d.ts
+++ b/src/types/hook.d.ts
@@ -1,12 +1,7 @@
-// Ambient type declarations for the renderer-injected hook scripts.
-// assets/musicKitHook.js defines window.__sidra, window.__sidraHookedMk, and
-// window.AMWrapper at runtime. These declarations formalise that contract so
-// TypeScript can reference the shapes from preload and test code.
-//
-// One of three artefacts that define the same contract, with the hook itself and
-// src/preload.ts. The preload builds both allowlists from the unions below, so
-// tsc holds those two together. The hook is plain JavaScript and is never type
-// checked, so the contract tests read it off disk instead.
+// Shared contract for assets/musicKitHook.js and src/preload.ts. The hook defines
+// window.__sidra and window.__sidraHookedMk, and the preload exposes window.AMWrapper.
+// TypeScript checks the preload allowlists against these unions. Contract tests
+// read the plain JavaScript hook because TypeScript does not check that file.
 
 // ---------------------------------------------------------------------------
 // IPC channel string literal types
@@ -56,21 +51,31 @@ type ReceiveChannel =
 // ---------------------------------------------------------------------------
 
 /**
- * Methods exposed on window.__sidra by assets/musicKitHook.js. Each key answers
- * one ReceiveChannel; the contract test reads the hook off disk and compares its
- * command table to this interface, which is the only thing tying the two.
+ * Commands exposed on window.__sidra by assets/musicKitHook.js.
+ * Contract tests compare the hook command table with this interface.
  */
 interface SidraHook {
+  /** Replaces the queue with the supplied URL and starts playback. */
   openUri(uri: string): Promise<void>;
+  /** Starts or resumes playback. */
   play(): Promise<void>;
+  /** Pauses playback without clearing the queue. */
   pause(): Promise<void>;
+  /** Stops playback and reports completion with the supplied request ID. */
   stop(requestId: number): Promise<void>;
+  /** Toggles between playing and paused. */
   playPause(): Promise<void>;
+  /** Advances to the next queue item. */
   next(): Promise<void>;
+  /** Returns to the previous queue item. */
   previous(): Promise<void>;
+  /** Moves the playhead to an absolute position in seconds. */
   seek(seconds: number): Promise<void>;
+  /** Sets MusicKit software volume between zero and one. */
   setVolume(volume: number): void;
+  /** Sets the MusicKit repeat mode. */
   setRepeat(mode: number): void;
+  /** Sets the MusicKit shuffle mode. */
   setShuffle(mode: number): void;
 }
 
@@ -80,7 +85,9 @@ interface SidraHook {
  * payload untyped and this declaration is otherwise checked against nothing.
  */
 interface AMWrapperBridge {
+  /** Allow-listed renderer-to-main event forwarding. */
   ipcRenderer: {
+    /** Sends an event with its optional payload and document generation. */
     send(channel: SendChannel, data?: unknown, generation?: number): void;
   };
 }
@@ -100,6 +107,7 @@ interface SidraCommandMessage {
 // Global window augmentation
 // ---------------------------------------------------------------------------
 
+/** Hook state and the isolated preload bridge exposed to the main world. */
 interface Window {
   /** The command surface, assigned last so a part-attached hook leaves it unset. */
   __sidra: SidraHook;
@@ -114,5 +122,6 @@ interface Window {
    * replaced instance and re-attach.
    */
   __sidraHookedMk: unknown;
+  /** IPC bridge exposed by src/preload.ts, not by the hook. */
   AMWrapper: AMWrapperBridge;
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -19,6 +19,7 @@ const updateLog = log.scope('update');
 
 const GITHUB_API_URL = 'https://api.github.com/repos/wimpysworld/sidra/releases/latest';
 
+/** Latest release details shared by both update paths and the tray. */
 export interface UpdateInfo {
   version: string;
   /** Release page to open. Empty when the update is already downloaded. */
@@ -41,12 +42,8 @@ export function setUpdateReady(version: string): void {
 }
 
 /**
- * Raise the "update available" notification both update paths share. The caller
- * supplies the click action, because this module opens the release page while
- * src/autoUpdate.ts installs the download it already has. The label names the
- * calling path, so one log scope still tells the two apart. Does nothing when
- * notifications are off or when createNotification() finds nothing to receive
- * one.
+ * Notify only when the preference and notification availability allow it.
+ * The caller supplies a release-page or install action and a label that identifies the update path in logs.
  */
 export function showUpdateNotification(version: string, label: string, onClick: () => void): void {
   if (!getNotificationsEnabled()) return;
@@ -68,17 +65,9 @@ export function showUpdateNotification(version: string, label: string, onClick: 
 const VERSION_PART = /^[0-9]+$/;
 
 /**
- * Read the first three parts of a version as numbers. A part past the end of the
- * version counts as 0, so 1.0 reads as 1.0.0, and parts beyond the third are
- * ignored. Returns null when a part that is present is not a run of decimal
- * digits, which is how a malformed version is refused before anything is
- * compared. The two cases stay distinct: the padding happens because the index is
- * past the end of the array, never because a part read as zero, so 2..0 is
- * refused rather than filled in as 2.0.0.
- *
- * The test is the regular expression, not Number.isFinite(). Number() accepts far
- * more than a decimal integer and reads 0x10 as 16, 1e2 as 100, and both an empty
- * part and a whitespace one as 0, so every one of those parsed as a valid version.
+ * Read three decimal parts, padding absent trailing parts with zero and ignoring later parts.
+ * Reject present parts that contain anything except digits, including empty parts.
+ * The regular expression excludes non-decimal forms that Number() accepts, such as 0x10.
  */
 function versionParts(version: string): number[] | null {
   const split = version.split('.');
@@ -95,26 +84,9 @@ function versionParts(version: string): number[] | null {
 }
 
 /**
- * Compare two major.minor.patch versions numerically, so 0.10.0 beats 0.9.0
- * where a string compare would not. Sidra tags releases with exactly three
- * numeric parts, but neither side is guaranteed to carry three: a missing part
- * counts as 0, so 1.0 beats 0.3.0 and equals 1.0.0.
- *
- * A valid part is a run of decimal digits and nothing else. A version carrying
- * anything else in the first three is refused outright and the answer is "not
- * newer", so a malformed tag never offers an update. That refuses 0x10 and 1e2,
- * which Number() reads happily, along with a leading + and a negative part; none
- * is a valid Sidra release tag. A part with a decimal point is refused by the same
- * rule but cannot be reached, because the dot is what splits the parts. A leading
- * v is not this function's problem, because checkForUpdates() strips it. Both
- * sides are checked before any comparison runs: a remote Sidra cannot parse must
- * not be offered, and a local one leaves it unable to tell what is installed. The
- * whole version is refused rather than the single bad part, because a decision
- * reached before that part is read is no more trustworthy than one reached after
- * it; 0.4.x is therefore not newer than 0.3.0 even though the minor part alone
- * would say so. Testing NaN in the comparisons instead is not enough: NaN > x and
- * NaN < x are both false, so 0.x.99 fell through to the third part and offered an
- * update over 0.3.0.
+ * Compare the first three decimal version parts numerically, padding missing trailing parts with zero.
+ * Return false if either version has an invalid part, validating all parts before comparison so an earlier difference cannot hide malformed input.
+ * checkForUpdates() removes the release tag's leading v before calling this function.
  */
 export function isNewer(remote: string, local: string): boolean {
   const r = versionParts(remote);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,9 +6,10 @@ export function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-// Run named steps in order, each isolated so one failure cannot cancel the steps
-// after it. The reporter is a parameter to keep this module free of
-// electron-log.
+/**
+ * Run named steps in order, continuing after each reported failure.
+ * The caller supplies the reporter to keep this module independent of electron-log.
+ */
 export function runSteps(
   steps: readonly (readonly [string, () => void])[],
   report: (name: string, err: unknown) => void,

--- a/src/utils/openExternal.ts
+++ b/src/utils/openExternal.ts
@@ -6,19 +6,9 @@ import { errorMessage } from '../utils';
 type ScopedLog = ReturnType<typeof log.scope>;
 
 /**
- * Hands a URL to the system browser, refusing anything that is not http or
- * https. Every external-link path goes through here, so a hardening change is
- * made once instead of in each caller.
- *
- * The parsed URL reaches the browser, not the string that came in. Chromium
- * re-parses the argument with its own parser, so passing the raw string would
- * open a URL that nothing checked. Normalisation is the cost: percent-encoding
- * is canonicalised, a default port is dropped, an IDN host is punycoded and dot
- * segments are resolved. For an http(s) URL each of those names the same
- * resource.
- *
- * Both refusals are logged. A silent refusal leaves a dead menu item or a
- * notification click that does nothing, with no record of why.
+ * Opens an HTTP(S) URL in the system browser and logs malformed or disallowed URLs.
+ * Passes the parsed URL string, not the raw input, because Chromium parses the
+ * argument again and must receive the URL that passed validation.
  */
 export function openExternalUrl(url: string, scopedLog: ScopedLog): void {
   let parsed: URL;

--- a/src/utils/progressBar.ts
+++ b/src/utils/progressBar.ts
@@ -4,11 +4,8 @@ import { BrowserWindow } from 'electron';
 const US_PER_SEC = 1_000_000;
 
 /**
- * Show playback position on the taskbar or dock progress bar: the macOS dock,
- * the Windows taskbar and the Linux Unity launcher. Media with no known
- * duration, such as a radio stream, clears the bar rather than showing an empty
- * one, and the fraction is clamped so a position past the reported duration
- * cannot overfill it.
+ * Shows clamped playback progress on the macOS dock, Windows taskbar or Linux Unity launcher.
+ * Clears the bar when the duration is absent or non-positive, as for a radio stream.
  */
 export function updateProgressBar(win: BrowserWindow, positionUs: number, durationMs: number | undefined): void {
   if (!durationMs || durationMs <= 0) {
@@ -22,10 +19,7 @@ export function updateProgressBar(win: BrowserWindow, positionUs: number, durati
   win.setProgressBar(progress);
 }
 
-/**
- * Remove the progress bar. A negative value is how Electron expresses "no
- * progress" on every platform.
- */
+/** Removes the progress bar with Electron's negative-value sentinel. */
 export function clearProgressBar(win: BrowserWindow): void {
   win.setProgressBar(-1);
 }

--- a/src/wedgeDetector.ts
+++ b/src/wedgeDetector.ts
@@ -67,12 +67,8 @@ export function init(ctx: IntegrationContext): void {
   const { player, getMainWindow: getWin } = ctx;
   if (!getWin) throw new Error('wedgeDetector requires getMainWindow');
 
-  // All state here is module-scoped, so a second init() attaches a second copy
-  // of all three listeners and a second will-quit handler. The skip path
-  // survives that by luck rather than design: startTimer() returns early when a
-  // timer already exists, and the duplicated writes to lastAdvanceTime and
-  // skipAttempts happen to be idempotent. The caller guards its own re-entry;
-  // this guard means the module does not depend on it.
+  // Module-scoped state requires one set of listeners and one will-quit handler,
+  // regardless of whether the caller guards repeated initialisation.
   if (initialised) {
     wedgeLog.warn('wedge detector already initialised, ignoring repeat init');
     return;

--- a/test/aboutWindow.test.ts
+++ b/test/aboutWindow.test.ts
@@ -19,7 +19,7 @@ import { BrowserWindow, app } from 'electron';
 import { showAboutWindow } from '../src/aboutWindow';
 import { getZoomFactor } from '../src/config';
 
-// Helpers to build a mock BrowserWindow with event support
+// Event handlers stay accessible so tests can drive the window lifecycle.
 interface MockWebContents {
   setZoomFactor: ReturnType<typeof vi.fn>;
 }
@@ -55,7 +55,6 @@ function createMockBrowserWindow(): MockBrowserWindowInstance {
   };
 }
 
-// Track the latest mock instance so the constructor function can return it.
 let latestMockInstance: MockBrowserWindowInstance;
 
 describe('showAboutWindow', () => {
@@ -69,10 +68,7 @@ describe('showAboutWindow', () => {
     vi.mocked(BrowserWindow).mockClear();
   });
 
-  // The module holds its window in a module-scoped variable that only the
-  // 'closed' handler clears, so firing that handler is the only reset it has.
-  // The handler closes over module scope, so the window the test finished with
-  // is the one to close.
+  // Only the latest window's 'closed' handler clears the module-scoped window reference.
   afterEach(() => {
     latestMockInstance._listeners['closed']?.[0]?.();
   });
@@ -149,9 +145,7 @@ describe('showAboutWindow', () => {
     expect(closedHandlers.length).toBeGreaterThan(0);
     closedHandlers[0]();
 
-    // The module holds one window reference, so a closed window that is not
-    // cleared leaves the About item dead for the rest of the session: focus()
-    // would be called on a destroyed window and nothing would be shown.
+    // Clearing the reference lets About create a window instead of calling focus() on the destroyed one.
     const newMockInstance = createMockBrowserWindow();
     latestMockInstance = newMockInstance;
     vi.mocked(BrowserWindow).mockClear();

--- a/test/artwork.test.ts
+++ b/test/artwork.test.ts
@@ -1,11 +1,8 @@
-// test/artwork.test.ts
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Readable, Writable } from 'stream';
 
-// One factory per module, used by the vi.mock below and again by the vi.doMock
-// that re-installs it after each vi.resetModules(). vi.mock is hoisted above the
-// imports, so the factories must be too: vi.hoisted() is the supported way.
-// Each call still builds fresh vi.fn()s, so the two sites stay independent.
+// Hoisted factories work with both vi.mock and vi.doMock after a module reset.
+// Each call creates fresh spies to keep the module instances independent.
 const { fsFactory, fsPromisesFactory } = vi.hoisted(() => ({
   fsFactory: () => ({
     default: {
@@ -25,7 +22,6 @@ const { fsFactory, fsPromisesFactory } = vi.hoisted(() => ({
   }),
 }));
 
-// Mock fs and fs/promises before importing the module under test
 vi.mock('fs', fsFactory);
 vi.mock('fs/promises', fsPromisesFactory);
 
@@ -33,12 +29,11 @@ import fs from 'fs';
 import fsPromises from 'fs/promises';
 import { net } from 'electron';
 
-// Helper: create a readable stream from a buffer for use as response.body
+// Response.body uses a Web stream rather than a Node stream.
 function createReadableBody(data: Buffer = Buffer.from('image-data')): ReadableStream<Uint8Array> {
   return Readable.toWeb(Readable.from(data)) as ReadableStream<Uint8Array>;
 }
 
-// Helper: create a mock fetch Response
 function createMockResponse(status: number, ok: boolean, body?: ReadableStream<Uint8Array> | null) {
   return {
     ok,
@@ -47,12 +42,9 @@ function createMockResponse(status: number, ok: boolean, body?: ReadableStream<U
   } as unknown as Response;
 }
 
-// Helper: install a write stream mock that collects the bytes written to it and
-// returns them. The module under test pipes the body with pipeline() from
-// stream/promises, which is left unmocked: it drives a real Writable, so the
-// download resolves only when the whole body has been written and the stream has
-// finished. A fresh Writable per call, because a download after a retry gets its
-// own stream and an already-ended one would reject.
+// Keep pipeline() real so download completion requires a finished Writable.
+// Each attempt needs a fresh stream because an ended stream rejects further writes.
+// Collected bytes let tests check that the complete body reaches the file.
 function mockWriteStream(): Buffer[][] {
   const files: Buffer[][] = [];
   vi.mocked(fs.createWriteStream).mockImplementation(() => {
@@ -68,8 +60,7 @@ function mockWriteStream(): Buffer[][] {
   return files;
 }
 
-// Helper: a successful fetch with a fresh body per call, so a second fetch cannot
-// be hidden by two callers draining one shared stream
+// A fresh body per fetch prevents callers from sharing an already-consumed stream.
 function mockSuccessfulFetch() {
   vi.mocked(net.fetch).mockImplementation(() => Promise.resolve(createMockResponse(200, true, createReadableBody())));
 }
@@ -113,8 +104,7 @@ describe('downloadArtwork', () => {
     const secondResult = await downloadArtwork(url);
     expect(secondResult).toBe(firstResult);
     expect(net.fetch).not.toHaveBeenCalled();
-    // Only the disk-cache branch touches mtime, so this fails if the settled
-    // in-flight promise was replayed instead
+    // Only a disk-cache hit touches mtime. Reusing a settled promise skips it.
     expect(fsPromises.utimes).toHaveBeenCalledWith(firstResult, expect.any(Date), expect.any(Date));
   });
 
@@ -128,8 +118,7 @@ describe('downloadArtwork', () => {
     expect(result).toMatch(/\.jpg$/);
     expect(fs.mkdirSync).toHaveBeenCalled();
     expect(fs.createWriteStream).toHaveBeenCalled();
-    // The whole body reaches the file, so a pipe that resolved early or dropped
-    // the stream would leave truncated artwork renamed onto the cache path.
+    // The complete body must reach disk before the file becomes a cache entry.
     expect(Buffer.concat(files[0]).toString()).toBe('image-data');
     // The download lands on a .tmp path and is renamed onto the cache path, so
     // a half-written file can never be read back as a cache hit.
@@ -145,9 +134,7 @@ describe('downloadArtwork', () => {
 
     const result = await downloadArtwork(url);
     expect(result).toBeNull();
-    // The status is checked before the stream is opened, so an error page body
-    // is never written and renamed onto the cache path, where it would be
-    // served as this track's artwork until the seven day sweep took it.
+    // Reject the status before opening a stream so an error page cannot become cached artwork.
     expect(fs.createWriteStream).not.toHaveBeenCalled();
   });
 
@@ -158,9 +145,7 @@ describe('downloadArtwork', () => {
 
     const result = await downloadArtwork(url);
     expect(result).toBeNull();
-    // The tmp name carries a timestamp, so it is distinct on every attempt and
-    // a failure that skipped the unlink would add a file to the cache
-    // directory each time the network dropped.
+    // Remove the temporary file so failed downloads cannot accumulate in the cache.
     expect(fsPromises.unlink).toHaveBeenCalled();
   });
 

--- a/test/authFrameFix.test.ts
+++ b/test/authFrameFix.test.ts
@@ -10,11 +10,8 @@ const authFixSource = fs.readFileSync(
   'utf-8',
 );
 
-// The asset is not standalone-executable JavaScript: loadAssets() in src/main.ts
-// substitutes the config token when it reads the file, so this test has to do
-// the same before it runs it. The payload is deliberately not the production
-// one, so a value that reaches the injected stylesheet or the log line proves it
-// came from here and not from a default in the asset.
+// Substitute the config token before execution, as loadAssets() does in src/main.ts.
+// Distinct fixture values show that the stylesheet and log use the supplied payload, not asset defaults.
 const CONFIG = {
   css: '.stub-passkey { display: none !important; }\n',
   containerSelectors: PASSKEY_CONTAINER_SELECTORS,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,11 +1,8 @@
 import { describe, it, expect, expectTypeOf, beforeEach } from 'vitest';
 import type { ThemeName } from '../src/theme';
 
-// No mock of ../src/config here, deliberately. A hand-written stand-in would
-// sit at this point in the file and every runtime assertion below would read
-// that stand-in's own defaults back out, so a real defect in src/config.ts
-// would pass. electron-conf/main is mocked globally in test/setup.ts, so the
-// real module loads and runs unmodified.
+// Test the real config module. A self-mock checks its own defaults and hides production defects.
+// test/setup.ts mocks electron-conf/main so the real module can load.
 import {
   getStorefront, setStorefront,
   getLanguage, setLanguage,
@@ -31,11 +28,8 @@ import { Conf } from 'electron-conf/main';
 import { DEFAULT_SERVICE_ID } from '../src/musicService';
 import type { AnyStartPageId, ClassicalStartPageId, MusicServiceId } from '../src/musicService';
 
-// Each assertion pins a getter return type or a setter parameter type against
-// its StoreSchema key type, so a key whose type drifts fails at the boundary
-// rather than at whichever caller happens to read it. expectTypeOf checks
-// nothing at run time: Vitest transpiles without type-checking, so these only
-// fail under `npx tsc -p tsconfig.test.json --noEmit`, which `just lint` runs.
+// Compare accessors with StoreSchema so type drift fails at the config boundary.
+// Vitest does not type-check. `npx tsc -p tsconfig.test.json --noEmit`, run by `just lint`, enforces expectTypeOf assertions.
 
 describe('Config store type assertions', () => {
   it('getStorefront returns string | undefined', () => {
@@ -243,7 +237,7 @@ describe('Config store runtime behaviour', () => {
   it('setClassicalStartPage rejects a music start page at compile time', () => {
     // @ts-expect-error 'radio' is a music start page, not a Classical one
     setClassicalStartPage('radio');
-    // The union is the only guard; the write itself is unchecked at runtime.
+    // The union is the only guard. The write itself is unchecked at runtime.
     expect(store.get('classical.startPage')).toBe('radio');
   });
 
@@ -281,7 +275,7 @@ describe('Config store runtime behaviour', () => {
   });
 
   it('setLanguage persists null and reads back as null', () => {
-    // The signature allows null, meaning "no override"; a stored null must stay
+    // The signature allows null, meaning "no override". A stored null must stay
     // distinguishable from a key that was never written.
     setLanguage(null);
     expect(getLanguage()).toBeNull();
@@ -430,9 +424,8 @@ describe('Config store runtime behaviour', () => {
   });
 
   it('getPendingScrobbles drops an entry timestamped in the future and keeps the valid one', () => {
-    // Last.fm ignores a future scrobble without an API error, so the flush reads
-    // success and drops the whole batch, taking the valid plays beside it. The
-    // millisecond value is what a hand-edited store most often holds.
+    // Last.fm can ignore a future timestamp without an API error, so reject it before submission.
+    // A millisecond timestamp must not be mistaken for seconds.
     store.set('lastfm.pendingScrobbles', [
       { artist: 'Orbital', track: 'Halcyon', timestamp: 1700000600 },
       { artist: 'Orbital', track: 'Chime', timestamp: 4102444800 },

--- a/test/discord-presence.test.ts
+++ b/test/discord-presence.test.ts
@@ -270,6 +270,28 @@ describe('discord presence integration', () => {
     });
   });
 
+  // MusicKit never populates url on a library item, so the button URL must come
+  // from getShareUrl(), which rebuilds it from the catalogue id.
+  it('keeps the service button for a library track with a catalogue id and no url', () => {
+    player.emitNowPlaying({ ...TRACK, url: undefined, playParams: { catalogId: '1440833098' } });
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(activity()).toMatchObject({
+      buttons: expect.arrayContaining([
+        { label: 'Play on Apple Music', url: 'https://music.apple.com/song/1440833098' },
+      ]),
+    });
+  });
+
+  it('omits the service button when the payload yields no share URL', () => {
+    player.emitNowPlaying({ ...TRACK, url: undefined });
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(activity().buttons).toEqual([
+      { label: expect.any(String), url: 'https://github.com/wimpysworld/sidra' },
+    ]);
+  });
+
   it('sends no timestamps while paused but keeps the status display', () => {
     player.setPlaybackState(PlaybackState.Paused);
     player.emitNowPlaying(TRACK);

--- a/test/discord-presence.test.ts
+++ b/test/discord-presence.test.ts
@@ -14,15 +14,12 @@ const RECONNECT_BASE_MS = 2000;
 const RECONNECT_CAP_MS = 60_000;
 const CLEAR_ACTIVITY_TIMEOUT_MS = 2000;
 
-// How a scripted connect attempt ends. 'timeout' clears the cached connection
-// promise, 'transport' leaves it set; the two failures differ in the library
-// and the source has to survive both.
+// 'timeout' clears the cached connection promise, while 'transport' retains it.
+// The integration must recover from both library failure paths.
 type ConnectOutcome = 'connected' | 'timeout' | 'transport';
 
-// What a test may read back off a constructed client. The class itself lives
-// inside the vi.mock factory, which is hoisted above every declaration here, so
-// the registry is typed structurally: a type annotation is erased, a reference
-// to the class would not be.
+// Use a structural type because the client class lives inside the hoisted vi.mock factory.
+// Type annotations disappear at runtime, unlike a reference to that class.
 interface ClientHandle {
   isConnected: boolean;
   connectAttempts: number;
@@ -30,15 +27,9 @@ interface ClientHandle {
   listenerCount(event: string): number;
 }
 
-// The RPC client talks to a Discord socket that no test has. Every method the
-// module calls returns a promise: production chains .then().catch() onto
-// setActivity() and .catch() onto clearActivity(), so a bare vi.fn() throws
-// inside them. The spies live in a hoisted holder because each test loads a
-// fresh module instance, which builds a fresh Client. setActivity is typed with
-// its argument so mock.calls carries the activity object; an untyped vi.fn()
-// gives an empty call tuple and indexing it fails. outcome is the per-test
-// script, and instances records every client built so a test can tell which one
-// is live.
+// Promise-returning spies replace Discord socket calls and support production .then()/.catch() chains.
+// The hoisted holder survives fresh module imports. Typed setActivity arguments let tests inspect recorded activities.
+// outcome controls connection results, while instances records clients so tests can identify the live one.
 const rpc = vi.hoisted(() => ({
   setActivity: vi.fn((_activity: SetActivity) => Promise.resolve({})),
   clearActivity: vi.fn(() => Promise.resolve()),
@@ -53,14 +44,9 @@ const rpc = vi.hoisted(() => ({
 vi.mock('@xhayper/discord-rpc', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@xhayper/discord-rpc')>();
 
-  // Reproduces Client.connect() as @xhayper/discord-rpc 1.3.4 writes it, defect
-  // included: it registers a once('connected') listener on every attempt and
-  // removes it only when that event arrives, so each failure leaves one behind.
-  // The timeout path clears connectionPromise and the transport-rejection path
-  // does not, which is why a reused instance can hand back the same rejected
-  // promise forever without a fresh connect. destroy() closes the transport and
-  // nothing else: no listener is removed, no promise cleared. A stand-in that
-  // cannot fail this way passes whether or not the source discards the client.
+  // Model @xhayper/discord-rpc 1.3.4: failed connections retain once('connected') listeners.
+  // Transport rejection also retains connectionPromise, so reuse returns the same rejected promise without connecting.
+  // destroy() closes only the transport. Keeping both failure modes makes client replacement observable.
   class FakeClient {
     isConnected = false;
     connectAttempts = 0;
@@ -382,9 +368,7 @@ describe('discord presence reconnect', () => {
   });
 
   it('reads the playhead through the replacement client, so a reconnected session still carries timestamps', async () => {
-    // The snapshot read is what once sat behind a non-null assertion. The
-    // client that makes it here is the one scheduleReconnect() built, not the
-    // one init() did, so it proves the player reaches a client init() never saw.
+    // A replacement client's ready handler must read the player snapshot, even though init() did not create that client.
     rpc.outcome = (attempt) => (attempt === 1 ? 'transport' : 'connected');
     const discord = await loadDiscord();
     discord.init({ player, getMainWindow: () => null });
@@ -430,10 +414,8 @@ describe('discord presence reconnect', () => {
     expect(rpc.setActivity).toHaveBeenCalledTimes(2);
   });
 
-  // clearActivity() settles only when Discord answers the nonce, so a live
-  // socket behind a Discord that answers no RPC never settles it. The destroy
-  // has to run anyway, or the socket leaks and the stale activity stays on the
-  // user's profile.
+  // clearActivity() waits for Discord's nonce reply, which can remain pending on a live socket.
+  // Teardown must still destroy the transport to release the socket and stale activity.
   it('destroys a retired client whose activity clear never answers, and destroys it once', async () => {
     const discord = await loadDiscord();
     discord.init({ player, getMainWindow: () => null });

--- a/test/i18n-consistency.test.ts
+++ b/test/i18n-consistency.test.ts
@@ -1,4 +1,3 @@
-// test/i18n-consistency.test.ts
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -9,11 +8,8 @@ import * as i18n from '../src/i18n';
 type RecordEntry = [name: string, record: Record<string, string>];
 
 /**
- * The module exports translation records alongside functions, so an object
- * export is a record and a function export is not. Deriving the list this way
- * puts a new record under the guard with no edit to this file. Do not put the
- * names back in a hand-written list: the previous one fell behind the records
- * it was meant to cover and left the whole tray media-control group unchecked.
+ * Object exports are translation records, while function exports are not.
+ * Derive the list from exports so new records receive coverage without a separate list to update.
  */
 function isRecordEntry(entry: [string, unknown]): entry is RecordEntry {
   return typeof entry[1] === 'object' && entry[1] !== null;

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -1,4 +1,3 @@
-// test/i18n.test.ts
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { app } from 'electron';
 import { DISCORD_PLAY_ON_TEXT, getLocalizedString, getNavigationStrings, getTrayStrings, LOADING_TEXT } from '../src/i18n';

--- a/test/integrationCleanup.test.ts
+++ b/test/integrationCleanup.test.ts
@@ -53,6 +53,47 @@ function endOfString(source: string, openIndex: number): number {
 }
 
 /**
+ * Blank comments and string contents so a registration or removal quoted in either
+ * cannot satisfy the sweep. Event-name arguments are string literals the matchers
+ * need, so string content survives only when it is word characters and hyphens;
+ * any quoted call text carries a dot and a parenthesis and is blanked.
+ */
+function stripCommentsAndStrings(source: string): string {
+  const KEEPABLE_STRING = /^[\w-]+$/;
+  let out = '';
+  for (let i = 0; i < source.length; i += 1) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (ch === '/' && next === '/') {
+      const eol = source.indexOf('\n', i);
+      if (eol === -1) return out;
+      i = eol - 1;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      const end = source.indexOf('*/', i + 2);
+      if (end === -1) return `${out} `;
+      out += ' ';
+      i = end + 1;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const end = endOfString(source, i);
+      if (end === -1) {
+        // Drop the rest of an unterminated literal so nothing inside it can match.
+        return out + ch + ch;
+      }
+      const content = source.slice(i + 1, end);
+      out += ch + (KEEPABLE_STRING.test(content) ? content : '') + ch;
+      i = end;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+/**
  * Find the block body by balancing braces outside comments and string literals.
  * Return `null` for unreadable blocks so the cleanup check fails instead of assuming that removals exist.
  */
@@ -105,11 +146,14 @@ function cleanupRegions(source: string): { bodies: string[]; unbalanced: number 
 
 /**
  * Return listener-cleanup faults, using the same pure check for source files and fixtures.
+ * Match against the source with comments and string contents blanked, so a call quoted
+ * in either neither counts as a registration nor satisfies a removal.
  * Require removals inside cleanup blocks because a removal elsewhere does not establish teardown.
  * Registration order is unrestricted because MPRIS declares cleanup before attaching its listeners.
  */
-function findCleanupFaults(source: string): string[] {
+function findCleanupFaults(rawSource: string): string[] {
   const faults: string[] = [];
+  const source = stripCommentsAndStrings(rawSource);
 
   // Named references let teardown remove listeners, including `once` listeners that do not fire before quit.
   // Node exposes the original callback through the once wrapper's `.listener`, so removeListener accepts that reference even after delivery.
@@ -244,6 +288,58 @@ describe('player listener cleanup', () => {
       expect(findCleanupFaults(source)).toEqual([
         expect.stringContaining('inline function, which cannot be removed'),
       ]);
+    });
+
+    it('ignores a removal written in a comment inside the cleanup block', () => {
+      const source = `
+        export function init(): void {
+          ${REGISTER}
+
+          app.on('will-quit', () => {
+            // TODO: ${REMOVE}
+            teardown();
+          });
+        }
+      `;
+
+      expect(findCleanupFaults(source)).toEqual([
+        expect.stringContaining("registers 'playbackStateDidChange'"),
+      ]);
+    });
+
+    it('ignores a removal quoted in a string literal inside the cleanup block', () => {
+      const source = `
+        export function init(): void {
+          ${REGISTER}
+
+          app.on('will-quit', () => {
+            log.warn("${REMOVE}");
+          });
+        }
+      `;
+
+      expect(findCleanupFaults(source)).toEqual([
+        expect.stringContaining("registers 'playbackStateDidChange'"),
+      ]);
+    });
+
+    it('ignores a registration that appears only in a comment', () => {
+      const source = `
+        /* Callers must pair ${REGISTER} with a removal on quit. */
+        export function init(): void {}
+      `;
+
+      expect(findCleanupFaults(source)).toEqual([]);
+    });
+
+    it('ignores a registration inside a template literal', () => {
+      const source = `
+        export function init(): void {
+          const doc = \`example: ${REGISTER}\`;
+        }
+      `;
+
+      expect(findCleanupFaults(source)).toEqual([]);
     });
 
     // addListener aliases on, so matching only player.on misses valid registrations.

--- a/test/integrationCleanup.test.ts
+++ b/test/integrationCleanup.test.ts
@@ -1,10 +1,5 @@
-// test/integrationCleanup.test.ts
-//
-// Enforces the AGENTS.md claim that every listener is cleaned up on will-quit.
-// Nothing else in the suite notices when it breaks, and it breaks quietly:
-// anonymous listeners cannot be removed at all, a module can stop its timer
-// and leave its listeners attached, and a teardown closure is discarded by
-// calling the function that returns it as a bare statement.
+// Check that player listeners have named references and removals inside cleanup blocks.
+// Timer cleanup alone leaves listeners attached. A returned teardown closure also needs a caller.
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -20,7 +15,7 @@ import { setPlatform, restorePlatform } from './mocks/platform';
 const SRC_DIR = path.join(__dirname, '..', 'src');
 const INTEGRATIONS_DIR = path.join(SRC_DIR, 'integrations');
 
-/** Every module that takes a Player and may register listeners on it. */
+/** Integration entry points and other known modules that register Player listeners. */
 function playerConsumerFiles(): string[] {
   const integrations = fs
     .readdirSync(INTEGRATIONS_DIR, { withFileTypes: true })
@@ -28,23 +23,20 @@ function playerConsumerFiles(): string[] {
     .map((entry) => path.join(INTEGRATIONS_DIR, entry.name, 'index.ts'))
     .filter((file) => fs.existsSync(file));
 
-  // wedgeDetector and tray are not under integrations/ but register on the
-  // same Player and are bound by the same claim.
+  // wedgeDetector and tray need the same cleanup checks despite living outside integrations/.
   return [...integrations, path.join(SRC_DIR, 'wedgeDetector.ts'), path.join(SRC_DIR, 'tray.ts')];
 }
 
 /**
- * The two cleanup forms this tree uses: the `will-quit` handler an integration
- * registers, and the teardown closure `initTrayStateManager` returns. A
- * separate test in this file checks main.ts wires that closure to `will-quit`.
+ * Match integration `will-quit` handlers and returned teardown closures.
+ * A separate test checks that main.ts registers the tray closure on `will-quit`.
  */
 const CLEANUP_OPENER =
   /app\.on\(\s*'will-quit'\s*,\s*(?:async\s*)?\(\s*\)\s*=>\s*\{|return\s*(?:async\s*)?\(\s*\)\s*=>\s*\{/;
 
 /**
- * The index of the quote that closes the string literal starting at
- * `openIndex`, or -1 when it never closes. A `${}` expression inside a template is skipped whole; the
- * braces in it balance, so passing over them costs the brace count nothing.
+ * Find the closing quote, or return -1 for an unterminated literal.
+ * Template contents are skipped as text, without parsing interpolation or nested templates.
  */
 function endOfString(source: string, openIndex: number): number {
   const quote = source[openIndex];
@@ -61,11 +53,8 @@ function endOfString(source: string, openIndex: number): number {
 }
 
 /**
- * The body of the block whose `{` sits at `openIndex`, found by balancing
- * braces forward, or `null` when the balance never returns to zero. Comments
- * and string literals are stepped over so a brace inside either is not counted.
- * Returning `null` fails the sweep rather than passing it: a block this scanner
- * cannot read is a block whose removals it cannot see.
+ * Find the block body by balancing braces outside comments and string literals.
+ * Return `null` for unreadable blocks so the cleanup check fails instead of assuming that removals exist.
  */
 function balancedBody(source: string, openIndex: number): string | null {
   let depth = 0;
@@ -115,27 +104,15 @@ function cleanupRegions(source: string): { bodies: string[]; unbalanced: number 
 }
 
 /**
- * What is wrong with one module's listener cleanup; empty means nothing is.
- * Pure, so the on-disk sweep and the fixtures below exercise the same code.
- *
- * The removal has to sit inside a cleanup block, not merely somewhere in the
- * file. A removal parked in a function nothing calls at teardown reads exactly
- * like a real one to a whole-file search, and leaves the listener attached for
- * the life of the process - the failure this file exists to catch. Position is
- * not checked: mpris registers its `will-quit` handler above its `player.on`
- * calls, and that order is fine.
+ * Return listener-cleanup faults, using the same pure check for source files and fixtures.
+ * Require removals inside cleanup blocks because a removal elsewhere does not establish teardown.
+ * Registration order is unrestricted because MPRIS declares cleanup before attaching its listeners.
  */
 function findCleanupFaults(source: string): string[] {
   const faults: string[] = [];
 
-  // Only a named reference can be removed later, so an inline listener is a
-  // failure whatever else the file does.
-  //
-  // `once` is held to the same rule as `on`: it detaches itself only after it
-  // fires, so until then it is a live listener and quitting has to remove it.
-  // Node stores the wrapper with `.listener` set to the original function, so
-  // `removeListener` takes the same reference the registration used, and it is
-  // a harmless no-op when the listener has already fired.
+  // Named references let teardown remove listeners, including `once` listeners that do not fire before quit.
+  // Node exposes the original callback through the once wrapper's `.listener`, so removeListener accepts that reference even after delivery.
   const named = [
     ...source.matchAll(
       /player\.(?:on|once|addListener)\(\s*'([^']+)'\s*,\s*([A-Za-z_$][\w$]*)\s*\)/g,
@@ -168,10 +145,8 @@ function findCleanupFaults(source: string): string[] {
 }
 
 describe('player listener cleanup', () => {
-  // A source sweep rather than a per-module behavioural test, so a new
-  // integration directory is covered the moment it is added. Reaching every
-  // module behaviourally would mean mocking dbus, discord-rpc and three
-  // platforms; this catches the omission the same way and cannot go stale.
+  // Discover integration directories automatically so new modules receive the same structural cleanup check.
+  // This check needs no D-Bus, Discord or platform mocks, but does not prove that teardown runs.
   describe('every registration has a matching removal', () => {
     for (const file of playerConsumerFiles()) {
       const relative = path.relative(path.join(__dirname, '..'), file);
@@ -271,9 +246,7 @@ describe('player listener cleanup', () => {
       ]);
     });
 
-    // `addListener` is the same registration under another name, so a sweep
-    // matching `player.on(` alone passes a module that registers this way
-    // while reading as coverage.
+    // addListener aliases on, so matching only player.on misses valid registrations.
     it('rejects an addListener registration with no removal', () => {
       const source = `
         export function init(): void {

--- a/test/itms.test.ts
+++ b/test/itms.test.ts
@@ -1,7 +1,4 @@
-// test/itms.test.ts
-// Covers the pure itms:// parser only. buildItmsRouteURL, which turns a route
-// token into a URL, belongs to test/storefront.test.ts along with the rest of
-// that module.
+// Test the pure itms:// parser here. test/storefront.test.ts covers buildItmsRouteURL and its storefront resolution.
 import { describe, it, expect } from 'vitest';
 
 import { transformItmsUrl, extractItmsUrlFromArgv, type ItmsRouteToken } from '../src/itms';

--- a/test/lastfm.test.ts
+++ b/test/lastfm.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-// The notify stand-in mirrors the D-Bus daemon gate; 'construct' mode is what
-// this file needs, because every assertion here counts the notifications that
-// reached the user, and the electron constructor mock is where the freeze this
-// gate exists to prevent would begin.
+// 'construct' mode exposes notification construction to assertions while preserving the D-Bus daemon gate.
+// Constructing a notification without a daemon can freeze Electron on Linux.
 import { resetNotifyFake, notifyFake } from './mocks/notify';
 
 import { createHash } from 'crypto';
@@ -717,10 +715,8 @@ describe('now playing request', () => {
   });
 
   it('sends a duration of 0 for a track under half a second', async () => {
-    // This request reports a duration for any track that has one, while
-    // trackParams() omits it once the rounded seconds are 0. That difference is
-    // the whole reason the two build their bodies apart, and 400ms is the only
-    // input that shows it: applying the helper here would drop the parameter.
+    // Now-playing retains a duration that rounds to zero, while trackParams() omits it for scrobbles.
+    // A 400ms track distinguishes the two request formats.
     const params = await nowPlayingFor({ ...TRACK, durationInMillis: 400 });
 
     expect(params.get('duration')).toBe('0');
@@ -839,7 +835,7 @@ describe('revoked session', () => {
     playPastThreshold(player);
     expect(pending).toHaveLength(2);
 
-    // The first refusal disconnects the account, as it should.
+    // The first refusal disconnects the account before the other request settles.
     pending[0](apiError(9));
     await flush();
     expect(session.key).toBeNull();
@@ -872,7 +868,7 @@ describe('revoked session', () => {
     playPastThreshold(player);
     expect(pending).toHaveLength(2);
 
-    // The first refusal disconnects the account, as it should.
+    // The first refusal disconnects the account before the other request settles.
     pending[0](apiError(9));
     await flush();
     expect(session.key).toBeNull();
@@ -895,9 +891,8 @@ describe('revoked session', () => {
     await flush();
     expect(queue.pending).toHaveLength(1);
 
-    // Only now does the request from before the disconnect fail. It carries the
-    // key the reconnected session holds, so the key tells them apart from
-    // nothing; the generation it went out under is what does.
+    // The stale request carries the same key as the reconnected session.
+    // Only its captured generation distinguishes the sessions.
     pending[1](apiError(9));
     await flush();
 
@@ -1364,9 +1359,7 @@ describe('queued scrobbles', () => {
       await flush();
     }
 
-    // 50 is the batch maximum Last.fm accepts, so one request always empties
-    // the queue. Past it the oldest play goes, being the one the user is least
-    // likely to miss.
+    // Last.fm accepts at most 50 plays per batch. The queue keeps the newest 50 by dropping the oldest play on overflow.
     expect(queue.pending).toHaveLength(50);
     expect(queue.pending[0].track).toBe('Track 1');
     expect(queue.pending[49].track).toBe('Track 50');
@@ -1685,8 +1678,8 @@ describe('queued scrobbles', () => {
     // Each distinct code once, however many entries carried it.
     expect(logged).toContain('ignored codes: 1, 5');
 
-    // None of those codes clears on a resend, so the batch goes as it always
-    // did and the log is the only place the loss is visible.
+    // Filtered plays are not retained. The daily limit can clear later, but retrying it needs a different queue policy.
+    // The outcome log records the loss.
     expect(batches()).toHaveLength(1);
     expect(queue.pending).toHaveLength(0);
   });
@@ -1775,12 +1768,7 @@ function respondToAuth(sessionResponse: () => Response): void {
   );
 }
 
-/**
- * These tests import the module through loadLastfm() for the same reason the
- * scrobble tests do: API_KEY and API_SECRET are resolved once at module load,
- * and the statically imported copy has neither, so every request path
- * short-circuits before it reaches the network.
- */
+/** Load through loadLastfm() so credentials exist before module-level initialisation. */
 describe('authentication', () => {
   beforeEach(startFromConnected);
   afterEach(restoreRealTime);
@@ -1815,7 +1803,7 @@ describe('authentication', () => {
     lastfm.startAuth();
     await flush();
 
-    // Interpolated, the `&` added a parameter and the `#` truncated the query.
+    // Raw interpolation treats `&` as a parameter separator and `#` as the end of the query.
     const opened = new URL(String(vi.mocked(shell.openExternal).mock.calls[0][0]));
     expect(opened.searchParams.get('token')).toBe('tok&foo=bar#frag');
     expect(opened.hash).toBe('');

--- a/test/macosDock.test.ts
+++ b/test/macosDock.test.ts
@@ -1,9 +1,5 @@
-// test/macosDock.test.ts
-//
-// The dock menu is built from getTrayStrings(), so every expectation reads the
-// same i18n module the integration does rather than an English literal. The
-// idle header is the case worth pinning: the Pause label there reads as a
-// transport control rather than as a statement of what is playing.
+// Read dock labels from getTrayStrings() so assertions follow the resolved locale.
+// The idle header describes playback, while Pause labels a control.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { app } from 'electron';
 

--- a/test/mocks/appLifecycle.ts
+++ b/test/mocks/appLifecycle.ts
@@ -1,12 +1,10 @@
-// test/mocks/appLifecycle.ts
 // Shared app lifecycle helper for tests that assert listener cleanup.
 import { vi } from 'vitest';
 import { app } from 'electron';
 
 /**
- * Runs the `will-quit` handlers a module registered, as quitting does. The
- * electron mock records them rather than firing them, and its `app.on` is a
- * plain `vi.fn()`, so the overloaded signature is narrowed to what is stored.
+ * Runs recorded `will-quit` handlers to simulate shutdown.
+ * The Electron mock stores calls in a plain `vi.fn()`, so the cast narrows its overloaded signature to the recorded arguments.
  */
 export function quit(): void {
   const registered = vi.mocked(app.on).mock.calls as unknown as Array<[string, () => void]>;

--- a/test/mocks/customTheme.ts
+++ b/test/mocks/customTheme.ts
@@ -1,6 +1,7 @@
 import { bundledTheme } from '../../src/palettes';
 import { buildThemeCss, type ThemeDefinition } from '../../src/themeTemplate';
 
+/** Builds matching JSON and CSS fixtures from Catppuccin, with dark colours for both schemes. */
 export function customThemeFixture(accent = '#ff0000') {
   const base = bundledTheme('catppuccin');
   if (!base) throw new Error('Custom theme fixture requires Catppuccin');

--- a/test/mocks/inlineScript.ts
+++ b/test/mocks/inlineScript.ts
@@ -1,6 +1,6 @@
 import { expect } from 'vitest';
 
-// Extracts the single, literal script block in repository fixtures, not arbitrary HTML.
+/** Extracts the single, literal script block in repository fixtures, not arbitrary HTML. */
 export function extractInlineScript(html: string): string {
   const openingTag = '<script>';
   const closingTag = '</script>';

--- a/test/mocks/notify.ts
+++ b/test/mocks/notify.ts
@@ -1,33 +1,15 @@
-// test/mocks/notify.ts
-// Shared stand-in for src/notify, the one place in Sidra a Notification is
-// constructed. createNotification() returns null while the D-Bus daemon gate is
-// closed, and that gate starts closed on Linux, because constructing a
-// Notification with no daemon freezes the window for about 100 seconds. The
-// probe that opens it never runs under test, so the fake mirrors the gate and a
-// test opens or closes it with `notifyFake.available`.
+// Shared src/notify fake with a test-controlled D-Bus daemon gate.
+// Production starts with the gate closed on Linux because constructing a Notification without a daemon can freeze the window.
+// The fake starts with the gate open. Set notifyFake.available to simulate the daemon probe.
 //
 // test/notify.test.ts covers the real gate and must not import this file.
 //
-// Two modes, because the two callers observe different things:
+// 'record' stores options, listeners and show() calls in notifyFake.built.
+// 'construct' uses the Electron constructor mock so tests can check that a closed gate prevents construction.
 //
-//   'record'     builds a plain object and pushes it onto `notifyFake.built`,
-//                so a test reads the options it was asked for and the show()
-//                the caller made on it.
-//   'construct'  builds an electron Notification, so the electron mock in
-//                test/setup.ts counts the constructions. A test asserting that
-//                nothing was constructed - the daemon gate holding back a
-//                forced notification - reads that constructor directly, which
-//                is the boundary the freeze sits behind.
+// Last.fm handles forced notifications before src/notify, so either mode observes them as construction while the notification preference is off.
 //
-// Either mode lets a test observe a forced notification, the one Last.fm sends
-// past the user's notifications preference: `force` never crosses into
-// src/notify, so what a test sees is a notification built while the preference
-// is off. In 'record' mode that is `notifyFake.built`, in 'construct' mode the
-// electron constructor mock.
-//
-// Vitest hoists vi.mock() calls to the top of the file they appear in and
-// resolves module paths relative to that file. Since this file lives in
-// test/mocks/, the path uses ../../src/ instead of ../src/.
+// Vitest hoists vi.mock() within this file and resolves its paths relative to test/mocks/, hence ../../src/.
 //
 // Import this file before the modules it stands in for:
 // import { notifyFake } from './mocks/notify';
@@ -44,20 +26,17 @@ export interface FakeNotification {
   removeAllListeners: ReturnType<typeof vi.fn>;
 }
 
-// A plain object, not vi.hoisted(): Vitest refuses to export a hoisted binding,
-// and nothing here needs one. vi.mock() hoists the registration below, but its
-// factory body runs only when src/notify is first imported, which is after this
-// module has finished evaluating.
+/** Test controls and recorded notifications. The mock factory reads this object after this module evaluates, so it needs no vi.hoisted(). */
 export const notifyFake = {
   /** The daemon gate. Closed, createNotification() returns null. */
   available: true,
-  /** Which object createNotification() hands back; see the note above. */
+  /** Selects recorded objects or the Electron constructor mock. */
   mode: 'record' as 'record' | 'construct',
   /** What 'record' mode built, oldest first. Untouched by 'construct' mode. */
   built: [] as FakeNotification[],
 };
 
-/** Clears the gate and the record, as each test file's beforeEach needs. */
+/** Opens the daemon gate, selects the mode and clears recorded notifications. */
 export function resetNotifyFake(mode: 'record' | 'construct'): void {
   notifyFake.available = true;
   notifyFake.mode = mode;

--- a/test/mocks/platform.ts
+++ b/test/mocks/platform.ts
@@ -1,15 +1,10 @@
-// test/mocks/platform.ts
 // Shared process.platform override for tests that exercise per-platform paths.
 
 let original: PropertyDescriptor | undefined;
 
 /**
- * Forces `process.platform`. Node declares the property non-writable and
- * configurable, so assignment does nothing and only `defineProperty` moves the
- * value. The descriptor is captured whole on the first call, because a saved
- * value alone has to be put back through a fresh descriptor and every such
- * variant passed `writable: true`, leaving the property writable for the rest
- * of the file in a state Node never has.
+ * Overrides `process.platform` through its configurable descriptor because the property is not writable.
+ * Saves the whole descriptor so restoration also preserves Node's property flags.
  */
 export function setPlatform(platform: string): void {
   original ??= Object.getOwnPropertyDescriptor(process, 'platform');
@@ -17,9 +12,7 @@ export function setPlatform(platform: string): void {
 }
 
 /**
- * Puts the captured descriptor back. Register it with `afterEach`, which Vitest
- * runs even when the test throws, so a forced platform cannot reach the next
- * test.
+ * Restores the captured descriptor. Register with `afterEach` so a thrown test cannot leave the platform override active.
  */
 export function restorePlatform(): void {
   if (original) Object.defineProperty(process, 'platform', original);

--- a/test/mocks/player.ts
+++ b/test/mocks/player.ts
@@ -1,33 +1,25 @@
-// test/mocks/player.ts
-// Shared fake Player for integration tests.
-//
-// Integrations receive a Player through IntegrationContext and read
-// playbackSnapshot() to decide whether playback is still live. The real Player
-// only updates that snapshot from IPC handlers, which these tests do not drive,
-// so FakePlayer puts it under test control.
-//
-// It extends the real Player rather than reimplementing the interface: Player
-// holds private fields, so a structural stand-in is not assignable to
-// IntegrationContext without a cast.
+// Integration tests control the playback snapshot without sending renderer IPC.
+// Extending Player preserves its private-field identity, so IntegrationContext accepts the fake without a cast.
 import { Player, PlaybackSnapshot, PlaybackState, NowPlayingPayload, TimedMetadataPayload } from '../../src/player';
 
+/** A Player with a test-controlled snapshot and explicit event helpers. */
 export class FakePlayer extends Player {
   private snapshot: PlaybackSnapshot = { isPlaying: false, positionUs: 0, state: PlaybackState.None };
 
+  /** Returns a copy so callers cannot mutate the test-controlled snapshot. */
   override playbackSnapshot(): PlaybackSnapshot {
     return { ...this.snapshot };
   }
 
+  /** Clears the fake snapshot before the real reset emits its events. */
   override resetForDocumentReplacement(): void {
     this.snapshot = { isPlaying: false, positionUs: 0, state: PlaybackState.None };
     super.resetForDocumentReplacement();
   }
 
   /**
-   * Moves the reported playhead and emits, as position reports from the
-   * renderer do. Both halves matter: the real Player stores the position and
-   * emits it from the same handler, and an integration may only trust the
-   * stored value once it has seen the event.
+   * Stores the playhead before emitting its position report, as the real Player does.
+   * Integrations trust the stored position only after they receive the event.
    */
   setPositionUs(positionUs: number): void {
     this.snapshot = { ...this.snapshot, positionUs };
@@ -50,10 +42,12 @@ export class FakePlayer extends Player {
     this.emit('playbackStateDidChange', { status: this.snapshot.isPlaying, state });
   }
 
+  /** Emits queue metadata without changing the playback snapshot. */
   emitNowPlaying(payload: NowPlayingPayload | null): void {
     this.emit('nowPlayingItemDidChange', payload);
   }
 
+  /** Emits radio song metadata without replacing the queue item. */
   emitTimedMetadata(payload: TimedMetadataPayload): void {
     this.emit('timedMetadataDidChange', payload);
   }

--- a/test/mocks/storefront-deps.ts
+++ b/test/mocks/storefront-deps.ts
@@ -1,4 +1,3 @@
-// test/mocks/storefront-deps.ts
 // Shared vi.mock() declarations for test files that import storefront.ts
 // (or main.ts, which re-exports storefront functions).
 //
@@ -6,9 +5,7 @@
 // Global mocks for electron, electron-log/main, and electron-conf/main live in
 // test/setup.ts and are not duplicated here.
 //
-// Vitest hoists vi.mock() calls to the top of the file they appear in and
-// resolves module paths relative to that file. Since this file lives in
-// test/mocks/, paths use ../../src/ instead of ../src/.
+// Vitest hoists vi.mock() within this file and resolves its paths relative to test/mocks/, hence ../../src/.
 //
 // Import this file as a side-effect: import './mocks/storefront-deps';
 import { vi } from 'vitest';

--- a/test/mpris.test.ts
+++ b/test/mpris.test.ts
@@ -14,10 +14,7 @@ import * as mpris from '../src/integrations/mpris';
 import { FakePlayer } from './mocks/player';
 import { quit } from './mocks/appLifecycle';
 
-// updateNowPlaying() hands every https:// artwork URL to downloadArtwork(),
-// which fetches over the network and writes to the cache directory. Resolving
-// null leaves mpris:artUrl at the value buildMetadata() produced, so the
-// metadata assertions read what the builder wrote and nothing else.
+// Avoid artwork network and cache writes. Resolving null preserves buildMetadata()'s mpris:artUrl for assertions.
 vi.mock('../src/artwork', () => ({
   downloadArtwork: vi.fn(() => Promise.resolve(null)),
 }));
@@ -49,16 +46,12 @@ interface DbusModule {
   interface: { Interface: DbusInterfaceClass };
 }
 
-// src/integrations/mpris/index.ts pulls @holusion/dbus-next in with a bare
-// require, which vi.mock does not intercept. The module loads fine off a bus -
-// only sessionBus() opens a socket - so the real one is loaded and that single
-// entry point is stubbed.
+// vi.mock does not intercept the integration's bare require of @holusion/dbus-next.
+// Load the real module and stub sessionBus(), the entry point that opens a socket.
 const dbus = require('@holusion/dbus-next') as DbusModule;
 
-// Captured before any spy is installed, so the wrapper below calls the real
-// static rather than itself. The real one is worth keeping in the path: it
-// throws on a property that configureMembers() never declared, which turns a
-// misspelled emission into a failure instead of a silent no-op.
+// Capture the real static before spying to avoid recursion.
+// Its validation rejects properties that configureMembers() does not declare.
 const realEmitPropertiesChanged = dbus.interface.Interface.emitPropertiesChanged;
 
 const busStub = {
@@ -117,14 +110,9 @@ interface RootInterface {
 }
 
 /**
- * PropertiesChanged payloads that carried a Position key, never cleared.
- *
- * Position moves on its own, so a PropertiesChanged carrying it would be
- * either a lie or a flood. The MPRIS spec forbids it outright: clients poll
- * the property or follow the Seeked signal. The check lives on the shared spy
- * so it covers every emission the file produces and belongs to no single test.
- * A debounced emission whose timer fires after its own test still fails the
- * next afterEach, which is why this array is never cleared.
+ * Retain every PropertiesChanged payload containing Position, which MPRIS forbids.
+ * Clients poll Position or use Seeked instead.
+ * Never clear this shared record, so a delayed emission still fails the next afterEach.
  */
 const positionBreaches: Array<Record<string, unknown>> = [];
 
@@ -135,10 +123,7 @@ let win: WindowStub;
 let player: FakePlayer;
 
 /**
- * init() exports the root interface first and the player interface second, so
- * the live MediaPlayer2Player instance is the second argument of the second
- * export. Driving the real methods and properties this way needs no production
- * change.
+ * Read the live interfaces from init()'s bus exports, root first and player second.
  */
 function initInterfaces(getMainWindow: () => BrowserWindow | null = () => win as unknown as BrowserWindow): {
   root: RootInterface;
@@ -859,11 +844,7 @@ describe('MPRIS OpenUri', () => {
   });
 });
 
-// MPRIS has three PlaybackStatus values and MusicKit has ten states, so the
-// mapping is lossy by design. Stopped (4) is the row that matters: mapping it
-// to 'Paused' leaves a client showing a pause button for a player that has
-// stopped. AGENTS.md also forbids an early-return guard for the transient
-// states, so those are pinned here rather than left to read as an accident.
+// MusicKit states map to three MPRIS statuses. Stopped and transient states report 'Stopped', never the previous status.
 describe('MPRIS PlaybackStatus mapping', () => {
   const STATUS_TABLE: ReadonlyArray<readonly [number, string]> = [
     [PlaybackState.None, 'Stopped'],
@@ -890,9 +871,7 @@ describe('MPRIS PlaybackStatus mapping', () => {
     expect(STATUS_TABLE.map(([state]) => state).sort()).toEqual(Object.values(PlaybackState).sort());
   });
 
-  // Called out because AGENTS.md names these four: they are momentary, and a
-  // guard that suppressed them would leave MPRIS reporting a state the player
-  // has already left.
+  // Suppressing transient states leaves MPRIS reporting a state that the player no longer holds.
   it('reports the transient states as Stopped', () => {
     const iface = initPlayerInterface();
     for (const state of [PlaybackState.Loading, PlaybackState.Seeking, PlaybackState.Waiting, PlaybackState.Stalled]) {
@@ -923,10 +902,7 @@ describe('MPRIS metadata', () => {
     return Object.fromEntries(Object.entries(metadata).map(([key, variant]) => [key, [variant.signature, variant.value]]));
   }
 
-  // The signature travels with the value on D-Bus, so a wrong one is not a
-  // cosmetic fault: a client reading xesam:artist expects an array of strings
-  // and mpris:length an int64. The exact key set is asserted too, because an
-  // extra key with a made-up name is as wrong as a missing one.
+  // D-Bus clients require the exact keys and signatures, including a string array for xesam:artist and int64 for mpris:length.
   it('builds every field of a full payload with the right signatures', () => {
     const iface = initPlayerInterface();
     player.emitNowPlaying(FULL_TRACK);
@@ -1270,9 +1246,7 @@ describe('MPRIS volume', () => {
     expect(iface.Volume).toBe(0.2);
   });
 
-  // An echo that never arrives would suppress the next in-app change for the
-  // life of the process. The safety timeout drops the whole queue, and the
-  // queue must not have cost that self-healing.
+  // The safety timeout clears pending echoes so a missing echo cannot suppress a later in-app change indefinitely.
   it('stops suppressing once the safety timeout expires', () => {
     const iface = initPlayerInterface();
     iface.Volume = 0.5;
@@ -1344,10 +1318,7 @@ describe('MPRIS position', () => {
     expect(seeked).not.toHaveBeenCalled();
   });
 
-  // Both the Seeked argument and the Position property are int64 fields, and
-  // the dbus-next marshaller converts one with BigInt(data.toString()), which
-  // throws on anything fractional. BigInt(String(value)) is that exact
-  // operation, so it is the honest assertion rather than a proxy for it.
+  // Seeked and Position use int64. BigInt(String(value)) checks the marshaller's conversion, which rejects fractional values.
   it('keeps a fractional position integral for the int64 marshaller', () => {
     const iface = initPlayerInterface();
     const seeked = vi.spyOn(iface, 'Seeked');
@@ -1364,11 +1335,8 @@ describe('MPRIS position', () => {
 });
 
 describe('MPRIS without a session bus', () => {
-  // dbus-next throws synchronously from sessionBus() when
-  // DBUS_SESSION_BUS_ADDRESS is unset and it cannot read the address from the
-  // filesystem. init() is called bare inside the did-finish-load handler in
-  // main.ts, so an escaping throw takes out every integration after it and the
-  // splash screen never closes.
+  // sessionBus() throws synchronously when neither the environment nor the filesystem supplies a bus address.
+  // MPRIS handles this expected absence locally and leaves the player without bus listeners.
   it('does not throw when the bus cannot be opened', () => {
     vi.spyOn(dbus, 'sessionBus').mockImplementation(() => {
       throw new Error('could not get DISPLAY environment variable');

--- a/test/musicKitHook.test.ts
+++ b/test/musicKitHook.test.ts
@@ -135,6 +135,7 @@ function createMusicKit(
 function createHarness({
   bridgeMissing = false,
   musicKitOverrides = {},
+  musicKitThrowsAtFirstPoll = false,
   musicKitThrowsAtInjection = false,
   navigatorOverrides,
   repeatInjection = false,
@@ -142,6 +143,7 @@ function createHarness({
 }: {
   bridgeMissing?: boolean;
   musicKitOverrides?: Record<string, unknown>;
+  musicKitThrowsAtFirstPoll?: boolean;
   musicKitThrowsAtInjection?: boolean;
   navigatorOverrides?: Record<string, unknown>;
   repeatInjection?: boolean;
@@ -213,8 +215,9 @@ function createHarness({
 
   // MusicKit can be present but mid-initialisation when the script is injected,
   // so getInstance() throws until it settles. Clearing the flag after the
-  // injection run models it settling before the 500ms poll first fires.
-  let getInstanceThrows = musicKitThrowsAtInjection;
+  // injection run models it settling before the 500ms poll first fires, and
+  // musicKitThrowsAtFirstPoll keeps it throwing through the first poll instead.
+  let getInstanceThrows = musicKitThrowsAtInjection || musicKitThrowsAtFirstPoll;
   // Held in a variable so replaceInstance() can swap what getInstance() hands
   // back, which is what the 5-second monitor watches for.
   let liveInstance = musicKit;
@@ -225,13 +228,19 @@ function createHarness({
     },
     PlaybackStates: { playing: 2 },
   };
-  if (musicKitThrowsAtInjection) {
+  if (musicKitThrowsAtInjection || musicKitThrowsAtFirstPoll) {
     Object.assign(context, { MusicKit: musicKitApi });
     Object.assign(window, { MusicKit: musicKitApi });
   }
 
   vm.runInContext(hookScript, context);
   if (repeatInjection) vm.runInContext(hookScript, context);
+
+  // Fire the first 500ms poll while getInstance() still throws. The hook must
+  // leave the poll running, so the later run below can attach.
+  if (musicKitThrowsAtFirstPoll) {
+    for (const callback of intervalCallbacks.slice()) callback();
+  }
 
   getInstanceThrows = false;
   Object.assign(context, { MusicKit: musicKitApi });
@@ -853,6 +862,19 @@ describe('musicKitHook', () => {
     const { musicKitListeners } = createHarness({ musicKitThrowsAtInjection: true });
 
     expect(musicKitListeners.has('playbackStateDidChange')).toBe(true);
+  });
+
+  it('keeps polling and attaches after getInstance() throws on the first poll', () => {
+    // window.MusicKit exists at the first poll, but getInstance() still throws.
+    // The poll must survive that lookup, because __sidraHookInjected blocks
+    // re-injection and a cleared poll would leave native controls dead.
+    const { bridgeSend, musicKit, musicKitListeners, window } = createHarness({
+      musicKitThrowsAtFirstPoll: true,
+    });
+
+    expect(musicKitListeners.has('playbackStateDidChange')).toBe(true);
+    expect(window.__sidraHookedMk).toBe(musicKit);
+    expect(bridgeSend).toHaveBeenCalledWith('hookReady', 1, 1);
   });
 
   it('installs no second message listener when the script is injected again', () => {

--- a/test/musicKitHook.test.ts
+++ b/test/musicKitHook.test.ts
@@ -944,6 +944,39 @@ describe('musicKitHook', () => {
     expect(musicKit.addEventListener.mock.calls.length).toBe(before);
   });
 
+  it('ignores every event from a replaced instance while the replacement still reports', () => {
+    const { bridgeSend, musicKit, musicKitListeners, replaceInstance, runMonitorCycles } = createHarness({
+      musicKitOverrides: { nowPlayingItem: radioItem },
+    });
+    const stale = new Map(musicKitListeners);
+    const replacement = replaceInstance();
+    runMonitorCycles(1);
+    bridgeSend.mockClear();
+
+    // The old instance keeps its listeners after re-attachment, and its events
+    // carry the current document generation, so only the hook can reject them.
+    // A delayed empty-item event from it must not clear the replacement's track.
+    Object.assign(musicKit, { volume: 0.2, repeatMode: 1, shuffleMode: 1, currentPlaybackTime: 9 });
+    stale.get('nowPlayingItemDidChange')?.({ item: null });
+    stale.get('playbackStateDidChange')?.({ state: 0 });
+    stale.get('playbackTimeDidChange')?.();
+    stale.get('repeatModeDidChange')?.();
+    stale.get('shuffleModeDidChange')?.();
+    stale.get('playbackVolumeDidChange')?.();
+    stale.get('timedMetadataDidChange')?.(timedSong);
+    expect(bridgeSend).not.toHaveBeenCalled();
+
+    const fresh = new Map(replacement.addEventListener.mock.calls);
+    Object.assign(replacement, { volume: 0.3 });
+    fresh.get('playbackVolumeDidChange')?.();
+    fresh.get('nowPlayingItemDidChange')?.({ item: { id: 'next-song', attributes: { name: 'Next' } } });
+    expect(bridgeSend).toHaveBeenCalledWith('volumeDidChange', 0.3, 1);
+    expect(bridgeSend).toHaveBeenCalledWith(
+      'nowPlayingItemDidChange',
+      expect.objectContaining({ trackId: 'next-song' }), 1,
+    );
+  });
+
   it('reports explicit media session position state on playback time changes', () => {
     const { mediaSession, musicKitListeners } = createHarness({
       musicKitOverrides: {

--- a/test/musicKitHook.test.ts
+++ b/test/musicKitHook.test.ts
@@ -149,10 +149,10 @@ function createHarness({
   repeatInjection?: boolean;
   volumeThrows?: boolean;
 } = {}) {
-  const intervals: Array<{ callback: () => void; delay: number }> = [];
+  const intervals = new Map<number, { callback: () => void; delay: number }>();
+  let nextIntervalId = 0;
   const timeouts = new Map<number, () => void>();
   let nextTimeoutId = 0;
-  const intervalCallbacks: Array<() => void> = [];
   const messageListeners: Array<(event: unknown) => void> = [];
   const pointerOverListeners: Array<(event: unknown) => void> = [];
   // Registrations the hook made on window. The wheel listener must never appear
@@ -202,13 +202,13 @@ function createHarness({
       return id;
     },
     clearTimeout: (id: number) => { timeouts.delete(id); },
-    clearInterval: vi.fn(),
+    clearInterval: (id: number) => { intervals.delete(id); },
     console,
     navigator,
     setInterval: vi.fn((callback: () => void, delay: number) => {
-      intervals.push({ callback, delay });
-      intervalCallbacks.push(callback);
-      return intervalCallbacks.length;
+      const id = ++nextIntervalId;
+      intervals.set(id, { callback, delay });
+      return id;
     }),
     window,
   });
@@ -239,13 +239,13 @@ function createHarness({
   // Fire the first 500ms poll while getInstance() still throws. The hook must
   // leave the poll running, so the later run below can attach.
   if (musicKitThrowsAtFirstPoll) {
-    for (const callback of intervalCallbacks.slice()) callback();
+    for (const { callback } of [...intervals.values()]) callback();
   }
 
   getInstanceThrows = false;
   Object.assign(context, { MusicKit: musicKitApi });
   Object.assign(window, { MusicKit: musicKitApi });
-  for (const callback of intervalCallbacks.slice()) callback();
+  for (const { callback } of [...intervals.values()]) callback();
 
   return {
     // Non-optional handle on the bridge send mock. window.AMWrapper is optional
@@ -288,13 +288,13 @@ function createHarness({
     // Fires only the 5-second instance monitor. The 250ms volume poll and the
     // 500ms waitForMK share the same mock, so they are filtered out by delay.
     runMonitorCycles: (count: number) => {
-      const monitors = intervals.filter(({ delay }) => delay === 5000);
       for (let cycle = 0; cycle < count; cycle++) {
+        const monitors = [...intervals.values()].filter(({ delay }) => delay === 5000);
         for (const { callback } of monitors) callback();
       }
     },
     runVolumePoll: () => {
-      for (const { callback } of intervals.filter(({ delay }) => delay === 250)) callback();
+      for (const { callback } of [...intervals.values()].filter(({ delay }) => delay === 250)) callback();
     },
     runTimeouts: () => {
       for (const [id, callback] of timeouts) {
@@ -307,9 +307,11 @@ function createHarness({
     // the waitForMK callback rather than the script body, so a re-run that
     // slipped past the injection guard would go unnoticed without the drain.
     reinject: () => {
-      const alreadyRun = intervalCallbacks.length;
+      const alreadyRun = nextIntervalId;
       vm.runInContext(hookScript, context);
-      for (const callback of intervalCallbacks.slice(alreadyRun)) callback();
+      for (const [id, { callback }] of [...intervals]) {
+        if (id > alreadyRun) callback();
+      }
     },
     pointerOverListeners,
     window,

--- a/test/musicKitHook.test.ts
+++ b/test/musicKitHook.test.ts
@@ -19,9 +19,7 @@ interface Registration {
 }
 
 /**
- * An element in a fake ancestor chain. It carries only what the hook uses:
- * class tokens, addEventListener/removeEventListener, and closest(), which is
- * how the hook finds the volume control from the pointer's target.
+ * Model ancestor traversal and listener registration so the hook can find the volume control from a pointer target.
  */
 interface FakeElement {
   tokens: string[];
@@ -169,8 +167,7 @@ function createHarness({
       musicKitListeners.set(event, listener);
     },
   );
-  // AMWrapper is optional because bridgeMissing models the preload bridge not
-  // being installed, which is one of the ways the attach used to throw.
+  // bridgeMissing omits AMWrapper to exercise attachment without a preload bridge.
   interface HarnessWindow {
     AMWrapper?: { ipcRenderer: { send: ReturnType<typeof vi.fn> } };
     addEventListener: ReturnType<typeof vi.fn>;
@@ -868,11 +865,8 @@ describe('musicKitHook', () => {
     expect(messageListeners).toHaveLength(1);
   });
 
-  // The 5-second monitor re-attaches whenever __sidraHookedMk does not match
-  // the live instance, so attachToInstance() must claim the marker as its first
-  // statement. Claimed last, anything that throws in between leaves it stale and
-  // every cycle adds another full set of MusicKit listeners. These three pin the
-  // marker being claimed first.
+  // Claim __sidraHookedMk before attachment can throw.
+  // Otherwise the 5-second monitor sees a stale marker and adds another set of listeners on every cycle.
   it('attaches each MusicKit listener once when the IPC bridge is missing', () => {
     const { musicKit, runMonitorCycles } = createHarness({ bridgeMissing: true });
 
@@ -970,10 +964,8 @@ describe('musicKitHook', () => {
   );
 
   it('still forwards playback events over IPC when navigator.mediaSession is unavailable', () => {
-    // Position state is a bonus for OS media controls; the IPC forwarding is
-    // the hook's actual job. A guard that swallowed the whole listener would
-    // leave MPRIS and every integration blind, so assert the sends, not that
-    // the listener merely survived.
+    // Position-state failures must not suppress IPC forwarding to integrations.
+    // Assert the sends because a caught exception alone does not prove that the listener completes.
     const { bridgeSend, musicKitListeners } = createHarness({
       navigatorOverrides: {},
       musicKitOverrides: {
@@ -996,10 +988,8 @@ describe('musicKitHook', () => {
   });
 
   it('still forwards playback events over IPC when setPositionState is missing', () => {
-    // Safari exposes navigator.mediaSession without setPositionState, which is
-    // the arm the object-presence check alone would let through. Both calls sit
-    // in a try/catch, so an unguarded call would not surface as a throw - the
-    // IPC sends are the only observable proof the listeners ran to completion.
+    // A mediaSession object does not guarantee a setPositionState method.
+    // Both calls catch exceptions, so IPC sends establish that a missing method does not interrupt forwarding.
     const { bridgeSend, musicKitListeners } = createHarness({
       navigatorOverrides: { mediaSession: {} },
       musicKitOverrides: {
@@ -1091,10 +1081,7 @@ describe('musicKitHook', () => {
   });
 
   it('forwards a MusicKit volume change over the volumeDidChange IPC channel', () => {
-    // The attach-time send already carries the mock's initial volume of 1, so
-    // a listener bound to an event MusicKit never fires would still leave a
-    // ('volumeDidChange', 1) call behind. Moving the volume first is what makes
-    // the assertion prove the listener ran.
+    // Attachment already sends volume 1. Change the volume so that an attachment send cannot satisfy the listener assertion.
     const { bridgeSend, musicKit, musicKitListeners } = createHarness();
 
     musicKit.volume = 0.42;
@@ -1212,12 +1199,8 @@ describe('musicKitHook', () => {
     expect(musicKit.volume).toBe(0.45);
   });
 
-  // The listener has to be non-passive to call preventDefault, and that is
-  // exactly why it must sit on the control. A non-passive wheel listener on
-  // window or document marks the whole document a non-fast-scrollable region,
-  // so Chromium stops scrolling on the compositor thread and every wheel tick
-  // waits behind Apple Music's main thread. Nothing else in the suite notices
-  // that, because the handler still behaves correctly while doing it.
+  // preventDefault requires a non-passive listener. Keep it on the control so only that region needs main-thread scrolling.
+  // A window or document listener moves all scrolling off the compositor thread, even when the handler ignores unrelated wheel events.
   it('registers no wheel listener on window', () => {
     const { globalRegistrations } = createHarness();
 

--- a/test/musicService.test.ts
+++ b/test/musicService.test.ts
@@ -48,9 +48,8 @@ describe('MusicService types', () => {
 });
 
 describe('MUSIC_SERVICES registry', () => {
-  // One whole-registry comparison rather than a field at a time: an added, renamed or dropped
-  // entry is caught as well, and a failure prints the whole diff instead of one stray value.
-  // Start page order is the tray submenu order, so the arrays are compared in order.
+  // Compare the whole registry to detect added, renamed or removed entries.
+  // Preserve array order because it determines the tray submenu order.
   it('matches the expected registry shape', () => {
     expect(MUSIC_SERVICES).toEqual({
       music: {
@@ -88,8 +87,7 @@ describe('MUSIC_SERVICES registry', () => {
   });
 });
 
-// Both services probe readiness with the same selector; a second copy of the literal would
-// drift silently, so the registry must reference the one in contentReady.ts.
+// Both services use contentReady.ts's selector so readiness checks cannot drift between copies.
 describe('content ready selector', () => {
   it('music entry uses CONTENT_READY_SELECTOR', () => {
     expect(MUSIC_SERVICES['music'].contentReadySelector).toBe(CONTENT_READY_SELECTOR);

--- a/test/navigationBar.test.ts
+++ b/test/navigationBar.test.ts
@@ -10,11 +10,8 @@ const navBarSource = fs.readFileSync(
   'utf-8',
 );
 
-// The asset is not standalone-executable JavaScript: loadAssets() in src/main.ts
-// substitutes the label token when it reads the file, so this test has to do the
-// same before it runs it. These labels are deliberately not English, so a label
-// that reaches a button proves it came from here and not from a default in the
-// asset.
+// Substitute the label token as main.ts loadAssets() does before executing the asset.
+// Non-English labels distinguish injected translations from asset defaults.
 const LABELS = { back: 'Zurück', forward: 'Vorwärts', reload: 'Neu laden', settings: 'Einstellungen' };
 
 const navBarScript = navBarSource.replace(NAV_LABELS_TOKEN, () => JSON.stringify(LABELS));
@@ -61,7 +58,7 @@ class StubElement {
     for (const listener of this.listeners.get(type) ?? []) listener.call(this);
   }
 
-  // Only tag-name selectors are needed; the script queries its own 'svg' child.
+  // Only tag-name selectors are needed because the script queries its own 'svg' child.
   querySelector(selector: string): StubElement | null {
     return this.descendants().find((element) => element.tagName === selector) ?? null;
   }

--- a/test/notifications.test.ts
+++ b/test/notifications.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-// The notify stand-in mirrors the D-Bus daemon gate; 'record' mode is what this
-// file needs, because the integration attaches listeners and calls show() on
-// the object it gets back, and the tests read both.
+// The notify fake models the D-Bus daemon gate. Record mode exposes listeners and show() calls for these assertions.
 import { FakeNotification, notifyFake, resetNotifyFake } from './mocks/notify';
 
 import { downloadArtwork } from '../src/artwork';

--- a/test/notify.test.ts
+++ b/test/notify.test.ts
@@ -19,10 +19,8 @@ interface DbusModule {
   sessionBus: () => DbusBus;
 }
 
-// src/notificationDaemon.ts pulls @holusion/dbus-next in with a bare require,
-// which vi.mock does not intercept. The module loads fine off a bus - only
-// sessionBus() opens a socket - so the real one is loaded and that single entry
-// point is stubbed. Every case here runs against this stub; no live bus.
+// vi.mock cannot intercept the daemon's bare require of @holusion/dbus-next.
+// Loading the real module opens no socket. Stub sessionBus(), its connection entry point, so no test uses a live bus.
 const dbus = require('@holusion/dbus-next') as DbusModule;
 
 const busStub = {
@@ -34,11 +32,8 @@ const busStub = {
 let probeOwner = false;
 
 /**
- * src/notify.ts lazy-requires ./notificationDaemon inside initNotificationProbe.
- * That is a real Node require, so it reaches neither Vitest's module registry
- * nor a .ts file, and vi.mock cannot see it. Patching Module._load hands the
- * real daemon module - freshly imported, running against the bus stub - to the
- * gate, so both modules are exercised together as they are in production.
+ * Routes initNotificationProbe()'s Node require to the real TypeScript daemon module with its stubbed bus.
+ * Module._load needs patching because Node require bypasses Vitest's module registry and cannot resolve the TypeScript file.
  */
 const moduleApi = Module as unknown as {
   _load: (request: string, parent: unknown, isMain: boolean) => unknown;
@@ -72,10 +67,8 @@ interface Loaded {
 }
 
 /**
- * The gate is module-level state in src/notify.ts, and that module reads
- * process.platform at load, so every case forces the platform, resets the
- * registry and re-imports. Without the reset the previous case's latch leaks
- * into the next one.
+ * Loads a fresh notification gate after setting the platform.
+ * The module reads process.platform at import and retains failure state, so each test needs its own copy.
  */
 async function loadNotify(platform: NodeJS.Platform): Promise<Loaded> {
   setPlatform(platform);
@@ -261,8 +254,7 @@ describe('notification gate on Linux', () => {
     expect(notify.createNotification(OPTIONS)).toBeNull();
   });
 
-  // The gate has its own try/catch, so this asserts the daemon swallows the
-  // throw itself rather than relying on its caller to do it.
+  // Test the daemon directly so the gate's catch cannot hide an escaping error.
   it('does not throw out of the probe when the session bus cannot be opened', async () => {
     await loadNotify('linux');
     vi.mocked(dbus.sessionBus).mockImplementation(() => {
@@ -290,8 +282,7 @@ describe('notification gate off Linux', () => {
     expect(NotificationMock).toHaveBeenCalledTimes(1);
   });
 
-  // NameOwnerChanged is the only way back from a latch, and it exists on Linux
-  // alone; latching here would kill notifications for the rest of the session.
+  // Only Linux receives NameOwnerChanged to clear failure state. Other platforms must keep notifications available after a failure.
   it('does not latch closed when a notification fails', async () => {
     const { notify } = await loadNotify('darwin');
 

--- a/test/openExternal.test.ts
+++ b/test/openExternal.test.ts
@@ -1,8 +1,5 @@
-// src/utils/openExternal.ts is the single gate every external-link path passes
-// through: the tray update item, the update notification click and the
-// setWindowOpenHandler in main.ts all call it. One gate means one place to
-// break, so the protocol allowlist and the argument handed to Chromium are
-// pinned here.
+// The tray update link, update notification and main.ts window-open handler share openExternalUrl().
+// Check its protocol allowlist and the URL that it passes to Chromium.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { shell } from 'electron';
 
@@ -10,11 +7,8 @@ import { openExternalUrl } from '../src/utils/openExternal';
 
 const openExternal = vi.mocked(shell.openExternal);
 
-// The electron-log stand-in in test/setup.ts shares one mock across every scope
-// method, so warn and debug cannot be told apart there. This fake gives each
-// level its own mock, which is what separates a refusal from an open. It is
-// typed off the function under test, so a change to the parameter type fails
-// the build rather than passing through a cast.
+// Separate logging mocks distinguish refusals from successful opens, unlike the shared mock in test/setup.ts.
+// Deriving the type from openExternalUrl() keeps parameter changes checked without a cast.
 type ScopedLog = Parameters<typeof openExternalUrl>[1];
 
 function fakeLog(): ScopedLog {
@@ -66,8 +60,7 @@ describe('openExternalUrl allowed protocols', () => {
 });
 
 describe('openExternalUrl refusals', () => {
-  // A javascript: URL handed to the browser is the payload this gate exists to
-  // stop, so it gets its own case rather than a row in the table below.
+  // The protocol gate must prevent JavaScript execution through external links.
   it('refuses a javascript URL, opens nothing and warns', () => {
     openExternalUrl('javascript:alert(1)', scopedLog);
 
@@ -90,9 +83,7 @@ describe('openExternalUrl refusals', () => {
     expect(warnings()).toEqual([`blocked external URL with disallowed protocol: ${url}`]);
   });
 
-  // The two refusals log different lines and the distinction is what tells a
-  // user reading the log a typo from a blocked scheme. A single "blocked"
-  // assertion would pass with either branch taken.
+  // Distinct warnings tell malformed URLs apart from blocked schemes. Check both so either branch cannot satisfy the other assertion.
   it('refuses a malformed URL with the malformed warning, not the protocol one', () => {
     openExternalUrl('not a url', scopedLog);
 
@@ -104,10 +95,8 @@ describe('openExternalUrl refusals', () => {
 });
 
 describe('openExternalUrl normalisation', () => {
-  // Chromium re-parses whatever string it is given, so the checked URL and the
-  // opened URL must be the same object. Each row is an input whose re-serialised
-  // form differs from the caller's string: if the raw string were passed on, the
-  // assertion reads back the input instead.
+  // Chromium re-parses its argument, so open the parsed URL instead of the unchecked input string.
+  // These inputs change during serialisation, which makes passing the raw string detectable.
   it.each([
     ['drops a default port', 'https://music.apple.com:443/gb/browse', 'https://music.apple.com/gb/browse'],
     ['lowercases the host', 'https://Music.Apple.COM/gb/browse', 'https://music.apple.com/gb/browse'],

--- a/test/player.test.ts
+++ b/test/player.test.ts
@@ -865,8 +865,7 @@ describe('getShareUrl', () => {
     expect(getShareUrl({ playParams: { kind: 'song', isLibrary: true } })).toBeUndefined();
   });
 
-  // MPRIS OpenUri navigates to either service without calling switchService(),
-  // so the window can sit on Classical while config still names music.
+  // During a service switch, the payload can still describe Classical after config changes to music.
   it('uses the payload host when it names Classical and config names music', () => {
     expect(
       getShareUrl({ sourceHost: 'classical.music.apple.com', playParams: { catalogId: '42' } }),
@@ -882,8 +881,7 @@ describe('getShareUrl', () => {
     ).toBe('https://music.apple.com/song/abc');
   });
 
-  // A payload from a hook older than this field must keep its previous result
-  // rather than losing the URL.
+  // Payloads without sourceHost use the configured service to retain a share URL.
   it('falls back to the persisted service when the payload carries no host', () => {
     state.service = 'classical';
     expect(getShareUrl({ playParams: { catalogId: '42' } })).toBe(

--- a/test/player.test.ts
+++ b/test/player.test.ts
@@ -425,6 +425,10 @@ describe('Player handle* payload validation', () => {
     ['malformed artwork URL', { artworkUrl: 'not a URL' }],
     ['non-string source host', { sourceHost: 123 }],
     ['unknown source host', { sourceHost: 'attacker.test' }],
+    // JSON.parse() creates an own __proto__ key, which an object literal cannot.
+    ['own __proto__ key', JSON.parse('{"__proto__": {"polluted": true}}') as Record<string, unknown>],
+    ['constructor key', { constructor: 'polluted' }],
+    ['toString key', { toString: 'polluted' }],
   ];
 
   it.each(BAD_METADATA)('handleNowPlayingItemDidChange drops %s', (_description, payload) => {

--- a/test/serviceSwitch.test.ts
+++ b/test/serviceSwitch.test.ts
@@ -99,9 +99,7 @@ describe('serviceSwitch', () => {
   });
 });
 
-// The itms:// path in main.ts is this function plus a URL. The service branch lives
-// here rather than in main.ts, which runs app.whenReady() at import and cannot be
-// loaded under Vitest, so driving the function directly covers the whole path.
+// main.ts passes validated itms:// URLs here. Test the service branch without running application startup.
 describe('routeToMusicService', () => {
   const tray = new Tray('/tmp/sidra-test/icon.png');
   const loadURL = vi.fn((_url: string) => { calls.push('loadURL'); });

--- a/test/storefront.test.ts
+++ b/test/storefront.test.ts
@@ -236,6 +236,29 @@ describe('buildAppleMusicURL - classical service', () => {
     const url = buildAppleMusicURL();
     expect(url).toBe('https://classical.music.apple.com/gb');
   });
+
+  // Round trips: what handleLastPageNavigation stored is what the launch resolves.
+  function lastStoredClassicalPath(): string {
+    const calls = mockedSetClassicalLastPageUrl.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    return calls[calls.length - 1][0];
+  }
+
+  it('resolves Home after Browse then Home, not the earlier Browse', () => {
+    mockedGetClassicalStartPage.mockReturnValue('last');
+    handleLastPageNavigation('https://classical.music.apple.com/gb/browse/catalog');
+    handleLastPageNavigation('https://classical.music.apple.com/gb');
+    mockedGetClassicalLastPageUrl.mockReturnValue(lastStoredClassicalPath());
+    expect(buildAppleMusicURL()).toBe('https://classical.music.apple.com/gb');
+  });
+
+  it('resolves Home with its query after a Home visit carrying one', () => {
+    mockedGetClassicalStartPage.mockReturnValue('last');
+    handleLastPageNavigation('https://classical.music.apple.com/gb/browse/catalog');
+    handleLastPageNavigation('https://classical.music.apple.com/gb?l=en-GB');
+    mockedGetClassicalLastPageUrl.mockReturnValue(lastStoredClassicalPath());
+    expect(buildAppleMusicURL()).toBe('https://classical.music.apple.com/gb?l=en-GB');
+  });
 });
 
 describe('buildAppleMusicURL - registry-driven page paths', () => {
@@ -350,6 +373,22 @@ describe('handleLastPageNavigation', () => {
   it('drops the fragment', () => {
     handleLastPageNavigation('https://music.apple.com/gb/search?term=jazz#top');
     expect(mockedSetLastPageUrl).toHaveBeenCalledWith('search?term=jazz');
+  });
+
+  it('stores the empty root path when classical Home is visited', () => {
+    handleLastPageNavigation('https://classical.music.apple.com/gb');
+    expect(mockedSetClassicalLastPageUrl).toHaveBeenCalledWith('');
+  });
+
+  it('keeps the query when storing the classical root', () => {
+    handleLastPageNavigation('https://classical.music.apple.com/gb?l=en-GB');
+    expect(mockedSetClassicalLastPageUrl).toHaveBeenCalledWith('?l=en-GB');
+  });
+
+  it('does not store the bare root for the music service', () => {
+    // music.apple.com declares no root start page: its bare root is a redirect stop.
+    handleLastPageNavigation('https://music.apple.com/gb');
+    expect(mockedSetLastPageUrl).not.toHaveBeenCalled();
   });
 
   it('does nothing for an unknown host', () => {

--- a/test/storefront.test.ts
+++ b/test/storefront.test.ts
@@ -199,16 +199,14 @@ describe('buildAppleMusicURL - classical service', () => {
   });
 
   it('falls back to home when a removed library start page is still persisted', () => {
-    // Classical has no library route on the web, so the type no longer admits the id.
-    // A store written by an older build still holds it, and it must resolve to home
-    // rather than building a URL that 404s.
+    // Classical has no web library route. Legacy stored ids must resolve to Home instead of an unavailable route.
     mockedGetClassicalStartPage.mockReturnValue('library' as ClassicalStartPageId);
     const url = buildAppleMusicURL();
     expect(url).toBe('https://classical.music.apple.com/gb');
   });
 
   it('builds a probed URL for every declared classical start page id', () => {
-    // Every URL here returned 200 unauthenticated; a new id must be probed before it is added.
+    // Start-page routes must work without authentication. Check new routes against the service before adding them here.
     const expected: Record<string, string> = {
       'home': 'https://classical.music.apple.com/gb',
       'browse': 'https://classical.music.apple.com/gb/browse/catalog',
@@ -236,7 +234,6 @@ describe('buildAppleMusicURL - classical service', () => {
     mockedGetClassicalStartPage.mockReturnValue('last');
     mockedGetClassicalLastPageUrl.mockReturnValue(undefined);
     const url = buildAppleMusicURL();
-    // falls through to default (home), which has empty path
     expect(url).toBe('https://classical.music.apple.com/gb');
   });
 });

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -8,9 +8,7 @@ vi.mock('../src/config', () => ({
   getMusicService: vi.fn(() => 'music'),
 }));
 
-// Hoisted so the same mock functions survive vi.resetModules(): the
-// watcher-failure test loads a second copy of src/theme.ts and has to drive the
-// same fs.
+// Hoisting keeps the same filesystem mocks across vi.resetModules() when watcher-failure tests load a fresh theme module.
 const fsMock = vi.hoisted(() => ({
   readFileSync: vi.fn(),
   existsSync: vi.fn(),
@@ -50,8 +48,7 @@ describe('theme helpers', () => {
     vi.mocked(fs.readFileSync).mockReturnValue('');
     vi.mocked(fs.readFileSync).mockClear();
     vi.mocked(fs.watch).mockReset();
-    // custom-theme.json contents are cached for the life of the process, so each test
-    // starts from a cold cache.
+    // The cache is module state, so clear it between tests.
     invalidateCustomThemeCache();
   });
 
@@ -60,17 +57,15 @@ describe('theme helpers', () => {
   });
 
   // vi.mocked() resolves fs.watch to its two-argument overload, so the mock is
-  // typed against the three-argument form initThemeCSS() actually calls.
+  // typed against the three-argument form initThemeCSS() calls.
   type WatchWithOptions = (
     filename: fs.PathLike,
     options: fs.WatchOptions,
     listener: fs.WatchListener<string | Buffer>,
   ) => fs.FSWatcher;
 
-  // Fake timers plus a captured fs.watch listener, so a test can drive the
-  // watcher and step past the 150ms debounce.
-  // init defaults to the statically imported module; the cache-disable tests
-  // pass a freshly loaded copy so the flag they flip stays out of other tests.
+  // Captured watcher events and fake timers let tests control the 150ms debounce.
+  // Cache-disable tests supply a fresh module so its permanent flag cannot affect other tests.
   function watcherHarness(options: { isDestroyed?: boolean; init?: typeof initThemeCSS } = {}) {
     vi.useFakeTimers();
     const removeInsertedCSS = vi.fn().mockResolvedValue(undefined);
@@ -127,10 +122,8 @@ describe('theme helpers', () => {
     };
   }
 
-  // A fresh copy of src/theme.ts wired to its own harness, for the tests that
-  // reach disableCustomThemeCache(). The copy is what keeps the disabled flag,
-  // which nothing switches back on, out of every other test.
-  // failToStart makes fs.watch throw, which is the other route to that call.
+  // A fresh module isolates disableCustomThemeCache(), whose flag never resets.
+  // failToStart simulates a watcher setup failure instead of a later watcher error.
   async function loadThemeWithWatcher(options: { failToStart?: boolean } = {}) {
     vi.resetModules();
     const theme = await import('../src/theme');
@@ -149,13 +142,8 @@ describe('theme helpers', () => {
     for (let i = 0; i < 8; i += 1) await Promise.resolve();
   }
 
-  // Leave the module tracking an inserted-CSS key, which is the state the tests
-  // below start from. Nothing writes that key from outside the CSS queue, so a
-  // real theme change against the harness window is the only way to install one:
-  // its insertCSS resolves the key and the module records what it returned.
-  // The clear first means the change inserts without a removal, so a key left by
-  // an earlier test cannot put a call on removeInsertedCSS that a count below
-  // would then read as its own. insertCSS is cleared for the same reason.
+  // Install a tracked key through the real CSS queue, its only writer.
+  // Clear any previous key first to avoid a removal, then clear the setup insert so assertions count only test operations.
   async function trackKey(harness: ReturnType<typeof watcherHarness>, key: string): Promise<void> {
     notifyDocumentReplacing();
     harness.insertCSS.mockResolvedValue(key);
@@ -278,14 +266,10 @@ describe('theme helpers', () => {
     expect(resolveTheme()).toBe('catppuccin');
   });
 
-  // main.ts calls injectThemeCss() from injectContent() on every page load, and
-  // src/main.ts cannot be imported under Vitest, so this is where that path is
-  // covered.
+  // Test the page-load CSS path directly, without running main.ts application startup.
   describe('injectThemeCss', () => {
     beforeEach(() => {
-      // The key outlives the module, so each test starts with none injected. The
-      // clear is queued, and the queue is FIFO, so it lands before anything the
-      // test itself queues.
+      // The module retains its key between tests. Queue the clear first so test operations start without a tracked sheet.
       notifyDocumentReplacing();
     });
 
@@ -735,8 +719,7 @@ describe('theme helpers', () => {
     notifyDocumentReplacing();
     harness.start();
 
-    // custom-theme.json appears while a bundled theme is active: no CSS work, but the
-    // tray still needs the new Style entry.
+    // A custom theme file does not change active bundled CSS, but Settings still needs the new theme entry.
     vi.mocked(fs.readFileSync).mockReturnValue(redTheme.json);
     await harness.emit('rename');
     expect(rebuildTray).toHaveBeenCalledTimes(1);

--- a/test/themes.test.ts
+++ b/test/themes.test.ts
@@ -21,10 +21,8 @@ const CSS_RGBA_RE = /^rgba\((\d+),(\d+),(\d+),([0-9.]+)\)$/;
 /** WCAG 2.x AA floor for body text. */
 const CONTRAST_FLOOR = 4.5;
 
-// Catppuccin Latte ships subtext0 at #6c6f85, which lands at 4.37:1. It is the
-// one documented exception to the floor: the Catppuccin values are Catppuccin's
-// own and are kept byte for byte, and Latte was checked on screen. A new palette
-// gets no entry here.
+// Catppuccin Latte's unchanged subtext0 (#6c6f85) has 4.37:1 contrast, the sole permitted exception to the floor.
+// New palettes must meet the floor without an exception.
 const SECONDARY_FLOORS: Record<string, number> = {
   'catppuccin light': 4.37,
 };
@@ -124,8 +122,7 @@ describe('palettes', () => {
     }
   });
 
-  // themeLabel takes a ThemeName, so a misspelt name fails tsc rather than
-  // rendering as Apple Music; there is no unknown-name case left to check.
+  // themeLabel takes a ThemeName, so tsc rejects misspelt names before they reach the label resolver.
   it('resolves labels for bundled, custom, and apple-music names', () => {
     expect(themeLabel('catppuccin')).toBe('Catppuccin');
     expect(themeLabel('rose-pine')).toBe('Ros\u00e9 Pine');
@@ -216,12 +213,8 @@ describe('buildThemeCss', () => {
         }
       });
 
-      // The generated stylesheet ships to the renderer, so a comment in it is
-      // output. Section labels stay; why a rule exists belongs in a TypeScript
-      // comment in src/themeTemplate.ts, outside the template literals. A label
-      // fits on one line and an explanation does not, so this is the mechanical
-      // form of that boundary. The leading banner is skipped: it identifies the
-      // sheet rather than explaining a rule.
+      // Generated CSS comments reach the renderer. Keep section labels on one line and put explanations outside the template in src/themeTemplate.ts.
+      // Exclude the leading banner because it identifies the stylesheet.
       it('emits section labels only, past the banner', () => {
         const body = css.slice(css.indexOf('*/') + 2);
         for (const comment of body.match(/\/\*[\s\S]*?\*\//g) ?? []) {
@@ -242,11 +235,8 @@ describe('buildThemeCss', () => {
   }
 });
 
-// buildThemeCss() renders one template and schemeBlock() takes a SchemeColours
-// record with no theme name in it, so every palette emits the same selectors,
-// properties, and section labels; only the values differ. The checks below read
-// selectors and property names alone, so one generated stylesheet answers for
-// all of them. Anything reading a palette value stays in the loop above.
+// Every palette uses one template, so one generated stylesheet covers shared selectors, properties and labels.
+// Keep checks of palette values in the per-theme loop above.
 describe('buildThemeCss emitted structure', () => {
   const css = buildThemeCss(BUNDLED_THEMES[0]);
   const darkCss = mediaBlock(css, 'prefers-color-scheme: dark');
@@ -286,8 +276,7 @@ describe('buildThemeCss emitted structure', () => {
     }
   });
 
-  // A scope hash changes on any Apple rebuild, so a selector carrying one is
-  // dead the next time they ship.
+  // Apple rebuilds can change scope hashes, so overrides must not depend on them.
   it('emits no Svelte scope hash', () => {
     expect(css).not.toMatch(/svelte-[a-z0-9]/);
   });

--- a/test/tray.test.ts
+++ b/test/tray.test.ts
@@ -155,13 +155,8 @@ afterEach(restorePlatform);
 afterEach(() => vi.unstubAllEnvs());
 
 /**
- * Puts every mock and every piece of tray module state the menu reads back to
- * the state this file builds a menu in, and drops the recorded calls on the
- * `nativeImage` factories that several tests assert were never called.
- * vitest.config.mts turns on neither `clearMocks` nor `mockReset`, so without a
- * reset of its own a block that moves one of these values, or that paints an
- * icon, leaves that behind for every block that follows, and the order of the
- * describes becomes part of the contract.
+ * Resets menu state and recorded nativeImage calls so tests do not depend on execution order.
+ * vitest.config.mts enables neither clearMocks nor mockReset, so this fixture must reset them explicitly.
  */
 function resetTrayMocks(): void {
   initSettingsActions({ getMainWindow: () => getSettingsMainWindow(), applyZoom: () => {}, switchService: id => switchSettingsService(id), refreshTray: () => {} });
@@ -728,9 +723,7 @@ describe('createTray - menu template inspection', () => {
     });
 
     it('falls back to Home when a stored library page is no longer offered', () => {
-      // Classical has no library route on the web, so the type no longer admits
-      // the id. A store written by an older build still holds it, and the menu
-      // must tick Home rather than ticking nothing at all.
+      // Classical has no web library route. A legacy stored id must select Home instead of leaving every item unchecked.
       vi.mocked(getClassicalStartPage).mockReturnValue('library' as string as ClassicalStartPageId);
       createTray();
       const template = getLastTemplate();
@@ -776,8 +769,7 @@ describe('createTray - menu template inspection', () => {
   });
 
   describe('Style submenu usable on both services', () => {
-    // The item carries no `enabled` key, so `not.toBe(false)` is the assertion:
-    // a restored gate sets it to false and fails here whatever the default is.
+    // An omitted enabled key leaves the item selectable, so reject only an explicit false.
     beforeEach(() => {
       setPlatform('linux');
       vi.mocked(getMusicService).mockReturnValue('classical');

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -119,8 +119,7 @@ describe('isNewer', () => {
   });
 
   it('returns false for an empty part inside the version', () => {
-    // Number('') is 0, so 2..0 once read as 2.0.0 and offered an update. A part
-    // past the end of a short version still counts as 0; an empty one does not.
+    // Number('') is 0, but an empty version part is invalid. Only omitted trailing parts default to zero.
     expect(isNewer('2..0', '1.0.0')).toBe(false);
     expect(isNewer('1..0', '0.3.0')).toBe(false);
     expect(isNewer('2.0.0', '1..0')).toBe(false);

--- a/test/wedgeDetector.test.ts
+++ b/test/wedgeDetector.test.ts
@@ -8,9 +8,7 @@ import type { IntegrationContext } from '../src/player';
 type WedgeDetector = typeof import('../src/wedgeDetector');
 type ScopedLog = ReturnType<typeof electronLog.scope>;
 
-// Every listener and counter in the module is module-scoped, and init() now
-// refuses a second call, so a shared instance cannot be re-initialised between
-// tests. Each test takes its own copy instead.
+// init() refuses repeat calls and keeps module-level state, so each test needs a fresh module.
 async function loadWedgeDetector(): Promise<WedgeDetector> {
   vi.resetModules();
   return import('../src/wedgeDetector');
@@ -94,7 +92,6 @@ describe('wedgeDetector', () => {
   it('does not fire skip when position advances', () => {
     player.handlePlaybackStateDidChange({ status: true, state: PlaybackState.Playing });
 
-    // Simulate position advancing every second
     for (let i = 1; i <= 8; i++) {
       vi.advanceTimersByTime(1000);
       player.handlePlaybackTimeDidChange(i * 1000);
@@ -106,8 +103,7 @@ describe('wedgeDetector', () => {
   it('respects MAX_SKIP_ATTEMPTS (3)', () => {
     player.handlePlaybackStateDidChange({ status: true, state: PlaybackState.Playing });
 
-    // Each skip resets lastAdvanceTime, so the stall has to build up again and
-    // every attempt costs another 6000ms.
+    // Each skip resets lastAdvanceTime, so the next attempt needs another full stall interval.
     vi.advanceTimersByTime(6000);
     expect(mockWin.webContents.send).toHaveBeenCalledTimes(1);
 
@@ -125,12 +121,12 @@ describe('wedgeDetector', () => {
   it('reset() clears state and stops timer', () => {
     player.handlePlaybackStateDidChange({ status: true, state: PlaybackState.Playing });
 
-    // Advance a bit but not past threshold
+    // Keep the timer active without reaching the stall threshold.
     vi.advanceTimersByTime(3000);
 
     wedgeDetector.reset();
 
-    // Advance well past threshold - should not fire because reset stopped timer
+    // reset() stops the timer, so elapsed time alone cannot trigger another skip.
     vi.advanceTimersByTime(10000);
 
     expect(mockWin.webContents.send).not.toHaveBeenCalled();
@@ -186,11 +182,7 @@ describe('wedgeDetector', () => {
   });
 
   it('ignores a second init so each listener is attached once', () => {
-    // Asserted on the emitter rather than through behaviour. The visible
-    // symptoms of a duplicate init are masked: startTimer() returns early when
-    // a timer already exists, and the duplicated writes to lastAdvanceTime and
-    // skipAttempts are idempotent. Counting registrations is what actually
-    // distinguishes one init from two.
+    // Count registrations because timer reuse and idempotent state writes hide duplicate listeners from playback assertions.
     const events = [
       'playbackStateDidChange',
       'nowPlayingItemDidChange',

--- a/test/windowsTaskbar.test.ts
+++ b/test/windowsTaskbar.test.ts
@@ -11,10 +11,7 @@ import { initCommandBridge } from '../src/commandBridge';
 import { FakePlayer } from './mocks/player';
 import { setPlatform, restorePlatform } from './mocks/platform';
 
-// The real i18n module resolves against the ['en-GB', 'en'] the app mock in
-// test/setup.ts reports, so every expectation reads the record the integration
-// reads. A retyped English literal would pass even after the tooltips stopped
-// going through getTrayStrings().
+// Use the real i18n records resolved against test/setup.ts languages ['en-GB', 'en'] so expectations follow translation changes.
 const strings = getTrayStrings();
 
 const TRACK: NowPlayingPayload = {


### PR DESCRIPTION
Keep MusicKit polling after an initial lookup failure and reject events from replaced instances, so native controls recover without stale playback updates. Reject prototype-named metadata fields, remember Classical Home, retain Discord links for library tracks, and show startup failures. Publish Windows blockmaps, supply Python in the Nix development shell, strengthen cleanup checks, and update comments and documentation.

Validation: all 1,679 tests passed across 49 files, and `just lint` passed.
